### PR TITLE
Add short/long MCP tool variants and package the server as an installable plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "osint-velocity",
+  "owner": { "name": "Velocity OSINT", "url": "https://projectvelocity.org" },
+  "description": "OSINT GEOINT — live geospatial-intelligence MCP tools, an analyst skill, and slash commands for Claude Code.",
+  "plugins": [
+    {
+      "name": "osint-geoint",
+      "source": "./plugin/osint-geoint",
+      "description": "Live ADS-B / AIS / GPS-jamming / SAR dark-vessel intelligence with cross-domain incident fusion, as 22 context-optimised MCP tools plus an analyst skill and commands.",
+      "version": "1.0.0",
+      "category": "intelligence",
+      "keywords": ["osint", "geoint", "adsb", "ais", "mcp"]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ __pycache__/
 opencode.jsonc
 .opencode.json
 .mcp.json
+# ...but the shipped plugin manifest is a checked-in template (user_config placeholders, no secrets).
+!plugin/osint-geoint/.mcp.json
 *.log
 coverage/
 .vite/

--- a/README.md
+++ b/README.md
@@ -180,9 +180,29 @@ It exposes 22 tools over `app.mcp_server` (a representative slice below; run
 
 Every tool returns compact, bounded JSON (counts, grids, ≤50-item samples), so
 an agent can sweep the planet for a few hundred tokens instead of pulling 15k
-features. Area-primary loading means the agent's region of interest stays fresh
-and dense even while the global firehose is being rate-limited; the rest of the
-world keeps streaming from the sticky snapshot.
+features. Heavy tools also take **`detail='short'`** (the default digest — top-N
+of each list plus a `<field>_total`) or **`detail='long'`** (the full bundle), so
+an agent sweeps in `short` and drills in `long`. Area-primary loading means the
+agent's region of interest stays fresh and dense even while the global firehose is
+being rate-limited; the rest of the world keeps streaming from the sticky snapshot.
+
+### Install as a Claude Code plugin (skill + commands + agent)
+
+The repo is also a Claude Code **plugin marketplace**. One install wires the MCP
+server *plus* an analyst skill (`osint-intel`), slash commands (`/osint-brief`,
+`/osint-watch`, `/osint-jamming`), and a `osint-watch-officer` agent. Start the
+backend (`bash scripts/run-api.sh`), then in Claude Code:
+
+```
+/plugin marketplace add /path/to/OSINT
+/plugin install osint-geoint@osint-velocity
+```
+
+Set **repo_dir** and **python** (the repo's venv interpreter) when prompted; the
+plugin runs that Python directly, so it works on Windows, macOS, and Linux. The
+installer prints the exact commands for your OS: `bash
+plugin/osint-geoint/install.sh` (Linux/macOS, `-y` to register the MCP server) or
+`plugin\osint-geoint\install.ps1` (Windows, `-Run` to register).
 
 ### Hosted: point your agent at the live endpoint
 

--- a/apps/api/app/intel/shape.py
+++ b/apps/api/app/intel/shape.py
@@ -1,0 +1,119 @@
+"""Context-optimising response shaper for the MCP tool layer.
+
+Every ``/api/intel/*`` route already returns *compact* JSON (counts, grids,
+capped samples). But "compact" is still tuned for a power-user reading one
+endpoint — an agent sweeping the planet across a dozen tool calls wants a far
+cheaper **digest** by default, and the *full* bundle only when it decides to
+drill in. This module gives every heavy MCP tool two variants off one payload:
+
+- ``short`` (the default) — a token-frugal digest of the SAME payload: scalars
+  and small dicts kept verbatim, long arrays capped to the top few items with a
+  companion ``<field>_total`` so the agent still knows the true size, verbose
+  strings (narratives) truncated. Orientation and broad sweeps cost a few
+  hundred tokens.
+- ``long`` — the full route payload, untouched. The comprehensive, agent-ready
+  view for when a specific incident/area is worth the context.
+
+The transform is a pure function (no I/O) so it is trivially testable and can
+never fail a tool call: it only ever *removes* detail from an already-valid
+payload. Error envelopes (``{"error": ...}``) pass through untouched — they are
+tiny and load-bearing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SHORT = "short"
+LONG = "long"
+VALID_DETAIL = (SHORT, LONG)
+
+# Defaults tuned so a short digest of the heaviest payloads (a global brief, a
+# full area bundle) lands in the low hundreds of tokens.
+_LIST_CAP = 5
+_STR_CAP = 240
+_MAX_DEPTH = 6
+
+
+def normalize_detail(detail: str | None) -> str:
+    """Coerce agent-supplied ``detail`` to a valid mode (default ``short``)."""
+    d = (detail or SHORT).strip().lower()
+    return d if d in VALID_DETAIL else SHORT
+
+
+def shape(
+    payload: Any,
+    detail: str | None = SHORT,
+    *,
+    list_cap: int = _LIST_CAP,
+    str_cap: int = _STR_CAP,
+) -> Any:
+    """Return ``payload`` for ``long``; a context-frugal digest for ``short``.
+
+    Only ``dict`` payloads are digested (every intel route returns an object).
+    Anything else, and any error envelope, is returned unchanged.
+    """
+    mode = normalize_detail(detail)
+    if mode == LONG or not isinstance(payload, dict):
+        return payload
+    if "error" in payload:  # structured backend error — never shrink it
+        return payload
+
+    truncated: list[str] = []
+    out = _shorten_dict(payload, list_cap, str_cap, depth=0, path="", dropped=truncated)
+    # A no-op when nothing was trimmed (already-small payload) — return it
+    # unchanged rather than tagging it, so short is a faithful passthrough for
+    # the many tools that already fit. Only annotate when detail was dropped.
+    if truncated:
+        out["truncated"] = True
+        out["hint"] = (
+            "Digest only — some arrays/strings were trimmed (see `*_total` "
+            "counts). Re-call with detail='long' for the full bundle."
+        )
+    return out
+
+
+def _shorten(
+    value: Any, list_cap: int, str_cap: int, depth: int, path: str, dropped: list[str]
+) -> Any:
+    if depth >= _MAX_DEPTH:
+        return value
+    if isinstance(value, dict):
+        return _shorten_dict(value, list_cap, str_cap, depth, path, dropped)
+    if isinstance(value, list):
+        return _shorten_list(value, list_cap, str_cap, depth, path, dropped)
+    if isinstance(value, str) and len(value) > str_cap:
+        dropped.append(path)
+        return value[: str_cap - 1] + "…"
+    return value
+
+
+def _shorten_dict(
+    d: dict[str, Any], list_cap: int, str_cap: int, depth: int, path: str, dropped: list[str]
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in d.items():
+        child = f"{path}.{k}" if path else str(k)
+        if isinstance(v, list) and len(v) > list_cap:
+            out[k] = [
+                _shorten(x, list_cap, str_cap, depth + 1, child, dropped) for x in v[:list_cap]
+            ]
+            # Honest full-set size sits beside the capped sample so the agent
+            # knows how much it is NOT seeing (skip if the key already exists).
+            count_key = f"{k}_total"
+            if count_key not in d:
+                out[count_key] = len(v)
+            dropped.append(child)
+        else:
+            out[k] = _shorten(v, list_cap, str_cap, depth + 1, child, dropped)
+    return out
+
+
+def _shorten_list(
+    lst: list[Any], list_cap: int, str_cap: int, depth: int, path: str, dropped: list[str]
+) -> list[Any]:
+    # A bare list at this position (list-of-lists); cap and digest each kept item.
+    kept = [_shorten(x, list_cap, str_cap, depth + 1, path, dropped) for x in lst[:list_cap]]
+    if len(lst) > list_cap:
+        dropped.append(path)
+    return kept

--- a/apps/api/app/mcp_server.py
+++ b/apps/api/app/mcp_server.py
@@ -45,6 +45,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from starlette.routing import Route
 
 from app.config import get_settings
+from app.intel.shape import normalize_detail, shape
 
 mcp = FastMCP(
     "osint-geoint",
@@ -57,7 +58,12 @@ mcp = FastMCP(
         "load an incident's region PRIMARY -> query_vessels / gps_jamming / "
         "query_aircraft to drill into its evidence -> deep_analyze() to have a "
         "reasoning model judge it. intel_brief is the headline tool: it chains "
-        "signals into incidents so you don't correlate raw layers by hand."
+        "signals into incidents so you don't correlate raw layers by hand.\n\n"
+        "CONTEXT BUDGET: most tools take detail='short'|'long'. 'short' (the "
+        "default) is a token-frugal digest — headline counts plus the top few "
+        "items of each list, with `*_total` giving the true size — ideal for "
+        "orientation and broad sweeps. Switch to detail='long' only once you've "
+        "picked an incident/area worth the full, comprehensive bundle."
     ),
 )
 
@@ -318,14 +324,17 @@ async def _get(path: str, params: dict[str, Any] | None = None) -> dict[str, Any
 
 
 @mcp.tool()
-async def get_situation() -> dict[str, Any]:
+async def get_situation(detail: str = "short") -> dict[str, Any]:
     """Global situational snapshot — the cheap first call to orient.
 
     Returns total aircraft (airborne/ground, by category), GNSS-degraded count,
     active emergency squawks, the worst GPS-jamming cells worldwide, tracked
     vessel counts by category, and recent fusion-alert counts. A few hundred
-    tokens describing the whole planet."""
-    return await _get("/api/intel/situation")
+    tokens describing the whole planet.
+
+    detail='short' (default) trims the jamming/vessel/alert samples to their
+    top few; detail='long' returns the full situation bundle."""
+    return shape(await _get("/api/intel/situation"), detail)
 
 
 @mcp.tool()
@@ -335,6 +344,7 @@ async def focus_area(
     radius_nm: float = 200.0,
     label: str | None = None,
     cell_deg: float = 1.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Load a region PRIMARY and return a full intel bundle for it in one call.
 
@@ -350,7 +360,7 @@ async def focus_area(
         label: optional human name for the AOI (e.g. "Kaliningrad").
         cell_deg: density grid cell size in degrees (0.1–10; default 1.0).
     """
-    return await _get(
+    data = await _get(
         "/api/intel/area",
         {
             "lat": lat,
@@ -361,6 +371,7 @@ async def focus_area(
             "cell_deg": cell_deg,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -373,13 +384,14 @@ async def aircraft_density(
     max_lon: float | None = None,
     max_lat: float | None = None,
     cell_deg: float = 1.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Aircraft density over an area as a grid of cells (count, by category,
     GNSS-degraded per cell) plus totals, peak cell, and in-area vessel count.
 
     Give either a centre (lat, lon [, radius_nm]) or an explicit bbox
     (min_lon, min_lat, max_lon, max_lat). cell_deg sets grid resolution."""
-    return await _get(
+    data = await _get(
         "/api/intel/density",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -387,6 +399,7 @@ async def aircraft_density(
             "max_lon": max_lon, "max_lat": max_lat, "cell_deg": cell_deg,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -398,12 +411,13 @@ async def gps_jamming(
     min_lat: float | None = None,
     max_lon: float | None = None,
     max_lat: float | None = None,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """GPS/GNSS jamming assessment (GPSJam method: ADS-B NACp<8 / NIC<7 binned
     into 1° cells). Returns flagged cells ranked by severity, counts of
     high/medium cells, and a sample of affected aircraft. Omit all coordinates
     for a global view; otherwise pass a centre or a bbox to scope it."""
-    return await _get(
+    data = await _get(
         "/api/intel/jamming",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -411,6 +425,7 @@ async def gps_jamming(
             "max_lon": max_lon, "max_lat": max_lat,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -431,6 +446,7 @@ async def query_aircraft(
     gnss_degraded: bool | None = None,
     on_ground: bool | None = None,
     limit: int = 50,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Filtered aircraft query against the live snapshot. Returns matched_total
     + a capped list of compact records.
@@ -438,7 +454,7 @@ async def query_aircraft(
     category ∈ airliner|private|helicopter|glider|military|emergency.
     Combine with area (centre or bbox), squawk, callsign_contains, altitude
     band (metres), emergency / gnss_degraded / on_ground booleans. limit ≤200."""
-    return await _get(
+    data = await _get(
         "/api/intel/aircraft",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -451,6 +467,7 @@ async def query_aircraft(
             "on_ground": on_ground, "limit": limit,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -474,11 +491,12 @@ async def query_vessels(
     max_lat: float | None = None,
     dark_only: bool = False,
     limit: int = 50,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Vessels (AIS) in an area, classified (cargo/tanker/fishing/passenger/
     military/sailing/pleasure/tug). dark_only=True returns only dark-vessel
     candidates (moving with no static identity). Scoped by centre or bbox."""
-    return await _get(
+    data = await _get(
         "/api/intel/vessels",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -487,6 +505,7 @@ async def query_vessels(
             "dark_only": dark_only, "limit": limit,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -498,11 +517,12 @@ async def anomalies(
     min_lat: float | None = None,
     max_lon: float | None = None,
     max_lat: float | None = None,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Fused anomaly report for an area (or global if no coords): emergency
     aircraft, GPS-jamming hotspots, dark-vessel candidates, recent fusion
     alerts, plus a triage threat_level (low|elevated|high) and score."""
-    return await _get(
+    data = await _get(
         "/api/intel/anomalies",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -510,6 +530,7 @@ async def anomalies(
             "max_lon": max_lon, "max_lat": max_lat,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -523,6 +544,7 @@ async def intel_brief(
     max_lat: float | None = None,
     link_km: float = 50.0,
     window_hours: float = 6.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Cross-domain INCIDENT brief — the headline analytic tool.
 
@@ -536,7 +558,7 @@ async def intel_brief(
     scope it. Start here, then drill into an incident's centroid with
     query_vessels / gps_jamming / deep_analyze.
     """
-    return await _get(
+    data = await _get(
         "/api/intel/brief",
         {
             "lat": lat, "lon": lon, "radius_nm": radius_nm,
@@ -545,6 +567,7 @@ async def intel_brief(
             "link_km": link_km, "window_hours": window_hours,
         },
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -552,15 +575,17 @@ async def detect_deception(
     lat: float | None = None,
     lon: float | None = None,
     radius_nm: float = 500.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Denial & deception — "am I being fed?". Flags MANIPULATED tracks distinct
     from jamming: AIS duplicate-MMSI (one identity, two hulls) and impossible
     teleports; ADS-B GPS spoofing (many aircraft snapped to one false position)
     and kinematic position-injection. Run before trusting a feed in a contested
     area. Omit coords for global."""
-    return await _get(
+    data = await _get(
         "/api/intel/deception", {"lat": lat, "lon": lon, "radius_nm": radius_nm}
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -568,14 +593,16 @@ async def locate_emitter(
     lat: float | None = None,
     lon: float | None = None,
     radius_nm: float = 500.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Estimate a GPS jammer/spoofer LOCATION from the degraded-ADS-B footprint
     (severity-weighted centroid + CEP + confidence). Turns "jamming somewhere
     here" into "emitter ~here ±N km". Footprint-centroid estimate (~tens of km),
     not RF direction-finding — stated in the response. Scope with lat/lon."""
-    return await _get(
+    data = await _get(
         "/api/intel/emitter", {"lat": lat, "lon": lon, "radius_nm": radius_nm}
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -583,15 +610,17 @@ async def area_baseline(
     lat: float | None = None,
     lon: float | None = None,
     radius_nm: float = 500.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Is this normal? Current vessel / dark-vessel / jamming / military counts
     z-scored against a rolling baseline, with anomalies called out (e.g. "dark
     vessels +5σ", "traffic -3σ"). Global uses the background sampler; polling an
     AOI repeatedly builds that area's baseline. Distinguishes a real shift from
     a normal day."""
-    return await _get(
+    data = await _get(
         "/api/intel/baseline", {"lat": lat, "lon": lon, "radius_nm": radius_nm}
     )
+    return shape(data, detail)
 
 
 @mcp.tool()
@@ -599,6 +628,7 @@ async def whats_changed(
     lat: float | None = None,
     lon: float | None = None,
     radius_nm: float = 500.0,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Standing watch — what CHANGED since the last check, not the full picture.
 
@@ -608,9 +638,10 @@ async def whats_changed(
     so you can poll one region and be told only what moved. Use this to monitor
     instead of re-reading the whole brief each time.
     """
-    return await _get(
+    data = await _get(
         "/api/intel/watch", {"lat": lat, "lon": lon, "radius_nm": radius_nm}
     )
+    return shape(data, detail)
 
 
 def _compact_points(points: list[dict[str, Any]], max_points: int) -> list[dict[str, Any]]:
@@ -694,6 +725,7 @@ async def incident_history(
     hours: float = 6.0,
     limit: int = 25,
     max_incidents: int | None = None,
+    detail: str = "short",
 ) -> dict[str, Any]:
     """Timeline of how each incident built up over the recent window — per
     incident, a compact ``series`` of ``[time, threat_level, score]`` points.
@@ -713,25 +745,27 @@ async def incident_history(
         "/api/intel/incident-history",
         {"lat": lat, "lon": lon, "radius_nm": radius_nm, "hours": hours},
     )
-    return _compact_history(data, cap, max_points=12)
+    # detail='long' keeps a denser timeline (more transition points) per incident.
+    max_points = 40 if normalize_detail(detail) == "long" else 12
+    return _compact_history(data, cap, max_points=max_points)
 
 
 @mcp.tool()
-async def vessel_dossier(mmsi: int | str) -> dict[str, Any]:
+async def vessel_dossier(mmsi: int | str, detail: str = "short") -> dict[str, Any]:
     """Pattern-of-life dossier for one vessel (MMSI): recent track, AIS gaps,
     derived speed profile (loiter / transit / loiter-then-dash), area covered,
     which live incidents it appears in, and a behaviour assessment. The track is
     the store's ~1h retention window."""
     # MMSI is numeric; agents pass it as an int or a string — accept both.
-    return await _get(f"/api/intel/dossier/vessel/{quote(str(mmsi), safe='')}")
+    return shape(await _get(f"/api/intel/dossier/vessel/{quote(str(mmsi), safe='')}"), detail)
 
 
 @mcp.tool()
-async def aircraft_dossier(ident: str) -> dict[str, Any]:
+async def aircraft_dossier(ident: str, detail: str = "short") -> dict[str, Any]:
     """Pattern-of-life dossier for one aircraft (ICAO24 hex or callsign): recent
     track, gaps, derived speed profile, GNSS-integrity, emergency/military flags,
     and which live incidents it appears in."""
-    return await _get(f"/api/intel/dossier/aircraft/{quote(ident, safe='')}")
+    return shape(await _get(f"/api/intel/dossier/aircraft/{quote(ident, safe='')}"), detail)
 
 
 @mcp.tool()
@@ -797,16 +831,20 @@ async def deep_analyze(
 
     from app import llm  # noqa: PLC0415
 
-    # 1) gather context (already compact). The cross-domain incident BRIEF is the
-    #    centrepiece — the reasoner judges fused, cited incidents rather than
-    #    re-correlating raw layers in its head.
-    context: dict[str, Any] = {"question": question, "situation": await get_situation()}
+    # 1) gather context. Pull detail='long' internally — the reasoner runs
+    #    off-context with its own large window, so it should judge the FULL fused
+    #    picture, not the token-frugal digest the agent-facing default returns.
+    context: dict[str, Any] = {
+        "question": question,
+        "situation": await get_situation(detail="long"),
+    }
     context["incident_brief"] = await intel_brief(
         lat=lat, lon=lon, radius_nm=radius_nm,
         window_hours=12.0 if lat is None else 6.0,
+        detail="long",
     )
     if lat is not None and lon is not None:
-        context["focus_area"] = await focus_area(lat, lon, radius_nm)
+        context["focus_area"] = await focus_area(lat, lon, radius_nm, detail="long")
 
     # 2) reason off-context (DeepSeek → Ollama → raw data). Cap the wait so a
     #    slow upstream can't hang the tool for the 180 s default — the fast tier

--- a/apps/api/tests/test_mcp_detail.py
+++ b/apps/api/tests/test_mcp_detail.py
@@ -1,0 +1,114 @@
+"""short/long context-optimisation variants for the MCP tool layer.
+
+Covers the pure shaper (`app.intel.shape.shape`) and its wiring into the MCP
+tools (default `short` digest vs opt-in `long` full bundle).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import app.mcp_server as M
+from app.intel.shape import LONG, SHORT, normalize_detail, shape
+
+
+def test_normalize_detail_defaults_and_coerces() -> None:
+    assert normalize_detail(None) == SHORT
+    assert normalize_detail("") == SHORT
+    assert normalize_detail("LONG") == LONG
+    assert normalize_detail("  short ") == SHORT
+    assert normalize_detail("garbage") == SHORT  # unknown -> safe default
+
+
+def test_long_is_exact_passthrough() -> None:
+    payload = {"incidents": [{"id": i} for i in range(50)], "narrative": "x" * 999}
+    assert shape(payload, "long") is payload  # untouched, same object
+
+
+def test_error_envelope_never_shrunk() -> None:
+    err = {"error": "backend_unreachable", "detail": "y" * 999, "list": list(range(99))}
+    assert shape(err, "short") == err  # errors pass through verbatim
+
+
+def test_non_dict_passthrough() -> None:
+    assert shape([1, 2, 3], "short") == [1, 2, 3]
+    assert shape("hello", "short") == "hello"
+
+
+def test_small_payload_is_noop_under_short() -> None:
+    """The many already-tiny tool payloads must be returned UNCHANGED (no added
+    keys) so short is a faithful passthrough for them."""
+    payload = {"ok": True, "count": 3, "items": [1, 2, 3]}
+    out = shape(payload, "short")
+    assert out == payload
+    assert "truncated" not in out and "hint" not in out
+
+
+def test_short_caps_lists_and_reports_true_size() -> None:
+    payload = {"incidents": [{"id": i} for i in range(20)]}
+    out = shape(payload, "short", list_cap=5)
+    assert len(out["incidents"]) == 5
+    assert out["incidents_total"] == 20  # honest full-set size
+    assert out["truncated"] is True
+    assert "detail='long'" in out["hint"]
+    # first items are preserved in order (agent sees the head of the list)
+    assert [x["id"] for x in out["incidents"]] == [0, 1, 2, 3, 4]
+
+
+def test_short_truncates_verbose_strings() -> None:
+    payload = {"narrative": "n" * 500}
+    out = shape(payload, "short", str_cap=240)
+    assert len(out["narrative"]) == 240 and out["narrative"].endswith("…")
+    assert out["truncated"] is True
+
+
+def test_short_digests_nested_structures() -> None:
+    payload = {
+        "situation": {
+            "aircraft": {"total": 13000},
+            "gps_jamming": {"cells": [{"c": i} for i in range(40)]},
+        }
+    }
+    out = shape(payload, "short", list_cap=3)
+    assert out["situation"]["aircraft"]["total"] == 13000  # scalars kept
+    assert len(out["situation"]["gps_jamming"]["cells"]) == 3
+    assert out["situation"]["gps_jamming"]["cells_total"] == 40
+
+
+def test_existing_total_key_not_clobbered() -> None:
+    payload = {"cells": list(range(10)), "cells_total": 99}  # pre-set count wins
+    out = shape(payload, "short", list_cap=2)
+    assert out["cells_total"] == 99
+
+
+@pytest.mark.asyncio
+async def test_tool_short_default_vs_long(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A heavy tool defaults to the short digest; detail='long' returns it all."""
+    big = {
+        "incidents": [{"id": i, "narrative": "z" * 400} for i in range(30)],
+        "threat_level": "elevated",
+    }
+
+    async def _fake_get(path: str, params=None):  # type: ignore[no-untyped-def]
+        return big
+
+    monkeypatch.setattr(M, "_get", _fake_get)
+
+    short = await M.intel_brief()  # default detail
+    assert len(short["incidents"]) < 30
+    assert short["incidents_total"] == 30
+    assert short["threat_level"] == "elevated"  # headline scalar survives
+
+    full = await M.intel_brief(detail="long")
+    assert full is big  # long is the untouched bundle
+    assert len(full["incidents"]) == 30
+
+
+@pytest.mark.asyncio
+async def test_tool_short_errors_pass_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_get(path: str, params=None):  # type: ignore[no-untyped-def]
+        return {"error": "backend_500", "detail": "boom"}
+
+    monkeypatch.setattr(M, "_get", _fake_get)
+    out = await M.get_situation()  # short default must not mangle an error
+    assert out["error"] == "backend_500"

--- a/apps/api/tests/test_plugin_manifest.py
+++ b/apps/api/tests/test_plugin_manifest.py
@@ -1,0 +1,92 @@
+"""Guard: the Claude Code plugin (plugin/osint-geoint) stays internally valid.
+
+The plugin bundles the MCP server + skill + commands + agent. These are static
+files that Claude Code loads, so nothing else exercises them — this test is the
+runnable check that the manifests parse and every referenced path exists, so a
+rename or a typo can't silently break the install.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugin" / "osint-geoint"
+
+
+def _load(p: Path) -> dict:
+    return json.loads(p.read_text())
+
+
+def test_marketplace_lists_the_plugin() -> None:
+    mkt = _load(REPO / ".claude-plugin" / "marketplace.json")
+    assert mkt["name"] and mkt["owner"]["name"]
+    entry = next(p for p in mkt["plugins"] if p["name"] == "osint-geoint")
+    # marketplace `source` paths are relative to the marketplace ROOT (repo root).
+    src = (REPO / entry["source"]).resolve()
+    assert src == PLUGIN.resolve()
+    assert (PLUGIN / ".claude-plugin" / "plugin.json").is_file()
+
+
+def test_plugin_manifest_paths_resolve() -> None:
+    man = _load(PLUGIN / ".claude-plugin" / "plugin.json")
+    assert man["name"] == "osint-geoint"
+    # mcpServers points at a real .mcp.json inside the plugin.
+    assert man["mcpServers"] == "./.mcp.json"
+    assert (PLUGIN / ".mcp.json").is_file()
+    # Bundled component dirs exist and are non-empty.
+    assert list((PLUGIN / "skills").glob("*/SKILL.md"))
+    assert list((PLUGIN / "commands").glob("*.md"))
+    assert list((PLUGIN / "agents").glob("*.md"))
+    # Required user-config fields for the cross-platform python-direct launch.
+    assert man["userConfig"]["repo_dir"]["required"] is True
+    assert man["userConfig"]["python"]["required"] is True
+
+
+def test_mcp_json_launches_python_module_cross_platform() -> None:
+    """The plugin launches the venv Python directly (no shell launcher), so the
+    same manifest works on Windows, macOS and Linux."""
+    mcp = _load(PLUGIN / ".mcp.json")
+    srv = mcp["mcpServers"]["osint-geoint"]
+    assert srv["command"] == "${user_config.python}"
+    assert srv["args"] == ["-m", "app.mcp_server"]
+    assert srv["cwd"] == "${user_config.repo_dir}/apps/api"
+    assert srv["env"]["PYTHONPATH"] == "${user_config.repo_dir}/apps/api"
+    # No bash launcher is bundled (it wouldn't run on Windows).
+    assert not (PLUGIN / "bin").exists()
+
+
+def test_skill_frontmatter_present() -> None:
+    skill = PLUGIN / "skills" / "osint-intel" / "SKILL.md"
+    text = skill.read_text()
+    assert text.startswith("---")
+    head = text.split("---", 2)[1]
+    assert "name:" in head and "description:" in head
+    # Progressive-disclosure references exist.
+    assert (skill.parent / "reference" / "tools.md").is_file()
+    assert (skill.parent / "reference" / "workflows.md").is_file()
+    # The short/long convention is taught in the skill.
+    assert "detail='short'" in text or "detail=" in text
+
+
+@pytest.mark.parametrize("cmd", ["osint-brief", "osint-watch", "osint-jamming"])
+def test_commands_have_description(cmd: str) -> None:
+    text = (PLUGIN / "commands" / f"{cmd}.md").read_text()
+    assert text.startswith("---") and "description:" in text.split("---", 2)[1]
+
+
+def test_cross_platform_installers() -> None:
+    import os
+
+    for f in ["install.sh", "install.ps1", "install.cmd", "install.command"]:
+        assert (PLUGIN / f).is_file(), f"missing installer {f}"
+    # POSIX shell installers must keep the exec bit (macOS .command double-click
+    # silently fails without it — a real defect the review caught).
+    for f in ["install.sh", "install.command"]:
+        assert os.access(PLUGIN / f, os.X_OK), f"{f} must be executable"
+    # A BOM-less .ps1 is parsed with the ANSI codepage on Windows PowerShell 5.1,
+    # so any non-ASCII byte mojibakes at parse time — keep it pure ASCII.
+    assert (PLUGIN / "install.ps1").read_bytes().isascii(), "install.ps1 must be ASCII"

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -90,6 +90,24 @@ run `--list-tools` for the full set. A slice:
 `list_focus_areas`, `data_sources`, `deep_analyze`, `news_analysis`,
 `fact_check`, `aoi_imagery`.
 
+### Context budget: `detail='short'` vs `'long'`
+
+Every heavy tool takes a `detail` argument (`app/intel/shape.py`):
+
+- **`short`** (the default) — a token-frugal *digest* of the same payload:
+  scalars and small dicts kept, long arrays capped to the top few items with a
+  companion `<field>_total` giving the true size, verbose strings truncated, and
+  a top-level `truncated`/`hint` flag when anything was dropped. Ideal for
+  orientation and planet-wide sweeps. When nothing needs trimming the payload is
+  returned unchanged (short is a faithful passthrough for the already-small
+  tools).
+- **`long`** — the full route payload, untouched. Use it once you have picked one
+  incident/area/entity worth the extra context.
+
+The shaper is a pure function (no I/O) applied in the MCP layer, so the guarded
+`/api/intel/*` routes are unchanged. Rule of thumb for an agent: **sweep in
+`short`, drill in `long`.**
+
 ### `deep_analyze` (reasoning model)
 
 Gathers the relevant intel JSON and hands it to a **reasoning model** — DeepSeek
@@ -99,6 +117,26 @@ the agent's context. Auto-picks the smallest installed model; degrades to
 returning the raw structured JSON (`analysis: null`) when Ollama is absent.
 
 ## Running
+
+### Claude Code plugin (skill + commands + agent + MCP)
+
+The repo doubles as a Claude Code **plugin marketplace** (`plugin/osint-geoint/`).
+Installing the plugin wires the MCP server **and** an analyst skill
+(`osint-intel`), three slash commands (`/osint-brief`, `/osint-watch`,
+`/osint-jamming`), and a `osint-watch-officer` agent. Start the backend first
+(`bash scripts/run-api.sh`), then in Claude Code:
+
+```
+/plugin marketplace add /path/to/OSINT
+/plugin install osint-geoint@osint-velocity
+```
+
+Set **repo_dir** and **python** (the repo's venv interpreter) when prompted — the
+plugin launches that Python directly (`python -m app.mcp_server`), so one manifest
+works on Windows, macOS, and Linux. The installer prints the exact commands per OS:
+`bash plugin/osint-geoint/install.sh` (Linux/macOS, `-y` to register) or
+`plugin\osint-geoint\install.ps1` (Windows, `-Run` to register). See
+[`plugin/osint-geoint/README.md`](../plugin/osint-geoint/README.md).
 
 ### Hosted
 

--- a/plugin/osint-geoint/.claude-plugin/plugin.json
+++ b/plugin/osint-geoint/.claude-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "osint-geoint",
+  "displayName": "OSINT GEOINT",
+  "description": "Live geospatial intelligence as MCP tools — ADS-B aircraft, AIS vessels, GPS-jamming, SAR dark vessels, and a cross-domain incident-fusion engine — bundled with an analyst skill and slash commands. Sweep the planet for a few hundred tokens; drill on demand.",
+  "version": "1.0.0",
+  "author": { "name": "Velocity OSINT", "url": "https://projectvelocity.org" },
+  "homepage": "https://projectvelocity.org",
+  "repository": "https://github.com/AndrewCTF/osint-geospatial-console",
+  "license": "MIT",
+  "keywords": ["osint", "geoint", "adsb", "ais", "gps-jamming", "sar", "mcp", "intelligence"],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "commands": ["./commands/"],
+  "agents": ["./agents/"],
+  "userConfig": {
+    "repo_dir": {
+      "type": "directory",
+      "title": "OSINT repo directory",
+      "description": "Absolute path to your cloned OSINT repo — the folder that contains apps/api. The backend must be running (bash scripts/run-api.sh) for the tools to return live data.",
+      "required": true
+    },
+    "python": {
+      "type": "file",
+      "title": "Python interpreter",
+      "description": "Absolute path to the repo's venv Python (has the apps/api deps): macOS/Linux <repo>/apps/api/.venv/bin/python, Windows <repo>\\apps\\api\\.venv\\Scripts\\python.exe. Run plugin/osint-geoint/install.sh (or install.ps1 on Windows) to print the exact path.",
+      "required": true
+    },
+    "api_base": {
+      "type": "string",
+      "title": "Backend base URL",
+      "description": "URL of the running OSINT backend the tools query over localhost.",
+      "default": "http://127.0.0.1:8000",
+      "required": false
+    }
+  }
+}

--- a/plugin/osint-geoint/.mcp.json
+++ b/plugin/osint-geoint/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "osint-geoint": {
+      "command": "${user_config.python}",
+      "args": ["-m", "app.mcp_server"],
+      "cwd": "${user_config.repo_dir}/apps/api",
+      "env": {
+        "PYTHONPATH": "${user_config.repo_dir}/apps/api",
+        "API_BASE": "${user_config.api_base}"
+      }
+    }
+  }
+}

--- a/plugin/osint-geoint/README.md
+++ b/plugin/osint-geoint/README.md
@@ -1,0 +1,69 @@
+# OSINT GEOINT — Claude Code plugin
+
+Live geospatial intelligence as MCP tools, bundled with an analyst **skill**,
+three **slash commands**, and a **watch-officer agent**. Sweep the planet for a
+few hundred tokens; drill on demand.
+
+- **22 MCP tools** over live ADS-B (aircraft), AIS (vessels), a GPS-jamming
+  layer, Sentinel-1 SAR dark vessels, geocoded events, and a cross-domain
+  incident-fusion engine.
+- **Context-optimised** — every heavy tool takes `detail='short'` (a token-frugal
+  digest, the default) or `detail='long'` (the full bundle). See the skill.
+- **Skill** `osint-intel` teaches the brief-first → drill-second workflow, with
+  `reference/tools.md` and `reference/workflows.md` loaded on demand.
+- **Commands** `/osint-brief`, `/osint-watch`, `/osint-jamming`.
+- **Agent** `osint-watch-officer` for standing surveillance.
+
+## Install
+
+The tools query a **local OSINT backend**, so start it first (from the repo root):
+
+```bash
+bash scripts/run-api.sh          # backend on :8000
+```
+
+**Full plugin** (MCP + skill + commands + agent):
+
+```
+/plugin marketplace add /path/to/OSINT
+/plugin install osint-geoint@osint-velocity
+```
+
+When prompted, set **repo_dir** to your cloned OSINT repo (the folder containing
+`apps/api`) and **python** to that repo's venv interpreter —
+`apps/api/.venv/bin/python` (macOS/Linux) or `apps\api\.venv\Scripts\python.exe`
+(Windows). `api_base` defaults to `http://127.0.0.1:8000`. The plugin launches
+that Python directly (`python -m app.mcp_server`), so the same manifest works on
+Windows, macOS, and Linux.
+
+**MCP only** (no skill/commands), or to script it — the installer prints the exact
+commands for your OS and, with the run flag, registers the server via
+`claude mcp add`:
+
+```bash
+# Linux / macOS  (or double-click install.command on macOS)
+bash plugin/osint-geoint/install.sh          # print commands
+bash plugin/osint-geoint/install.sh -y       # also register the MCP server
+```
+
+```powershell
+# Windows PowerShell  (or double-click install.cmd)
+plugin\osint-geoint\install.ps1              # print commands
+plugin\osint-geoint\install.ps1 -Run         # also register the MCP server
+```
+
+**Hosted** (no local backend; needs a Velocity token):
+
+```bash
+claude mcp add --transport http osint-geoint \
+  https://projectvelocity.org/mcp \
+  --header "Authorization: Bearer $VELOCITY_TOKEN"
+```
+
+## First moves
+
+`get_situation()` to orient → `intel_brief()` for cited cross-domain incidents →
+`focus_area(lat, lon)` to load a region PRIMARY → drill with `query_vessels` /
+`gps_jamming` / `detect_deception` → `deep_analyze()` for an off-context judgement.
+
+Full architecture and the `/api/intel/*` HTTP surface: [`docs/mcp-server.md`](../../docs/mcp-server.md).

--- a/plugin/osint-geoint/agents/osint-watch-officer.md
+++ b/plugin/osint-geoint/agents/osint-watch-officer.md
@@ -1,0 +1,35 @@
+---
+name: osint-watch-officer
+description: Autonomous OSINT watch officer. Briefs a region across air / maritime / GPS-jamming domains, then monitors it and surfaces only material changes. Use for standing surveillance of an area of interest, or when the user says "keep an eye on X" over live open-source feeds.
+---
+
+You are an OSINT **watch officer** driving the `osint-geoint` MCP tools over live
+open-source feeds (ADS-B aircraft, AIS vessels, GPS-jamming, SAR dark vessels,
+geocoded events) with a cross-domain incident-fusion engine.
+
+## Doctrine
+
+- **Fuse, don't correlate by hand.** `intel_brief()` already chains co-located
+  signals into cited incidents. Lead from incidents; use raw layers only to
+  corroborate or challenge.
+- **Budget context.** Sweep with `detail='short'`; switch to `'long'` only on the
+  one incident/area you commit to. Never open a global call in `long`.
+- **Trust, but verify the feed.** In a jammed or high-tension area run
+  `detect_deception()` before believing tracks — spoofing and duplicate-MMSI are
+  distinct from jamming.
+
+## Loop
+
+1. Establish the AOI PRIMARY once: `focus_area(lat, lon, radius_nm, label)`.
+2. Baseline: `intel_brief(lat, lon, detail='long')`. Record the incident set.
+3. Monitor: each cycle call `whats_changed(lat, lon)` and report **only** NEW /
+   ESCALATED / DE-ESCALATED / RESOLVED. Stay silent when nothing material moved.
+4. On escalation: `incident_history(lat, lon)` for the build-up sequence, then
+   drill the evidence (`query_vessels`, `query_aircraft`, `gps_jamming`,
+   `locate_emitter`, dossiers) and, if warranted, `deep_analyze(...)`.
+
+## Reporting
+
+Terse and cited: threat level, the domains that converged, concrete numbers and
+entity IDs (ICAO24 / MMSI / incident id), and one recommended follow-up. If a
+layer is empty or key-gated (`data_sources()`), say so — never invent coverage.

--- a/plugin/osint-geoint/commands/osint-brief.md
+++ b/plugin/osint-geoint/commands/osint-brief.md
@@ -1,0 +1,14 @@
+---
+description: Cross-domain intelligence brief for an area (or global) from the live OSINT feeds
+argument-hint: [place | lat,lon | global]
+---
+
+Produce an intelligence brief for: **$ARGUMENTS**
+
+1. If `$ARGUMENTS` names a place, resolve it to `lat`/`lon` (use your knowledge or a quick search). If it is empty or `global`, brief globally.
+2. `get_situation()` to orient (global counts, worst jamming, emergencies).
+3. `intel_brief(...)` scoped to the area (or global), `detail='short'` first — it returns ranked, cited INCIDENTS, not raw layers.
+4. Summarise the top incidents: threat level, domains, one-line narrative, evidence IDs.
+5. Offer to `focus_area()` + drill (`detail='long'`) into the single highest-threat incident.
+
+Keep it tight: verdict → top incidents with numbers/IDs → the one recommended next query. Never invent signals the tools did not return.

--- a/plugin/osint-geoint/commands/osint-jamming.md
+++ b/plugin/osint-geoint/commands/osint-jamming.md
@@ -1,0 +1,17 @@
+---
+description: Hunt GPS jamming/spoofing and estimate the emitter location
+argument-hint: [place | lat,lon | global]
+---
+
+Hunt GPS jamming for: **$ARGUMENTS**
+
+Follow the jammer-hunt playbook:
+
+1. `get_situation()` → read `gps_jamming.high` (any high-severity cells worldwide?).
+2. `gps_jamming(area or global)` → the worst cell's centre.
+3. `focus_area(lat, lon, 300)` → a fresh, un-rate-limited pull of that region.
+4. `locate_emitter(lat, lon, 300)` → weighted-centroid estimate + CEP + confidence. State clearly it is a **footprint estimate (~tens of km), not RF direction-finding**.
+5. `query_aircraft(lat, lon, gnss_degraded=True, detail='long')` → the affected aircraft, to corroborate the footprint with real tracks.
+6. `detect_deception(lat, lon)` → rule out that this is GPS **spoofing** (position injection) rather than jamming.
+
+Report: emitter estimate ±CEP, affected-aircraft count, confidence, and caveats.

--- a/plugin/osint-geoint/commands/osint-watch.md
+++ b/plugin/osint-geoint/commands/osint-watch.md
@@ -1,0 +1,14 @@
+---
+description: Stand a watch over an area — baseline once, then report only what changes
+argument-hint: [place | lat,lon]
+---
+
+Stand a watch over: **$ARGUMENTS**
+
+1. Resolve `$ARGUMENTS` to `lat`/`lon`.
+2. `focus_area(lat, lon, radius_nm, label="…")` once to load the area PRIMARY (dedicated fresh fetch).
+3. `intel_brief(lat, lon, detail='long')` for the baseline picture; summarise it.
+4. Then poll `whats_changed(lat, lon)` — report **only** what is NEW / ESCALATED / DE-ESCALATED / RESOLVED. Do not re-brief the whole area each cycle.
+5. On an escalation, `incident_history(lat, lon)` to show how it built up over time.
+
+If the user wants this to repeat automatically on a cadence, suggest the `/loop` skill wrapping `whats_changed` for this area.

--- a/plugin/osint-geoint/install.cmd
+++ b/plugin/osint-geoint/install.cmd
@@ -1,0 +1,3 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1" %*
+pause

--- a/plugin/osint-geoint/install.command
+++ b/plugin/osint-geoint/install.command
@@ -1,0 +1,5 @@
+#!/bin/bash
+# macOS double-click wrapper - runs the POSIX installer in Terminal.
+set -euo pipefail
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$dir/install.sh" "$@"

--- a/plugin/osint-geoint/install.ps1
+++ b/plugin/osint-geoint/install.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    Ez-install the OSINT GEOINT MCP server into Claude Code - Windows.
+
+.DESCRIPTION
+    Prints the exact commands to register the OSINT GEOINT MCP server with
+    Claude Code (full plugin, MCP-only CLI, or hosted HTTP). With -Run it also
+    executes the Option-B 'claude mcp add' registration for you.
+
+    (Linux/macOS: use plugin/osint-geoint/install.sh)
+
+.PARAMETER Run
+    Also register the MCP server now via 'claude mcp add' (needs the Claude Code
+    CLI on PATH). Equivalent to install.sh's -y flag.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File plugin\osint-geoint\install.ps1
+    Print the exact install commands.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File plugin\osint-geoint\install.ps1 -Run
+    Also register the MCP server now.
+#>
+param([switch]$Run)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ASCII-only output below: a BOM-less .ps1 is decoded with the ANSI codepage on
+# Windows PowerShell 5.1, so any non-ASCII source would mojibake at parse time.
+
+$repo = (Get-Item $PSScriptRoot).Parent.Parent.FullName   # plugin\osint-geoint -> repo root
+$py   = Join-Path $repo 'apps\api\.venv\Scripts\python.exe'
+if (-not (Test-Path $py)) { $py = 'python' }
+$apiBase = if ($env:API_BASE) { $env:API_BASE } else { 'http://127.0.0.1:8000' }
+
+Write-Host "OSINT repo:  $repo"
+Write-Host "Python:      $py"
+Write-Host "API base:    $apiBase"
+Write-Host ""
+
+Write-Host "== Option A - full plugin (MCP + skill + commands + agent) ================"
+Write-Host "In Claude Code, run:"
+Write-Host "    /plugin marketplace add $repo"
+Write-Host "    /plugin install osint-geoint@osint-velocity"
+Write-Host "  When prompted:  repo_dir = $repo   python = $py"
+Write-Host ""
+Write-Host "== Option B - MCP server only (Claude Code CLI) ==========================="
+Write-Host "    claude mcp add osint-geoint ``"
+Write-Host "        --env ""PYTHONPATH=$repo\apps\api"" ``"
+Write-Host "        --env ""API_BASE=$apiBase"" ``"
+Write-Host "        ""--"" ""$py"" -m app.mcp_server"
+Write-Host "    (or just re-run this script with -Run, which registers it reliably)"
+Write-Host ""
+Write-Host "== Option C - hosted (no local backend; needs a Velocity token) ==========="
+Write-Host "    claude mcp add --transport http osint-geoint ``"
+Write-Host "        https://projectvelocity.org/mcp ``"
+Write-Host "        --header ""Authorization: Bearer <VELOCITY_TOKEN>"""
+Write-Host ""
+Write-Host "NOTE: Options A/B query a LOCAL backend - start it first:  bash scripts/run-api.sh"
+Write-Host "      (on Windows: run it under WSL, or launch the venv uvicorn directly)."
+
+if ($Run -or $env:INSTALL_RUN -eq '1') {
+    if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+        # Write-Host (not Write-Error) so the clean message shows and `exit 1`
+        # actually runs under $ErrorActionPreference='Stop'.
+        Write-Host "'claude' not on PATH - install the Claude Code CLI first." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host ""
+    Write-Host "Registering the MCP server via 'claude mcp add'..."
+    # Build an explicit argument array and splat it. PowerShell passes each
+    # element to the native exe verbatim (including the literal '--'); do NOT
+    # use the '--%' stop-parsing token - it would swallow the $py/$repo vars.
+    $mcpArgs = @(
+        'mcp', 'add', 'osint-geoint',
+        '--env', "PYTHONPATH=$repo\apps\api",
+        '--env', "API_BASE=$apiBase",
+        '--', $py, '-m', 'app.mcp_server'
+    )
+    & claude @mcpArgs
+    Write-Host "Done. Verify with:  claude mcp list"
+}

--- a/plugin/osint-geoint/install.sh
+++ b/plugin/osint-geoint/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Ez-install the OSINT GEOINT MCP server into Claude Code — Linux & macOS.
+# (Windows: use plugin/osint-geoint/install.ps1)
+#
+#   bash plugin/osint-geoint/install.sh        # print the exact install commands
+#   bash plugin/osint-geoint/install.sh -y     # also register the MCP server now
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"                 # plugin/osint-geoint -> repo root
+py="$repo/apps/api/.venv/bin/python"
+[ -x "$py" ] || py="$(command -v python3 || echo python3)"
+api_base="${API_BASE:-http://127.0.0.1:8000}"
+
+echo "OSINT repo:  $repo"
+echo "Python:      $py"
+echo "API base:    $api_base"
+echo
+
+echo "── Option A — full plugin (MCP + skill + commands + agent) ──────────────"
+echo "In Claude Code, run:"
+echo "    /plugin marketplace add $repo"
+echo "    /plugin install osint-geoint@osint-velocity"
+echo "  When prompted:  repo_dir = $repo   python = $py"
+echo
+echo "── Option B — MCP server only (Claude Code CLI) ─────────────────────────"
+echo "    claude mcp add osint-geoint \\"
+echo "        --env \"PYTHONPATH=$repo/apps/api\" \\"
+echo "        --env \"API_BASE=$api_base\" \\"
+echo "        -- \"$py\" -m app.mcp_server"
+echo
+echo "── Option C — hosted (no local backend; needs a Velocity token) ─────────"
+echo "    claude mcp add --transport http osint-geoint \\"
+echo "        https://projectvelocity.org/mcp \\"
+echo "        --header \"Authorization: Bearer \$VELOCITY_TOKEN\""
+echo
+echo "NOTE: Options A/B query a LOCAL backend — start it first:  bash scripts/run-api.sh"
+
+if [ "${1:-}" = "-y" ] || [ "${INSTALL_RUN:-}" = "1" ]; then
+  command -v claude >/dev/null 2>&1 || { echo "'claude' not on PATH — install the Claude Code CLI first." >&2; exit 1; }
+  echo
+  echo "Registering the MCP server via 'claude mcp add'…"
+  claude mcp add osint-geoint \
+    --env "PYTHONPATH=$repo/apps/api" \
+    --env "API_BASE=$api_base" \
+    -- "$py" -m app.mcp_server
+  echo "Done. Verify with:  claude mcp list"
+fi

--- a/plugin/osint-geoint/skills/osint-intel/SKILL.md
+++ b/plugin/osint-geoint/skills/osint-intel/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: osint-intel
+description: >-
+  Drive the OSINT GEOINT MCP server — live ADS-B aircraft, AIS vessels,
+  GPS-jamming (NACp/NIC), Sentinel-1 SAR dark vessels, geocoded events, and a
+  cross-domain incident-fusion engine. Use when the user asks about live air or
+  maritime traffic, GPS jamming/spoofing, dark/AIS-off vessels, a region's
+  threat picture, denial & deception, or wants to stand watch over an area.
+when_to_use: >-
+  Any live geospatial-intelligence question — "what's flying/sailing near X",
+  "is there GPS jamming in the Baltic", "any dark vessels off Y", "give me the
+  threat picture for Z", "watch this area and tell me what changes".
+---
+
+# OSINT GEOINT — analyst playbook
+
+You have an MCP server (`osint-geoint`) over a live intelligence console: ~13k
+aircraft (ADS-B), ~21k vessels (AIS), a GPS-jamming layer, SAR dark-vessel
+detections, geocoded events, and a fusion engine that chains co-located signals
+into **cited incidents**. Every tool returns distilled JSON, so you can sweep the
+planet for a few hundred tokens.
+
+## The one habit that matters: brief first, drill second
+
+Do **not** pull raw layers and correlate them by hand — the fusion engine already
+did. The spine of every investigation:
+
+1. **`get_situation()`** — one cheap call to orient (global counts, worst jamming
+   cells, emergencies, vessel mix).
+2. **`intel_brief()`** — the headline tool. Ranked, cited cross-domain INCIDENTS
+   (a convergence of ≥2 domains within a link distance), each with a narrative,
+   threat level, evidence IDs, and recommended follow-ups. Omit coords for global;
+   pass `lat,lon,radius_nm` or a bbox to scope.
+3. **`focus_area(lat, lon, radius_nm)`** — mark the incident's region PRIMARY: a
+   dedicated always-fresh fetch that bypasses global rate limits, plus a full
+   bundle (aircraft, density, jamming, vessels, anomalies) in one call.
+4. **Drill** into the evidence: `query_vessels`, `query_aircraft`, `gps_jamming`,
+   `detect_deception`, `locate_emitter`, `vessel_dossier`, `aircraft_dossier`.
+5. **`deep_analyze(question, lat, lon)`** — hand the gathered intel to a reasoning
+   model; heavy analysis runs off your context, only the conclusion returns.
+
+To **monitor** instead of re-reading: `whats_changed()` returns only what is NEW /
+ESCALATED / DE-ESCALATED / RESOLVED since your last check.
+
+## Context budget: `detail='short'` vs `'long'`
+
+Most tools take `detail`:
+
+- **`short`** (default) — a token-frugal digest: headline counts plus the top few
+  items of each list, with a companion `<field>_total` telling you the true size
+  and a `hint`/`truncated` flag when anything was trimmed. Use it for orientation
+  and broad sweeps.
+- **`long`** — the full, comprehensive bundle. Switch to it only once you have
+  picked one incident/area/entity worth the extra context.
+
+Rule of thumb: sweep in `short`, drill in `long`. Never open with `long` on a
+global call — you will burn context on regions you are about to discard.
+
+## Before you trust a contested feed
+
+In a jammed or high-tension area, run **`detect_deception()`** first — it flags
+manipulated tracks (duplicate-MMSI vessels, impossible teleports, GPS-spoof
+position injection) that are distinct from mere jamming. Trusting a spoofed feed
+is worse than having no feed.
+
+## References (load on demand — keep this file cheap)
+
+- **`reference/tools.md`** — every tool, its parameters, what it returns, and when
+  to reach for it. Read it when you need a parameter you don't remember.
+- **`reference/workflows.md`** — worked playbooks: hunt a GPS jammer, find dark
+  vessels, run a standing watch, build a pattern-of-life dossier, fact-check an
+  event against the news layer.
+
+## Honesty contract
+
+The data is real and often thin. Cite concrete numbers and IDs. If a layer is
+empty or a feed is key-gated (`data_sources()` says which), say so — never invent
+vessels, aircraft, or events the tools did not return.

--- a/plugin/osint-geoint/skills/osint-intel/reference/tools.md
+++ b/plugin/osint-geoint/skills/osint-intel/reference/tools.md
@@ -1,0 +1,60 @@
+# OSINT GEOINT — tool reference
+
+22 tools. All geography is optional and accepted two ways: a **centre**
+(`lat`, `lon`, `radius_nm`) or an explicit **bbox** (`min_lon`, `min_lat`,
+`max_lon`, `max_lat`). Omit both for a **global** view. Most tools take
+`detail='short'` (default digest) or `'long'` (full bundle) — see the SKILL.
+
+## Orient & fuse (start here)
+
+| Tool | Use it to… | Key args |
+| --- | --- | --- |
+| `get_situation()` | Cheapest first call — global counts, worst jamming cells, emergencies, vessel mix. | `detail` |
+| `intel_brief(...)` | **Headline.** Ranked, cited cross-domain INCIDENTS with narratives + evidence IDs + follow-ups. | area/bbox, `link_km=50`, `window_hours=6`, `detail` |
+| `anomalies(...)` | Fused triage report: emergencies, jamming hotspots, dark vessels, alerts + `threat_level`. | area/bbox, `detail` |
+| `focus_area(lat, lon, radius_nm)` | Load a region **PRIMARY** (dedicated fresh fetch) + full bundle in one call. | `label`, `cell_deg=1.0`, `detail` |
+
+## Drill into evidence
+
+| Tool | Use it to… | Key args |
+| --- | --- | --- |
+| `query_aircraft(...)` | Filtered aircraft: category, squawk, callsign, altitude band, emergency/gnss/on-ground flags. | filters, `limit=50`, `detail` |
+| `lookup_aircraft(ident)` | One aircraft by ICAO24 hex (exact) or callsign (substring) + integrity/threat assessment. | `ident` |
+| `query_vessels(...)` | AIS vessels classified (cargo/tanker/fishing/passenger/military/…); `dark_only=True` for dark candidates. | area/bbox, `dark_only`, `limit=50`, `detail` |
+| `aircraft_density(...)` | Density grid (count, by-category, GNSS-degraded per cell) + peak cell + in-area vessels. | area/bbox, `cell_deg=1.0`, `detail` |
+| `gps_jamming(...)` | GPSJam assessment (NACp<8 / NIC<7 binned to 1° cells), ranked by severity + affected sample. | area/bbox, `detail` |
+
+## Adversary & attribution
+
+| Tool | Use it to… | Key args |
+| --- | --- | --- |
+| `detect_deception(...)` | **"Am I being fed?"** Duplicate-MMSI, teleports, GPS-spoof injection — distinct from jamming. Run before trusting a contested feed. | area, `detail` |
+| `locate_emitter(...)` | Estimate a jammer/spoofer LOCATION from the degraded-ADS-B footprint (weighted centroid + CEP + confidence). Not RF DF. | area, `detail` |
+| `area_baseline(...)` | "Is this normal?" Current counts z-scored against a rolling baseline; anomalies called out (e.g. "dark vessels +5σ"). | area, `detail` |
+
+## Monitor & history
+
+| Tool | Use it to… | Key args |
+| --- | --- | --- |
+| `whats_changed(...)` | Standing watch — only NEW/ESCALATED/DE-ESCALATED/RESOLVED since your last check. Poll this instead of re-briefing. | area, `detail` |
+| `incident_history(...)` | Per-incident timeline `[time, threat_level, score]` — reveals sequence (jamming → dark vessels → event). | area, `hours=6`, `limit=25`, `detail` |
+| `vessel_dossier(mmsi)` | Pattern-of-life for one vessel: track, AIS gaps, speed profile, incidents it appears in. | `mmsi`, `detail` |
+| `aircraft_dossier(ident)` | Pattern-of-life for one aircraft: track, gaps, GNSS integrity, emergency/military flags. | `ident`, `detail` |
+| `list_focus_areas()` | Which AOIs are loaded PRIMARY (fetch stats; direct vs snapshot fallback). | — |
+
+## Reasoning, news & imagery
+
+| Tool | Use it to… | Key args |
+| --- | --- | --- |
+| `deep_analyze(question, lat, lon)` | Hand gathered intel to a reasoning model (DeepSeek → Ollama). Heavy analysis off your context; conclusion returns. | `question`, area, `tier='reason'|'fast'` |
+| `news_analysis()` | Cross-source debiased world news: verified facts (≥2 outlets) vs attributed claims vs rhetoric, with bias flags. | — |
+| `fact_check(claim)` | Adjudicate one claim vs current headlines → `{verdict, reasoning, sources, confidence}`. | `claim` |
+| `aoi_imagery(before, after, lat, lon)` | What VHR/Sentinel imagery exists for a place at two dates (no download). `best_source` says which to use. | dates, area, `window_days=30` |
+| `data_sources()` | Which feeds are always-on vs key-gated, + configured reasoning backend. Explain coverage gaps with this. | — |
+
+## Reading a `short` digest
+
+When `detail='short'` trims something you'll see: capped arrays, a `<field>_total`
+giving the real size, and top-level `truncated: true` + a `hint`. Re-issue the
+same call with `detail='long'` to get the untrimmed bundle. If those keys are
+absent, the payload was already small — you have all of it.

--- a/plugin/osint-geoint/skills/osint-intel/reference/workflows.md
+++ b/plugin/osint-geoint/skills/osint-intel/reference/workflows.md
@@ -1,0 +1,76 @@
+# OSINT GEOINT — worked playbooks
+
+Each playbook is short → drill. Sweep with `detail='short'`; switch to `'long'`
+only on the one target you commit to.
+
+## 1. Hunt a GPS jammer
+
+1. `get_situation()` → read `gps_jamming.high` to see if any high-severity cells
+   exist worldwide.
+2. `gps_jamming()` (global, short) → note the worst cell's centre.
+3. `focus_area(lat, lon, 300)` → load it PRIMARY for a fresh, un-rate-limited pull.
+4. `locate_emitter(lat, lon, 300)` → weighted-centroid estimate + CEP + confidence.
+   State it's a footprint estimate (~tens of km), not RF direction-finding.
+5. `query_aircraft(lat, lon, gnss_degraded=True, detail='long')` → the affected
+   aircraft — corroborate the footprint with real tracks.
+6. `deep_analyze("Is this coordinated jamming, and where is the emitter?", lat, lon)`.
+
+## 2. Find & work dark vessels
+
+1. `intel_brief(lat, lon, radius_nm)` → does a dark-vessel incident already exist?
+   Let fusion do the correlation.
+2. `query_vessels(lat, lon, dark_only=True, detail='long')` → dark candidates
+   (moving, no static identity).
+3. For each of interest: `vessel_dossier(mmsi)` → track, AIS gaps, speed profile
+   (loiter / transit / loiter-then-dash), which incidents it appears in.
+4. `area_baseline(lat, lon)` → is the dark-vessel count actually anomalous
+   (e.g. "+5σ") or a normal day here?
+5. `detect_deception(lat, lon)` → make sure a "dark vessel" isn't a spoofed or
+   duplicate-MMSI artefact before you escalate.
+
+## 3. Stand a watch over an area
+
+1. Establish the area PRIMARY once: `focus_area(lat, lon, radius_nm, label="…")`.
+2. Baseline it: `intel_brief(lat, lon, radius_nm, detail='long')` — the full picture.
+3. Then poll **`whats_changed(lat, lon, radius_nm)`** on a cadence — it diffs
+   against your previous call for that area and returns only NEW / ESCALATED /
+   DE-ESCALATED / RESOLVED incidents. Do NOT re-brief every cycle.
+4. On an escalation, `incident_history(lat, lon)` shows how it built up over time.
+
+## 4. Build a pattern-of-life dossier
+
+- Aircraft: `aircraft_dossier(ident)` (ICAO24 hex or callsign) → recent track,
+  gaps, GNSS integrity, emergency/military flags, live incidents.
+- Vessel: `vessel_dossier(mmsi)` → track over the ~1 h retention window, AIS gaps,
+  derived speed profile, area covered.
+- Pair with `lookup_aircraft(ident)` for a point-in-time integrity/threat read.
+
+## 5. Verify an event against open news
+
+1. `news_analysis()` → debiased world events: verified facts (≥2 independent
+   outlets) vs attributed claims vs rhetoric.
+2. `fact_check("<specific claim>")` → `{verdict, reasoning, supporting_sources,
+   confidence}`. Use before treating any statement as fact.
+3. Cross with geospatial: if a claim names a place, `intel_brief(lat, lon)` there
+   to see whether the live picture supports it.
+
+## 6. Assess imagery availability for a site
+
+`aoi_imagery(before="YYYY-MM-DD", after="YYYY-MM-DD", lat, lon, radius_km=5)` →
+what Maxar VHR (event-gated, ~0.3–0.5 m) and Sentinel (10 m, global) scenes exist
+for each date **without downloading**. Read `best_source` to decide which to pull.
+
+## Global sweep, cheaply
+
+To scan the planet without blowing context: `get_situation()` →
+`intel_brief()` (global, short) → pick the top 1–2 incidents → `focus_area()` +
+`detail='long'` only on those. Everything you discard cost you a few tokens.
+
+## Failure modes to expect
+
+- **Backend cold-start**: the very first global call can take up to ~75 s while
+  the snapshot warms; after that every call is instant. Retry once on a timeout.
+- **Key-gated layers**: fires (FIRMS) and some imagery need keys. `data_sources()`
+  tells you what's on. Report the gap; don't infer the missing layer.
+- **Contested feeds**: always `detect_deception()` before trusting tracks in a
+  jammed/high-tension area.


### PR DESCRIPTION
## Summary

Two additions on top of the existing MCP server:

**Context optimisation — short/long tool variants.** The heavy MCP tools now take
`detail='short'` (a token-frugal digest, the default) or `detail='long'` (the full
bundle). The shaper (`apps/api/app/intel/shape.py`) runs in the MCP layer so the
guarded `/api/intel/*` routes are untouched; it caps long arrays to the top few
items with a companion `<field>_total`, truncates verbose strings, flags what it
trimmed, and is a faithful passthrough when a payload is already small.
`deep_analyze` pulls `long` internally so the reasoning model keeps the full picture.

**Packaged as an installable plugin.** The repo is now a plugin marketplace
(`.claude-plugin/marketplace.json` → `plugin/osint-geoint/`) bundling the MCP
server, an analyst skill (`osint-intel`, with on-demand tool/workflow references),
three slash commands (`/osint-brief`, `/osint-watch`, `/osint-jamming`), and an
`osint-watch-officer` agent. The plugin launches the venv Python directly
(`python -m app.mcp_server`), so one manifest works on Windows, macOS, and Linux.

## Proof (live, real MCP stdio transport → booted backend)

| tool | short → long | saved |
| --- | --- | --- |
| `query_aircraft` | 1,397 → 47,374 B | 97% |
| `query_vessels` | 1,151 → 31,191 B | 96% |
| `aircraft_density` | 1,134 → 20,741 B | 95% |
| `gps_jamming` | 1,973 → 22,653 B | 91% |
| `anomalies` | 3,228 → 14,034 B | 77% |
| `get_situation` | 1,074 → 1,074 B | 0% (no-op, nothing to trim) |

Each short digest carried `truncated=true` + honest `*_total` counts; error
envelopes pass through untouched.

## Install

Backend up (`bash scripts/run-api.sh`), then either:

- **Full plugin:** `/plugin marketplace add <repo>` → `/plugin install osint-geoint@osint-velocity`
- **OS installer:** `install.sh` / `install.command` (Linux/macOS), `install.ps1` / `install.cmd` (Windows) — each prints the exact commands and, with the run flag, registers the server.

## Verification

- `pytest apps/api` → **1088 passed, 1 skipped**
- ruff clean; shell `bash -n` clean
- New guards: `test_mcp_detail.py`, `test_plugin_manifest.py` (asserts the manifest resolves, the POSIX installers keep their exec bit, and `install.ps1` stays ASCII)

## Not verified

The Windows scripts (`install.ps1` / `install.cmd`) are review-validated but not
executed on a Windows host (no PowerShell in this environment).
