### PR TITLE
De-flake dossier last_fix test: assert by position, not wall-clock age

### DIFF
--- a/apps/api/tests/test_dossier.py
+++ b/apps/api/tests/test_dossier.py
@@ -107,8 +107,11 @@ async def test_dossier_merges_db_history_with_live_fix(tmp_path) -> None:
     assert res["found"] is True
     # 20 DB + 1 live (the live fix is far in time from every DB row → no dedup).
     assert res["track"]["fixes"] == 21
-    # Freshest fix wins for last_fix + identity comes from the live tier.
-    assert res["last_fix"]["age_s"] <= 5
+    # Freshest fix wins for last_fix: it must be the live fix (lon 20 / lat 51),
+    # not a staler DB row (lon ~10 / lat 50). Asserted by position rather than a
+    # wall-clock age bound — the old `age_s <= 5` flaked on slow/loaded CI where
+    # the test's own elapsed time pushed the live fix's age past 5 s.
+    assert (res["last_fix"]["lon"], res["last_fix"]["lat"]) == (20.0, 51.0)
     assert res["callsign"] == "LIVE99"
 
 


### PR DESCRIPTION
## Problem

`test_dossier.py::test_dossier_merges_db_history_with_live_fix` asserts `res["last_fix"]["age_s"] <= 5`. This is a wall-clock bound tied to the test's own execution speed: on a slow or loaded CI runner the elapsed time between seeding the fix and building the dossier pushes the live fix's age past 5s. It failed the `api` job on a run that took 253s (measured age 13). It slipped into master via #27 because that squash merge predated this fix.

## Fix

The test's intent is that the freshest (live) fix wins `last_fix`, not a staler DB row. The live fix is at a unique position (lon 20 / lat 51) that no DB row shares (DB rows are lon ~10 / lat 50), so assert that position directly — same intent, no wall-clock dependency.

## Verification

`pytest apps/api/tests/test_dossier.py` → 6 passed. One file changed.