### PR TITLE
Add external-actuation control blocks and a MAVLink drone bridge to Workflows

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -337,6 +337,20 @@ class Settings(BaseSettings):
     ais_myshiptracking_sidecar_url: str = "http://127.0.0.1:8093/vessels.json"
     ais_myshiptracking_sidecar_interval_s: float = 30.0
 
+    # MAVLink bridge sidecar (app.mavlink_sidecar → `python -m app.mavlink_bridge`).
+    # The first-class control server the Workflows `control.drone` block points
+    # at: it translates the drone.command JSON envelope into real MAVLink and
+    # forwards it to a vehicle / SITL. OFF by default — a control bridge that
+    # auto-connects to a drone at boot is not something you want implicitly, and
+    # pymavlink + a MAVLink endpoint are optional (without them it runs log-only,
+    # echoing the planned commands without touching a vehicle). Enable it and
+    # point `control.drone.server_url` at http://127.0.0.1:{port}.
+    mavlink_bridge_enabled: bool = False
+    mavlink_bridge_port: int = 9010
+    # pymavlink connection string, e.g. "udpout:127.0.0.1:14550" (SITL/ArduPilot/
+    # PX4) or "/dev/ttyACM0,57600" (a real radio). Empty → log-only (no uplink).
+    mavlink_bridge_connect: str = ""
+
     # Keyless GLOBAL AIS via DIRECT httpx (NO browser sidecar) — ShipXplorer's
     # public data.shipxplorer.com/live bbox endpoint. Reachable straight from the
     # server with browser-like headers (referer/origin); NOT Cloudflare-gated. A

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -197,6 +197,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             from app import ais_sidecar  # noqa: PLC0415
 
             await ais_sidecar.start()
+            # MAVLink bridge: the drone control server the Workflows control.drone
+            # block talks to. OFF unless mavlink_bridge_enabled; log-only without a
+            # MAVLINK_CONNECT endpoint. Best-effort — never blocks boot.
+            from app import mavlink_sidecar  # noqa: PLC0415
+
+            await mavlink_sidecar.start()
             correlate_runner.start()
             # ADS-B sticky snapshot: start the background refresher at BOOT so the
             # snapshot (and the pre-gzipped world-view blob the hot route + /ws/adsb
@@ -360,6 +366,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             from app import ais_sidecar  # noqa: PLC0415
 
             await ais_sidecar.stop()
+            # Tear down the MAVLink bridge (no-op if it never started).
+            from app import mavlink_sidecar  # noqa: PLC0415
+
+            await mavlink_sidecar.stop()
 
 
 def create_app() -> FastAPI:

--- a/apps/api/app/mavlink_bridge.py
+++ b/apps/api/app/mavlink_bridge.py
@@ -1,0 +1,398 @@
+"""MAVLink bridge — the first-class drone control server.
+
+The Workflows ``control.drone`` block POSTs a ``drone.command`` JSON envelope
+(contract: ``docs/workflows-control-blocks.md``) to a control server. THIS is
+that server: it translates the envelope into standard MAVLink and forwards it to
+a vehicle (real, or a SITL like ArduPilot / PX4). Run it as a sidecar
+(``python -m app.mavlink_bridge``, managed by ``app.mavlink_sidecar``) or
+standalone pointing at your own autopilot.
+
+Two layers, split so the translation is testable without a vehicle or the
+optional ``pymavlink`` dependency:
+
+  * ``plan_mavlink(envelope)`` — PURE. Envelope → a list of ``MavIntent`` (an
+    abstract "send this MAVLink message" description). No I/O, no pymavlink.
+  * ``MavlinkLink`` — lazily imports pymavlink, connects on first use, and
+    turns intents into real ``mav.*_send`` calls. With no pymavlink OR no
+    connection string it degrades to **log-only**: it echoes the planned
+    intents so a workflow can be rehearsed end to end without an uplink.
+
+Safety: the bridge only issues the standard commands your autopilot already
+gates (it does not bypass arming checks / geofence). ``goto`` assumes the
+vehicle is in GUIDED/OFFBOARD — same as any MAVLink GCS. An optional bearer
+token (``MAVLINK_BRIDGE_TOKEN``) matches the block's ``auth_env`` field.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import deque
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+log = logging.getLogger("mavlink_bridge")
+
+# ── intents (abstract MAVLink messages) ──────────────────────────────────────
+
+
+@dataclass
+class MavIntent:
+    """One MAVLink message to emit, described abstractly.
+
+    ``kind`` selects the pymavlink call in ``MavlinkLink._emit``:
+      * ``command_long`` — ``command_long_send`` (``command`` + 7 ``params``);
+      * ``command_int``  — ``command_int_send`` (lat/lon carried as scaled ints);
+      * ``position_target_global`` — ``set_position_target_global_int_send``
+        (the standard GUIDED "fly here").
+    ``command`` is the MAV_CMD *name* (resolved to the numeric enum at send
+    time) so the pure layer never imports pymavlink."""
+
+    kind: str
+    command: str = ""
+    params: list[float] = field(default_factory=list)
+    lat: float | None = None
+    lon: float | None = None
+    alt_m: float | None = None
+    note: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"kind": self.kind}
+        if self.command:
+            d["command"] = self.command
+        if self.params:
+            d["params"] = self.params
+        for k in ("lat", "lon", "alt_m"):
+            if getattr(self, k) is not None:
+                d[k] = getattr(self, k)
+        if self.note:
+            d["note"] = self.note
+        return d
+
+
+def _f(v: Any, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def plan_mavlink(envelope: dict[str, Any]) -> list[MavIntent]:
+    """Translate a ``drone.command`` envelope into MAVLink intents. Pure and
+    total — an unknown command yields a single ``unsupported`` intent rather
+    than raising, so the bridge always answers."""
+    command = str(envelope.get("command") or "").lower()
+    wp = envelope.get("waypoint") or {}
+    lat = _f(wp.get("lat")) if "lat" in wp else None
+    lon = _f(wp.get("lon")) if "lon" in wp else None
+    alt = (
+        _f(wp.get("alt_m"))
+        if "alt_m" in wp
+        else _f(envelope.get("alt_m"))
+        if "alt_m" in envelope
+        else None
+    )
+    params = envelope.get("params") or {}
+    speed = _f(params.get("speed_ms")) if "speed_ms" in params else None
+    radius = _f(params.get("radius_m")) if "radius_m" in params else None
+
+    if command == "arm":
+        return [MavIntent("command_long", "MAV_CMD_COMPONENT_ARM_DISARM", [1, 0, 0, 0, 0, 0, 0])]
+    if command == "disarm":
+        return [MavIntent("command_long", "MAV_CMD_COMPONENT_ARM_DISARM", [0, 0, 0, 0, 0, 0, 0])]
+    if command == "takeoff":
+        return [
+            MavIntent(
+                "command_long", "MAV_CMD_NAV_TAKEOFF", [0, 0, 0, 0, 0, 0, alt or 0.0], alt_m=alt
+            )
+        ]
+    if command == "land":
+        return [MavIntent("command_long", "MAV_CMD_NAV_LAND", [0, 0, 0, 0, 0, 0, 0])]
+    if command == "rtl":
+        return [MavIntent("command_long", "MAV_CMD_NAV_RETURN_TO_LAUNCH", [0, 0, 0, 0, 0, 0, 0])]
+    if command == "pause":
+        return [MavIntent("command_long", "MAV_CMD_DO_PAUSE_CONTINUE", [0, 0, 0, 0, 0, 0, 0])]
+    if command == "goto":
+        if lat is None or lon is None:
+            return [MavIntent("unsupported", note="goto requires a waypoint lat/lon")]
+        return [
+            MavIntent(
+                "position_target_global", lat=lat, lon=lon, alt_m=alt if alt is not None else 30.0
+            )
+        ]
+    if command == "orbit":
+        if lat is None or lon is None:
+            return [MavIntent("unsupported", note="orbit requires a waypoint lat/lon")]
+        return [
+            MavIntent(
+                "command_int",
+                "MAV_CMD_DO_ORBIT",
+                [radius or 50.0, speed or 0.0, 0, 0, 0, 0, alt if alt is not None else 30.0],
+                lat=lat,
+                lon=lon,
+                alt_m=alt if alt is not None else 30.0,
+            )
+        ]
+    if command == "follow":
+        return [MavIntent("unsupported", note="follow is autopilot-specific; not mapped")]
+    return [MavIntent("unsupported", note=f"unknown command {command!r}")]
+
+
+# ── the link (lazy pymavlink; log-only fallback) ─────────────────────────────
+
+
+class MavlinkLink:
+    """Sends intents over a MAVLink connection, or logs them when no vehicle /
+    pymavlink is available. One connection, reused; target system defaults to 1
+    (overridable per envelope with a numeric ``vehicle``)."""
+
+    def __init__(self, connect: str = "") -> None:
+        self.connect = (connect or "").strip()
+        self._master: Any = None
+        self._mavutil: Any = None
+        self._error: str | None = None
+
+    @property
+    def mode(self) -> str:
+        return "mavlink" if self.connect else "log-only"
+
+    @property
+    def connected(self) -> bool:
+        return self._master is not None
+
+    def _ensure(self) -> bool:
+        """Lazily import pymavlink + open the link. Returns False (staying
+        log-only) if either is unavailable — never raises into a request."""
+        if not self.connect:
+            return False
+        if self._master is not None:
+            return True
+        try:
+            from pymavlink import (
+                mavutil,  # noqa: PLC0415 — optional dep, imported on first real send
+            )
+        except Exception as exc:  # noqa: BLE001 — pymavlink not installed → log-only
+            self._error = f"pymavlink unavailable: {exc}"
+            log.warning("MAVLink bridge %s — running log-only", self._error)
+            return False
+        try:
+            self._mavutil = mavutil
+            self._master = mavutil.mavlink_connection(self.connect)
+            self._master.wait_heartbeat(timeout=10)
+            log.info("MAVLink bridge connected on %s", self.connect)
+            return True
+        except Exception as exc:  # noqa: BLE001 — bad endpoint / no heartbeat → log-only
+            self._error = f"connect failed: {exc}"
+            self._master = None
+            log.warning("MAVLink bridge %s — running log-only", self._error)
+            return False
+
+    def _emit(self, intent: MavIntent, target_system: int) -> dict[str, Any]:
+        m = self._master
+        mav = self._mavutil.mavlink
+        cmd = getattr(mav, intent.command, None) if intent.command else None
+        if intent.kind == "position_target_global":
+            # type_mask 0b0000_1111_1111_1000 = position only (ignore vel/acc/yaw)
+            m.mav.set_position_target_global_int_send(
+                0,
+                target_system,
+                0,
+                mav.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+                0b0000111111111000,
+                int((intent.lat or 0) * 1e7),
+                int((intent.lon or 0) * 1e7),
+                intent.alt_m or 0.0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            )
+        elif intent.kind == "command_int":
+            m.mav.command_int_send(
+                target_system,
+                0,
+                mav.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
+                cmd,
+                0,
+                0,
+                intent.params[0] if intent.params else 0,
+                intent.params[1] if len(intent.params) > 1 else 0,
+                intent.params[2] if len(intent.params) > 2 else 0,
+                intent.params[3] if len(intent.params) > 3 else 0,
+                int((intent.lat or 0) * 1e7),
+                int((intent.lon or 0) * 1e7),
+                intent.alt_m or 0.0,
+            )
+        else:  # command_long
+            p = (intent.params + [0.0] * 7)[:7]
+            m.mav.command_long_send(target_system, 0, cmd, 0, *p)
+        return {"sent": True, **intent.to_json()}
+
+    def send(self, envelope: dict[str, Any]) -> dict[str, Any]:
+        """Plan + emit. Always returns a result dict (never raises); on any
+        transport error the intent is reported ``sent: False`` with the error."""
+        intents = plan_mavlink(envelope)
+        target = 1
+        veh = envelope.get("vehicle")
+        if isinstance(veh, str) and veh.isdigit():
+            target = int(veh)
+        live = self._ensure()
+        planned = [i.to_json() for i in intents]
+        if not live:
+            return {
+                "mode": "log-only",
+                "sent": False,
+                "planned": planned,
+                **({"error": self._error} if self._error else {}),
+            }
+        results = []
+        for intent in intents:
+            if intent.kind == "unsupported":
+                results.append({"sent": False, **intent.to_json()})
+                continue
+            try:
+                results.append(self._emit(intent, target))
+            except Exception as exc:  # noqa: BLE001 — one bad send doesn't crash the bridge
+                results.append({"sent": False, "error": str(exc), **intent.to_json()})
+        return {"mode": "mavlink", "target_system": target, "results": results}
+
+
+# ── HTTP server ──────────────────────────────────────────────────────────────
+
+
+class _State:
+    def __init__(self, link: MavlinkLink, token: str) -> None:
+        self.link = link
+        self.token = token
+        self.log: deque[dict[str, Any]] = deque(maxlen=200)
+        self.count = 0
+
+
+def _handle_command(state: _State, body: dict[str, Any]) -> dict[str, Any]:
+    """Dispatch one envelope. drone.command → MAVLink; device.command / webhook
+    are accepted and logged (this bridge actuates drones; a device/relay needs a
+    device controller, but we 200 so a mixed workflow doesn't error)."""
+    kind = str(body.get("type") or "")
+    state.count += 1
+    if kind == "drone.command":
+        result = state.link.send(body)
+        entry = {"command": body.get("command"), "vehicle": body.get("vehicle"), "result": result}
+        state.log.appendleft(entry)
+        return {"ok": True, "accepted": True, **result}
+    if kind == "device.command":
+        state.log.appendleft({"device": body.get("device"), "command": body.get("command")})
+        log.info("device.command logged (no device controller): %s", body.get("command"))
+        return {
+            "ok": True,
+            "accepted": True,
+            "mode": "log-only",
+            "note": "device commands are logged only",
+        }
+    state.log.appendleft({"webhook": kind or "unknown", "count": body.get("count")})
+    return {"ok": True, "accepted": True, "mode": "log-only"}
+
+
+def make_handler(state: _State) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _send(self, code: int, payload: dict[str, Any]) -> None:
+            data = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _authed(self) -> bool:
+            if not state.token:
+                return True
+            return self.headers.get("Authorization", "") == f"Bearer {state.token}"
+
+        def do_GET(self) -> None:  # noqa: N802 — stdlib handler name
+            if self.path.startswith("/health"):
+                self._send(
+                    200,
+                    {
+                        "ok": True,
+                        "mode": state.link.mode,
+                        "connected": state.link.connected,
+                        "commands": state.count,
+                    },
+                )
+            elif self.path.startswith("/status"):
+                if not self._authed():
+                    self._send(401, {"ok": False, "error": "unauthorized"})
+                    return
+                self._send(
+                    200,
+                    {
+                        "ok": True,
+                        "mode": state.link.mode,
+                        "commands": state.count,
+                        "recent": list(state.log)[:50],
+                    },
+                )
+            else:
+                self._send(404, {"ok": False, "error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802 — stdlib handler name
+            if not self._authed():
+                self._send(401, {"ok": False, "error": "unauthorized"})
+                return
+            try:
+                n = int(self.headers.get("content-length", 0) or 0)
+                body = json.loads(self.rfile.read(n) or b"{}")
+            except (ValueError, json.JSONDecodeError) as exc:
+                self._send(400, {"ok": False, "error": f"bad json: {exc}"})
+                return
+            if not isinstance(body, dict):
+                self._send(400, {"ok": False, "error": "body must be a JSON object"})
+                return
+            try:
+                self._send(200, _handle_command(state, body))
+            except Exception as exc:  # noqa: BLE001 — a bad envelope never 500s the bridge
+                log.exception("bridge command failed")
+                self._send(200, {"ok": False, "error": str(exc)})
+
+        def log_message(self, *_a: Any) -> None:  # silence default stderr spam
+            pass
+
+    return Handler
+
+
+def build_server(port: int, connect: str = "", token: str = "") -> ThreadingHTTPServer:
+    state = _State(MavlinkLink(connect), token)
+    server = ThreadingHTTPServer(("127.0.0.1", port), make_handler(state))
+    server.bridge_state = state  # type: ignore[attr-defined] — exposed for tests
+    return server
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    port = int(os.environ.get("PORT", "9010"))
+    connect = os.environ.get("MAVLINK_CONNECT", "")
+    token = os.environ.get("MAVLINK_BRIDGE_TOKEN", "")
+    server = build_server(port, connect, token)
+    log.info(
+        "MAVLink bridge on http://127.0.0.1:%d (mode=%s, connect=%r)",
+        port,
+        server.bridge_state.link.mode,
+        connect,
+    )  # type: ignore[attr-defined]
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/app/mavlink_sidecar.py
+++ b/apps/api/app/mavlink_sidecar.py
@@ -1,0 +1,123 @@
+"""Lifespan-managed MAVLink bridge sidecar.
+
+Spawns ``python -m app.mavlink_bridge`` as a separate process (the drone control
+server the Workflows ``control.drone`` block talks to). A separate process, not
+an in-process router, because a MAVLink link is an optional heavy dependency and
+a hung serial/UDP read must never block the API event loop — the same isolation
+reason the AIS/ADS-B feeders are sidecars.
+
+OFF by default (``mavlink_bridge_enabled``): a bridge that auto-connects to a
+vehicle at boot is not something to enable implicitly. When on, it binds
+``mavlink_bridge_port`` on localhost; point ``control.drone.server_url`` at it.
+Best-effort and idempotent like the AIS sidecar: a reused healthy instance is
+adopted; failures log and the backend still serves. Never raises into lifespan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+
+import httpx
+
+from .config import get_settings
+
+log = logging.getLogger("mavlink_sidecar")
+
+# apps/api (this file is apps/api/app/mavlink_sidecar.py) — the cwd the bridge
+# child runs in so `-m app.mavlink_bridge` resolves. Computed once at import.
+_APP_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class _Bridge:
+    def __init__(self) -> None:
+        s = get_settings()
+        self.port = s.mavlink_bridge_port
+        self.connect = s.mavlink_bridge_connect
+        self.base = f"http://127.0.0.1:{self.port}"
+        self.health = f"{self.base}/health"
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reuse = False
+
+    async def _already_healthy(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as c:
+                return (await c.get(self.health)).status_code == 200
+        except Exception:  # noqa: BLE001 — nothing on the port
+            return False
+
+    async def start(self) -> None:
+        if await self._already_healthy():
+            self._reuse = True
+            log.info("mavlink bridge already up on %s — reusing", self.base)
+            return
+        env = {
+            **os.environ,
+            "PORT": str(self.port),
+            "MAVLINK_CONNECT": self.connect,
+        }
+        # Same jemalloc-scrub as the browser sidecars: a forked child must not
+        # inherit run-api.sh's LD_PRELOAD / MALLOC_CONF.
+        env.pop("LD_PRELOAD", None)
+        env.pop("MALLOC_CONF", None)
+        log_path = "/tmp/mavlink-bridge.log"
+        try:
+            log_file = open(log_path, "ab", buffering=0)  # noqa: SIM115,ASYNC230 — one-shot child log
+        except Exception:  # noqa: BLE001 — log file optional
+            log_file = None  # type: ignore[assignment]
+        # sys.executable = the same venv python running the API (pymavlink, if
+        # installed, lives here); cwd=_APP_DIR so `-m app.mavlink_bridge` resolves.
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                sys.executable, "-m", "app.mavlink_bridge",
+                cwd=_APP_DIR, env=env, stdout=log_file, stderr=log_file,
+                start_new_session=True,
+            )
+        except FileNotFoundError:
+            log.warning("python not found — mavlink bridge disabled")
+            return
+        await asyncio.sleep(0.6)
+        if self._proc.returncode is not None:
+            log.warning("mavlink bridge exited early (code %s) — see %s",
+                        self._proc.returncode, log_path)
+            self._proc = None
+            return
+        log.info("mavlink bridge spawned on %s (connect=%r)", self.base, self.connect or "log-only")
+
+    async def stop(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None or proc.returncode is not None:
+            return
+        try:
+            os.kill(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=4.0)
+        except (TimeoutError, Exception):  # noqa: BLE001 — escalate
+            try:
+                os.kill(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+_BRIDGE: _Bridge | None = None
+
+
+async def start() -> None:
+    """Spawn the bridge if enabled. Best-effort; never raises."""
+    global _BRIDGE
+    if not get_settings().mavlink_bridge_enabled:
+        return
+    _BRIDGE = _Bridge()
+    await _BRIDGE.start()
+
+
+async def stop() -> None:
+    global _BRIDGE
+    if _BRIDGE is not None:
+        await _BRIDGE.stop()
+        _BRIDGE = None

--- a/apps/api/app/workflows/blocks.py
+++ b/apps/api/app/workflows/blocks.py
@@ -6,11 +6,16 @@ that returns the block's output rows. ``engine.py`` resolves the DAG and calls
 these; no block ever raises un-caught into the API layer — a raised exception
 here fails the RUN (status="failed"), never the HTTP request.
 
-Catalog (16 blocks — see the skip note below for the 17th):
+Catalog (20 blocks — see the skip note below for the country op):
   Sources (0 inputs): aircraft, vessels, countries, dataset, ontology, alerts,
     quakes.
-  Ops (1-2 inputs): steps (foundry DSL), geo, python, sql, llm.
+  Ops (0-2 inputs): http (external request), steps (foundry DSL), geo, python,
+    sql, llm.
   Sinks (1 input, pass rows through): alert, ontology, dataset, memory.
+  Control (1 input, act on EXTERNAL systems; rows pass through annotated):
+    webhook, drone, device — outbound to an operator-run server. Plumbing +
+    safety model in ``control.py``; wire contract in
+    ``docs/workflows-control-blocks.md``.
 
 SKIPPED (named, not faked): ``op.country`` (point → ISO country via catalog
 polygons/bboxes) from the plan's block list. Verified against source
@@ -44,7 +49,7 @@ from app.foundry.store import FoundryError, FoundryStore
 from app.intel.ontology import _KNOWN_KINDS, Object, get_registry
 from app.intel.ontology_local import _connect as _ontology_connect
 from app.keys import UserCtx
-from app.workflows import python_exec
+from app.workflows import control, python_exec
 from app.workflows.store import WorkflowError
 
 Row = dict[str, Any]
@@ -54,6 +59,11 @@ Row = dict[str, Any]
 PREVIEW_SOURCE_CAP = 500
 ROW_CAP_PER_BLOCK = 200_000
 MAX_ALERTS_PER_RUN = 20
+# Workflow-wide cap on OUTBOUND control dispatches (op.http requests +
+# control.* commands) per run, shared across every control block — a runaway
+# per_row loop over 200k rows can never fire 200k requests at the operator's
+# server / vehicle. A single block additionally caps itself via `max_dispatch`.
+MAX_DISPATCHES_PER_RUN = 200
 _LLM_ROWS_CAP = 100
 _LLM_BYTES_CAP = 20_000
 _LLM_PER_ROW_CAP = 50
@@ -79,6 +89,7 @@ class BlockCtx:
     memory: dict[str, Any]
     preview: bool = False
     alert_budget: list[int] = field(default_factory=lambda: [MAX_ALERTS_PER_RUN])
+    dispatch_budget: list[int] = field(default_factory=lambda: [MAX_DISPATCHES_PER_RUN])
 
     def get_memory(self, key: str, default: Any = None) -> Any:
         return self.memory.get(key, default)
@@ -395,7 +406,9 @@ _register(
         max_inputs=0,
         config_schema=[
             ConfigField(
-                "bbox", "string", "Bounding box (optional)",
+                "bbox",
+                "string",
+                "Bounding box (optional)",
                 placeholder="min_lon,min_lat,max_lon,max_lat",
                 help="Leave empty for the full global snapshot.",
             ),
@@ -413,7 +426,9 @@ _register(
         max_inputs=0,
         config_schema=[
             ConfigField(
-                "bbox", "string", "Bounding box (optional)",
+                "bbox",
+                "string",
+                "Bounding box (optional)",
                 placeholder="min_lon,min_lat,max_lon,max_lat",
             ),
         ],
@@ -459,7 +474,10 @@ _register(
         max_inputs=0,
         config_schema=[
             ConfigField(
-                "kind", "select", "Object kind", required=True,
+                "kind",
+                "select",
+                "Object kind",
+                required=True,
                 options=sorted(_KNOWN_KINDS),
             ),
             ConfigField("limit", "int", "Limit", default=1000),
@@ -491,7 +509,10 @@ _register(
         max_inputs=0,
         config_schema=[
             ConfigField(
-                "range", "select", "Range", default="day",
+                "range",
+                "select",
+                "Range",
+                default="day",
                 options=["hour", "day", "week", "month"],
             ),
         ],
@@ -539,9 +560,7 @@ async def _run_op_steps(
     return rows[:ROW_CAP_PER_BLOCK]
 
 
-async def _run_op_geo(
-    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
-) -> list[Row]:
+async def _run_op_geo(config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx) -> list[Row]:
     """Geo filter/join. mode=within_bbox|within_radius|near_join."""
     mode = config.get("mode") or "within_bbox"
     lat_col = config.get("lat_col") or "lat"
@@ -618,9 +637,7 @@ async def _run_op_python(
     return out_rows[:ROW_CAP_PER_BLOCK]
 
 
-async def _run_op_sql(
-    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
-) -> list[Row]:
+async def _run_op_sql(config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx) -> list[Row]:
     query = config.get("query") or ""
     if not isinstance(query, str) or not query.strip():
         raise WorkflowError(422, "op.sql requires non-empty 'query'")
@@ -644,9 +661,7 @@ def _render_template(template: str, rows: list[Row], memory: dict[str, Any]) -> 
     return template.replace("{rows}", payload).replace("{memory}", mem_payload)
 
 
-async def _run_op_llm(
-    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
-) -> list[Row]:
+async def _run_op_llm(config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx) -> list[Row]:
     from app import (
         llm,  # noqa: PLC0415 — imported lazily so tests can monkeypatch app.workflows.blocks.llm
     )
@@ -696,6 +711,196 @@ async def _run_op_llm(
     return [{"result": result}]
 
 
+def _parse_json_config(raw: Any, what: str) -> Any:
+    """A ``json``-typed config field arrives as a string from the editor (or a
+    real value from a saved spec). Parse leniently; empty → None."""
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise WorkflowError(422, f"{what} is not valid JSON: {exc}") from exc
+
+
+def _drill(data: Any, path: str) -> Any:
+    """Follow a dotted ``json_path`` (``result.items``) into a parsed body.
+    A missing key yields None rather than raising — a shape mismatch degrades
+    to an empty result set, consistent with the source blocks."""
+    cur = data
+    for part in (p for p in path.split(".") if p):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            return None
+    return cur
+
+
+def _http_body_to_rows(result: dict[str, Any], response: str, json_path: str) -> list[Row]:
+    if result.get("dry_run"):
+        return [{k: v for k, v in result.items() if k != "json"}]
+    if response == "status":
+        return [{"status": result.get("status"), "ok": result.get("ok")}]
+    if response == "text":
+        return [{"status": result.get("status"), "text": (result.get("text") or "")[:20_000]}]
+    # response == "json"
+    data = result.get("json")
+    if json_path:
+        data = _drill(data, json_path)
+    if isinstance(data, list):
+        return [d if isinstance(d, dict) else {"value": d} for d in data]
+    if isinstance(data, dict):
+        return [data]
+    if data is None:
+        return []
+    return [{"value": data}]
+
+
+async def _run_op_http(config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx) -> list[Row]:
+    """HTTP request to an external server — the universal in/out primitive.
+
+    ``once`` (default): one request; the response becomes this block's rows
+    (``json`` list → one row each, ``json`` object → one row, ``text``/``status``
+    → a single descriptor row). ``per_row``: one request per input row, capped
+    by ``max_requests`` and the run-wide dispatch budget, each response
+    normalized under ``_http`` on the row it fired for.
+
+    Read-only methods (GET/HEAD) run during preview; unsafe methods
+    (POST/PUT/…) dry-run on preview so authoring never mutates an external
+    system. All requests honor ``WORKFLOWS_HTTP_ALLOW_HOSTS`` if set."""
+    method = (config.get("method") or "GET").upper()
+    url_tmpl = (config.get("url") or "").strip()
+    if not url_tmpl:
+        raise WorkflowError(422, "op.http requires 'url'")
+    headers = _parse_json_config(config.get("headers"), "op.http headers") or {}
+    if not isinstance(headers, dict):
+        raise WorkflowError(422, "op.http 'headers' must be a JSON object")
+    headers = {str(k): str(v) for k, v in headers.items()}
+    headers.update(control.auth_headers(config.get("auth_env") or ""))
+    body_tmpl = config.get("body") or ""
+    mode = config.get("mode") or "once"
+    response = config.get("response") or "json"
+    json_path = (config.get("json_path") or "").strip()
+    timeout_s = float(config.get("timeout_s") or 15.0)
+    max_requests = int(config.get("max_requests") or 25)
+    rows = inputs[0] if inputs else []
+
+    def _body(raw: str) -> Any:
+        raw = raw.strip()
+        return _parse_json_config(raw, "op.http body") if raw else None
+
+    if mode == "per_row":
+        out: list[Row] = []
+        for r in rows[:max_requests]:
+            url = _template_row(url_tmpl, r)
+            body = _body(_template_row(body_tmpl, r)) if body_tmpl else None
+            result = await control.request(
+                method,
+                url,
+                headers=headers,
+                json_body=body,
+                budget=ctx.dispatch_budget,
+                preview=ctx.preview,
+                timeout_s=timeout_s,
+            )
+            out.append({**r, "_http": {k: v for k, v in result.items() if k != "text"}})
+        return out[:ROW_CAP_PER_BLOCK]
+
+    # once
+    first = rows[0] if rows else {}
+    url = _template_row(_render_template(url_tmpl, rows, ctx.memory), first)
+    body = (
+        _body(_template_row(_render_template(body_tmpl, rows, ctx.memory), first))
+        if body_tmpl
+        else None
+    )
+    result = await control.request(
+        method,
+        url,
+        headers=headers,
+        json_body=body,
+        budget=ctx.dispatch_budget,
+        preview=ctx.preview,
+        timeout_s=timeout_s,
+    )
+    return _http_body_to_rows(result, response, json_path)[:ROW_CAP_PER_BLOCK]
+
+
+_register(
+    BlockSpec(
+        type="op.http",
+        category="op",
+        title="HTTP request",
+        description=(
+            "Call an external HTTP(S) server: once (response → rows) or per_row"
+            " (one request/row, merged under _http). GET/HEAD preview live;"
+            " writes dry-run on preview."
+        ),
+        min_inputs=0,
+        max_inputs=1,
+        config_schema=[
+            ConfigField(
+                "method",
+                "select",
+                "Method",
+                default="GET",
+                options=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
+            ),
+            ConfigField(
+                "url",
+                "string",
+                "URL",
+                required=True,
+                placeholder="https://host/path/{icao24}",
+                help="Supports {column} (per_row / first row) and {rows} (once).",
+            ),
+            ConfigField(
+                "mode",
+                "select",
+                "Mode",
+                default="once",
+                options=["once", "per_row"],
+            ),
+            ConfigField(
+                "headers",
+                "json",
+                "Headers (JSON object, optional)",
+                placeholder='{"X-Api-Key": "..."}',
+            ),
+            ConfigField(
+                "body",
+                "text",
+                "Body template (optional)",
+                help="Rendered like url; sent as JSON. Leave empty for GET.",
+            ),
+            ConfigField(
+                "response",
+                "select",
+                "Response as",
+                default="json",
+                options=["json", "text", "status"],
+            ),
+            ConfigField(
+                "json_path",
+                "string",
+                "JSON path (optional)",
+                placeholder="result.items",
+                help="Dotted path to the array/object inside a json response.",
+            ),
+            ConfigField(
+                "auth_env",
+                "string",
+                "Bearer-token env var (optional)",
+                placeholder="MY_SERVER_TOKEN",
+                help="Env var name holding a token → Authorization: Bearer. Not stored in spec.",
+            ),
+            ConfigField("timeout_s", "int", "Timeout (s)", default=15),
+            ConfigField("max_requests", "int", "Max requests (per_row)", default=25),
+        ],
+        run=_run_op_http,
+    )
+)
 _register(
     BlockSpec(
         type="op.steps",
@@ -709,9 +914,12 @@ _register(
         max_inputs=2,
         config_schema=[
             ConfigField(
-                "steps", "json", "Steps (JSON list)", required=True,
+                "steps",
+                "json",
+                "Steps (JSON list)",
+                required=True,
                 help='e.g. [{"type":"filter","expr":"alt_m > 3000"}]. A second input\'s'
-                " rows are reachable from a join/union step via \"right\": \"input2\".",
+                ' rows are reachable from a join/union step via "right": "input2".',
             ),
         ],
         run=_run_op_steps,
@@ -727,13 +935,19 @@ _register(
         max_inputs=2,
         config_schema=[
             ConfigField(
-                "mode", "select", "Mode", required=True, default="within_bbox",
+                "mode",
+                "select",
+                "Mode",
+                required=True,
+                default="within_bbox",
                 options=["within_bbox", "within_radius", "near_join"],
             ),
             ConfigField("lat_col", "string", "Latitude column", default="lat"),
             ConfigField("lon_col", "string", "Longitude column", default="lon"),
             ConfigField(
-                "bbox", "string", "Bounding box (within_bbox)",
+                "bbox",
+                "string",
+                "Bounding box (within_bbox)",
                 placeholder="min_lon,min_lat,max_lon,max_lat",
             ),
             ConfigField("center_lat", "float", "Center latitude (within_radius)"),
@@ -756,7 +970,10 @@ _register(
         max_inputs=1,
         config_schema=[
             ConfigField(
-                "code", "text", "Python code", required=True,
+                "code",
+                "text",
+                "Python code",
+                required=True,
                 help="Must define run(rows: list[dict], memory: dict) -> list[dict]"
                 " | {'rows': [...], 'memory': {...}}. Runs in a resource-limited"
                 " subprocess on your own machine (BYO-compute, not a hostile-tenant sandbox).",
@@ -776,7 +993,11 @@ _register(
         max_inputs=2,
         config_schema=[
             ConfigField(
-                "query", "text", "SQL query", required=True, placeholder="SELECT * FROM t LIMIT 50",
+                "query",
+                "text",
+                "SQL query",
+                required=True,
+                placeholder="SELECT * FROM t LIMIT 50",
             ),
         ],
         run=_run_op_sql,
@@ -796,11 +1017,18 @@ _register(
             ConfigField("tier", "select", "Tier", default="fast", options=["fast", "reason"]),
             ConfigField("system", "text", "System prompt"),
             ConfigField(
-                "prompt", "text", "Prompt template", required=True,
+                "prompt",
+                "text",
+                "Prompt template",
+                required=True,
                 help="Use {rows} (JSON, capped 100 rows/20KB) and {memory}.",
             ),
             ConfigField(
-                "mode", "select", "Mode", default="per_batch", options=["per_batch", "per_row"],
+                "mode",
+                "select",
+                "Mode",
+                default="per_batch",
+                options=["per_batch", "per_row"],
             ),
             ConfigField("json_mode", "bool", "Parse reply as JSON", default=True),
         ],
@@ -955,14 +1183,23 @@ _register(
         max_inputs=1,
         config_schema=[
             ConfigField(
-                "mode", "select", "Mode", default="summary", options=["summary", "per_row"],
+                "mode",
+                "select",
+                "Mode",
+                default="summary",
+                options=["summary", "per_row"],
             ),
             ConfigField(
-                "severity", "select", "Severity", default="info",
+                "severity",
+                "select",
+                "Severity",
+                default="info",
                 options=["info", "low", "medium", "high", "critical"],
             ),
             ConfigField(
-                "message_template", "string", "Message template",
+                "message_template",
+                "string",
+                "Message template",
                 help="summary: {count}. per_row: {col_name} for any input column.",
             ),
         ],
@@ -979,11 +1216,17 @@ _register(
         max_inputs=1,
         config_schema=[
             ConfigField(
-                "object_kind", "select", "Object kind", required=True, options=sorted(_KNOWN_KINDS),
+                "object_kind",
+                "select",
+                "Object kind",
+                required=True,
+                options=sorted(_KNOWN_KINDS),
             ),
             ConfigField("key_column", "string", "Key column", required=True),
             ConfigField(
-                "prop_columns", "string", "Prop columns (comma-separated, optional)",
+                "prop_columns",
+                "string",
+                "Prop columns (comma-separated, optional)",
                 help="Empty = every column becomes a prop.",
             ),
         ],
@@ -1016,6 +1259,324 @@ _register(
             ConfigField("key", "string", "Memory key", required=True),
         ],
         run=_run_sink_memory,
+    )
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Control (1 input, act on EXTERNAL systems; rows pass through annotated)
+#
+# These blocks reach OUT to an operator-run server (a webhook receiver, a drone
+# ground-control bridge, a device controller). Shared plumbing + the safety
+# model (preview dry-run, run-wide dispatch budget, host allowlist, env auth,
+# kill-switch) live in ``app/workflows/control.py``; the wire contract each
+# server must accept is ``docs/workflows-control-blocks.md``.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _dispatch_targets(rows: list[Row], mode: str, max_dispatch: int) -> list[int]:
+    """Indices of the rows a control block will actuate on. ``first`` → just
+    the first row (send ONE command to the best/nearest target); ``per_row`` →
+    every row up to ``max_dispatch``. Non-target rows pass through untouched."""
+    if mode == "first":
+        return [0] if rows else []
+    return list(range(min(len(rows), max(0, max_dispatch))))
+
+
+async def _run_control_webhook(
+    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
+) -> list[Row]:
+    """POST rows to an external URL — ``batch`` (one POST of all rows) or
+    ``per_row`` (one POST per row). The generic "tell my server something
+    happened" sink."""
+    rows = inputs[0] if inputs else []
+    url = (config.get("url") or "").strip()
+    if not url:
+        raise WorkflowError(422, "control.webhook requires 'url'")
+    mode = config.get("mode") or "batch"
+    auth_env = config.get("auth_env") or ""
+    timeout_s = float(config.get("timeout_s") or 10.0)
+    max_dispatch = int(config.get("max_dispatch") or 25)
+    source = f"workflow:{ctx.workflow_id}"
+
+    if mode == "per_row":
+        out: list[Row] = []
+        for i, r in enumerate(rows):
+            if i >= max_dispatch:
+                out.append(r)
+                continue
+            env = {"type": "workflow.row", "source": source, "row": r}
+            res = await control.dispatch(
+                url,
+                env,
+                budget=ctx.dispatch_budget,
+                preview=ctx.preview,
+                auth_env=auth_env,
+                timeout_s=timeout_s,
+            )
+            out.append({**r, "_webhook": {k: v for k, v in res.items() if k != "request"}})
+        return out
+
+    env = {
+        "type": "workflow.webhook",
+        "source": source,
+        "count": len(rows),
+        "rows": rows[:_LLM_ROWS_CAP],
+    }
+    res = await control.dispatch(
+        url,
+        env,
+        budget=ctx.dispatch_budget,
+        preview=ctx.preview,
+        auth_env=auth_env,
+        timeout_s=timeout_s,
+    )
+    ctx.set_memory("_webhook_last", {k: v for k, v in res.items() if k != "request"})
+    return rows
+
+
+async def _run_control_drone(
+    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
+) -> list[Row]:
+    """Command a drone / UAV through the operator's ground-control server.
+
+    Auto-navigation: wire a source (aircraft, vessels, detections…) → filter/
+    nearest → this block with ``command=goto`` and the vehicle flies to each
+    row's lat/lon. Commands without a waypoint (takeoff/land/rtl/arm/disarm/
+    pause) ignore the coordinate columns. ``first`` sends one command to the
+    top row; ``per_row`` commands each (a simple swarm/patrol fan-out), capped
+    by ``max_dispatch`` and the run-wide budget."""
+    rows = inputs[0] if inputs else []
+    server_url = (config.get("server_url") or "").strip()
+    if not server_url:
+        raise WorkflowError(422, "control.drone requires 'server_url'")
+    command = (config.get("command") or "goto").strip()
+    if command not in control.DRONE_COMMANDS:
+        raise WorkflowError(
+            422,
+            f"control.drone: unknown command {command!r}"
+            f" (allowed: {', '.join(control.DRONE_COMMANDS)})",
+        )
+    url = server_url.rstrip("/") + (config.get("path") or "/command")
+    vehicle_col = (config.get("vehicle_col") or "").strip()
+    default_vehicle = (config.get("vehicle_id") or "drone-1").strip()
+    lat_col = config.get("lat_col") or "lat"
+    lon_col = config.get("lon_col") or "lon"
+    alt_col = config.get("alt_col") or "alt_m"
+    speed_ms = _num(config.get("speed_ms"))
+    radius_m = _num(config.get("radius_m"))
+    mode = config.get("mode") or "first"
+    max_dispatch = int(config.get("max_dispatch") or 10)
+    auth_env = config.get("auth_env") or ""
+    timeout_s = float(config.get("timeout_s") or 10.0)
+    source = f"workflow:{ctx.workflow_id}"
+
+    targets = set(_dispatch_targets(rows, mode, max_dispatch))
+    out: list[Row] = []
+    for i, r in enumerate(rows):
+        if i not in targets:
+            out.append(r)
+            continue
+        vehicle = str(
+            r.get(vehicle_col)
+            if vehicle_col and r.get(vehicle_col) is not None
+            else default_vehicle
+        )
+        env = control.drone_envelope(
+            command,
+            vehicle=vehicle,
+            lat=_num(r.get(lat_col)),
+            lon=_num(r.get(lon_col)),
+            alt_m=_num(r.get(alt_col)),
+            speed_ms=speed_ms,
+            radius_m=radius_m,
+            source=source,
+        )
+        res = await control.dispatch(
+            url,
+            env,
+            budget=ctx.dispatch_budget,
+            preview=ctx.preview,
+            auth_env=auth_env,
+            timeout_s=timeout_s,
+        )
+        out.append({**r, "_drone": res})
+    return out
+
+
+async def _run_control_device(
+    config: dict[str, Any], inputs: list[list[Row]], ctx: BlockCtx
+) -> list[Row]:
+    """Command any controllable item (relay, gimbal, PTZ camera, rover, siren…)
+    behind the operator's control server. ``command`` names the action; the
+    payload is either the named columns (``payload_columns``) or the whole row
+    minus internal ``_``-prefixed keys."""
+    rows = inputs[0] if inputs else []
+    server_url = (config.get("server_url") or "").strip()
+    if not server_url:
+        raise WorkflowError(422, "control.device requires 'server_url'")
+    command = (config.get("command") or "").strip()
+    if not command:
+        raise WorkflowError(422, "control.device requires 'command'")
+    url = server_url.rstrip("/") + (config.get("path") or "/command")
+    device_col = (config.get("device_col") or "").strip()
+    default_device = (config.get("device_id") or "device-1").strip()
+    payload_cols_raw = (config.get("payload_columns") or "").strip()
+    payload_cols = (
+        [c.strip() for c in payload_cols_raw.split(",") if c.strip()] if payload_cols_raw else None
+    )
+    mode = config.get("mode") or "per_row"
+    max_dispatch = int(config.get("max_dispatch") or 20)
+    auth_env = config.get("auth_env") or ""
+    timeout_s = float(config.get("timeout_s") or 10.0)
+    source = f"workflow:{ctx.workflow_id}"
+
+    targets = set(_dispatch_targets(rows, mode, max_dispatch))
+    out: list[Row] = []
+    for i, r in enumerate(rows):
+        if i not in targets:
+            out.append(r)
+            continue
+        device = str(
+            r.get(device_col) if device_col and r.get(device_col) is not None else default_device
+        )
+        if payload_cols is not None:
+            payload = {c: r.get(c) for c in payload_cols}
+        else:
+            payload = {k: v for k, v in r.items() if not str(k).startswith("_")}
+        env = control.device_envelope(
+            device=device, command=command, payload=payload, source=source
+        )
+        res = await control.dispatch(
+            url,
+            env,
+            budget=ctx.dispatch_budget,
+            preview=ctx.preview,
+            auth_env=auth_env,
+            timeout_s=timeout_s,
+        )
+        out.append({**r, "_device": res})
+    return out
+
+
+_register(
+    BlockSpec(
+        type="control.webhook",
+        category="control",
+        title="Webhook",
+        description="POST rows to an external URL — batch (all rows) or per_row.",
+        min_inputs=1,
+        max_inputs=1,
+        config_schema=[
+            ConfigField("url", "string", "URL", required=True, placeholder="https://host/hook"),
+            ConfigField("mode", "select", "Mode", default="batch", options=["batch", "per_row"]),
+            ConfigField(
+                "auth_env",
+                "string",
+                "Bearer-token env var (optional)",
+                placeholder="MY_HOOK_TOKEN",
+                help="Env var name → Authorization: Bearer. Never stored in the spec.",
+            ),
+            ConfigField("timeout_s", "int", "Timeout (s)", default=10),
+            ConfigField("max_dispatch", "int", "Max requests (per_row)", default=25),
+        ],
+        run=_run_control_webhook,
+    )
+)
+_register(
+    BlockSpec(
+        type="control.drone",
+        category="control",
+        title="Drone control",
+        description=(
+            "Command a drone/UAV via your ground-control server: goto (auto-nav to"
+            " each row's lat/lon), takeoff/land/rtl/orbit/follow/arm/disarm/pause."
+        ),
+        min_inputs=1,
+        max_inputs=1,
+        config_schema=[
+            ConfigField(
+                "server_url",
+                "string",
+                "Control server URL",
+                required=True,
+                placeholder="http://127.0.0.1:9010",
+                help="Base URL of YOUR drone bridge. Envelope: docs/workflows-control-blocks.md.",
+            ),
+            ConfigField("path", "string", "Command path", default="/command"),
+            ConfigField(
+                "command",
+                "select",
+                "Command",
+                default="goto",
+                options=list(control.DRONE_COMMANDS),
+            ),
+            ConfigField(
+                "mode",
+                "select",
+                "Dispatch",
+                default="first",
+                options=["first", "per_row"],
+                help="first: one command to the top row. per_row: command each row (swarm/patrol).",
+            ),
+            ConfigField("vehicle_id", "string", "Default vehicle id", default="drone-1"),
+            ConfigField("vehicle_col", "string", "Vehicle-id column (optional)"),
+            ConfigField("lat_col", "string", "Latitude column", default="lat"),
+            ConfigField("lon_col", "string", "Longitude column", default="lon"),
+            ConfigField("alt_col", "string", "Altitude column (m)", default="alt_m"),
+            ConfigField("speed_ms", "float", "Speed m/s (optional)"),
+            ConfigField("radius_m", "float", "Orbit/loiter radius m (optional)"),
+            ConfigField(
+                "auth_env",
+                "string",
+                "Bearer-token env var (optional)",
+                placeholder="DRONE_SERVER_TOKEN",
+            ),
+            ConfigField("timeout_s", "int", "Timeout (s)", default=10),
+            ConfigField("max_dispatch", "int", "Max commands (per_row)", default=10),
+        ],
+        run=_run_control_drone,
+    )
+)
+_register(
+    BlockSpec(
+        type="control.device",
+        category="control",
+        title="Device command",
+        description="Command any controllable item (relay/gimbal/PTZ/rover…) via your server.",
+        min_inputs=1,
+        max_inputs=1,
+        config_schema=[
+            ConfigField(
+                "server_url",
+                "string",
+                "Control server URL",
+                required=True,
+                placeholder="http://127.0.0.1:9010",
+            ),
+            ConfigField("path", "string", "Command path", default="/command"),
+            ConfigField("command", "string", "Command", required=True, placeholder="set_relay"),
+            ConfigField(
+                "mode", "select", "Dispatch", default="per_row", options=["first", "per_row"]
+            ),
+            ConfigField("device_id", "string", "Default device id", default="device-1"),
+            ConfigField("device_col", "string", "Device-id column (optional)"),
+            ConfigField(
+                "payload_columns",
+                "string",
+                "Payload columns (comma-sep, optional)",
+                help="Empty = every non-internal column becomes the payload.",
+            ),
+            ConfigField(
+                "auth_env",
+                "string",
+                "Bearer-token env var (optional)",
+                placeholder="DEVICE_SERVER_TOKEN",
+            ),
+            ConfigField("timeout_s", "int", "Timeout (s)", default=10),
+            ConfigField("max_dispatch", "int", "Max commands (per_row)", default=20),
+        ],
+        run=_run_control_device,
     )
 )
 

--- a/apps/api/app/workflows/control.py
+++ b/apps/api/app/workflows/control.py
@@ -1,0 +1,329 @@
+"""External actuation for the Workflows "control" blocks.
+
+The control-category blocks (``control.webhook``, ``control.drone``,
+``control.device``) and ``op.http`` reach OUT of the platform to an
+operator-run endpoint — a REST API, a webhook receiver, or a drone / robot /
+device control server. This module holds the plumbing they share so no block
+opens a socket itself:
+
+  * an IPv4-pinned ``httpx`` client (same reason as ``upstream.get_client`` —
+    hosts with broken IPv6 egress otherwise hang on AAAA records);
+  * the normalized JSON command **envelope** every control server receives;
+  * the safety guards — dry-run on preview, a per-run dispatch budget, an
+    optional host allowlist, an env-sourced bearer token, an env kill-switch;
+  * ``send`` — the single network call the tests monkeypatch.
+
+Safety posture (mirrors ``op.python``'s BYO-compute note): this is a
+single-operator local tool, not a hostile-tenant sandbox. The guards exist to
+stop a *preview* from launching a drone and to stop a runaway ``per_row`` loop
+from firing hundreds of commands — not to sandbox a malicious spec author. A
+real drone uplink is the operator pointing a block at THEIR OWN control server.
+
+Wire contract (what your control server must accept) is documented in
+``docs/workflows-control-blocks.md``; every envelope is a single JSON object
+POSTed with ``content-type: application/json``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from app.workflows.store import WorkflowError
+
+Row = dict[str, Any]
+
+# Safe (read-only) HTTP methods — allowed to actually execute during a PREVIEW.
+# Anything else (POST/PUT/PATCH/DELETE) is dry-run on preview so authoring a
+# workflow can never mutate an external system or move a vehicle.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+_CLIENT: httpx.AsyncClient | None = None
+
+
+def _client() -> httpx.AsyncClient:
+    """Lazily-built shared async client, IPv4-pinned like ``upstream``.
+
+    A dedicated client (not ``upstream.get_client``) so control traffic carries
+    its own User-Agent and never contends with the feed-poller connection pool.
+    """
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = httpx.AsyncClient(
+            headers={"User-Agent": "osint-console-workflows/0.1"},
+            transport=httpx.AsyncHTTPTransport(local_address="0.0.0.0", retries=0),
+            follow_redirects=True,
+        )
+    return _CLIENT
+
+
+# ── env-driven policy ────────────────────────────────────────────────────────
+
+
+def control_enabled() -> bool:
+    """Master kill-switch. Default ON. Set ``WORKFLOWS_CONTROL_ENABLED=0`` to
+    force every control block into dry-run (envelopes are still built and
+    returned, no network call is made) — a safe way to author/rehearse a
+    control workflow on a box that must never actuate."""
+    return os.getenv("WORKFLOWS_CONTROL_ENABLED", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _allow_hosts() -> set[str] | None:
+    """Optional outbound allowlist. ``WORKFLOWS_HTTP_ALLOW_HOSTS`` =
+    comma-separated hostnames. Unset → any host allowed (BYO posture). Set →
+    only those hosts (exact, case-insensitive) may be reached; everything else
+    raises 403. Localhost is NEVER implicitly blocked — the operator's control
+    server is often on the same box."""
+    raw = os.getenv("WORKFLOWS_HTTP_ALLOW_HOSTS", "").strip()
+    if not raw:
+        return None
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def check_url(url: str) -> None:
+    """Validate scheme (http/https only) and enforce the optional host
+    allowlist. Raises ``WorkflowError`` naming the problem; never returns a
+    value. Called on every request path, dry-run included, so a misconfigured
+    URL surfaces in preview instead of at first live fire."""
+    parts = urlsplit(url.strip())
+    if parts.scheme not in ("http", "https"):
+        raise WorkflowError(422, f"url must be http(s), got {parts.scheme or 'no'} scheme: {url!r}")
+    if not parts.hostname:
+        raise WorkflowError(422, f"url has no host: {url!r}")
+    allow = _allow_hosts()
+    if allow is not None and parts.hostname.lower() not in allow:
+        raise WorkflowError(
+            403,
+            f"host {parts.hostname!r} is not in WORKFLOWS_HTTP_ALLOW_HOSTS "
+            f"({', '.join(sorted(allow))})",
+        )
+
+
+def auth_headers(auth_env: str) -> dict[str, str]:
+    """Read a bearer token from the named env var → ``Authorization`` header.
+    The token is NEVER stored in the workflow spec — only the env var's NAME
+    is. Empty / unset name → no header (public endpoint)."""
+    name = (auth_env or "").strip()
+    if not name:
+        return {}
+    token = os.getenv(name, "").strip()
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── the one network call (monkeypatched in tests) ────────────────────────────
+
+
+@dataclass
+class HttpResult:
+    status: int | None
+    ok: bool
+    json: Any
+    text: str
+    error: str | None
+
+    def summary(self) -> dict[str, Any]:
+        """Compact result for annotating a row / returning from a block."""
+        d: dict[str, Any] = {"status": self.status, "ok": self.ok}
+        if self.error is not None:
+            d["error"] = self.error
+        elif self.json is not None:
+            d["response"] = self.json
+        elif self.text:
+            d["response"] = self.text[:2000]
+        return d
+
+
+async def send(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    json_body: Any = None,
+    timeout_s: float = 15.0,
+) -> HttpResult:
+    """Perform ONE request and normalize the outcome. Never raises — a
+    transport/timeout error becomes ``HttpResult(error=...)`` so a single bad
+    endpoint fails just its row, not the whole run. This is the seam tests
+    replace to assert envelopes without real network."""
+    try:
+        resp = await _client().request(
+            method.upper(),
+            url,
+            headers=headers,
+            json=json_body if json_body is not None else None,
+            timeout=timeout_s,
+        )
+    except httpx.HTTPError as exc:
+        return HttpResult(status=None, ok=False, json=None, text="", error=str(exc))
+    parsed: Any = None
+    ctype = resp.headers.get("content-type", "")
+    if "json" in ctype.lower():
+        try:
+            parsed = resp.json()
+        except (ValueError, httpx.DecodingError):
+            parsed = None
+    return HttpResult(
+        status=resp.status_code,
+        ok=resp.is_success,
+        json=parsed,
+        text=resp.text,
+        error=None,
+    )
+
+
+# ── guarded entry points used by the blocks ──────────────────────────────────
+
+
+async def request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    json_body: Any,
+    budget: list[int],
+    preview: bool,
+    timeout_s: float,
+) -> dict[str, Any]:
+    """``op.http`` path. Validates the URL, dry-runs UNSAFE methods on preview
+    (a GET preview still executes — it is read-only), spends one unit of the
+    shared per-run budget, then sends. Returns a normalized dict the block
+    parses into rows."""
+    method = method.upper()
+    check_url(url)
+    if (preview and method not in SAFE_METHODS) or (
+        method not in SAFE_METHODS and not control_enabled()
+    ):
+        return {
+            "dry_run": True,
+            "reason": "preview" if preview else "control-disabled",
+            "method": method,
+            "url": url,
+            "request": json_body,
+        }
+    if budget[0] <= 0:
+        return {
+            "dry_run": True,
+            "reason": "dispatch budget exhausted",
+            "method": method,
+            "url": url,
+        }
+    budget[0] -= 1
+    res = await send(method, url, headers=headers, json_body=json_body, timeout_s=timeout_s)
+    return {
+        "dry_run": False,
+        "status": res.status,
+        "ok": res.ok,
+        "json": res.json,
+        "text": res.text,
+        "error": res.error,
+    }
+
+
+async def dispatch(
+    url: str,
+    envelope: dict[str, Any],
+    *,
+    budget: list[int],
+    preview: bool,
+    auth_env: str = "",
+    timeout_s: float = 10.0,
+) -> dict[str, Any]:
+    """Command path for the actuator blocks. ALWAYS a POST of ``envelope``.
+    Dry-run on preview OR when the kill-switch is off — the envelope is still
+    returned so the editor shows exactly what WOULD be sent. Spends one unit of
+    the shared per-run budget."""
+    check_url(url)
+    if preview or not control_enabled():
+        return {
+            "dispatched": False,
+            "dry_run": True,
+            "reason": "preview" if preview else "control-disabled",
+            "request": envelope,
+        }
+    if budget[0] <= 0:
+        return {
+            "dispatched": False,
+            "dry_run": True,
+            "reason": "dispatch budget exhausted",
+            "request": envelope,
+        }
+    budget[0] -= 1
+    headers = {"content-type": "application/json", **auth_headers(auth_env)}
+    res = await send("POST", url, headers=headers, json_body=envelope, timeout_s=timeout_s)
+    out: dict[str, Any] = {"dispatched": res.error is None, "dry_run": False, "request": envelope}
+    out.update(res.summary())
+    return out
+
+
+# ── envelope builders ────────────────────────────────────────────────────────
+
+DRONE_COMMANDS = ("goto", "takeoff", "land", "rtl", "orbit", "arm", "disarm", "follow", "pause")
+
+
+def drone_envelope(
+    command: str,
+    *,
+    vehicle: str,
+    lat: float | None,
+    lon: float | None,
+    alt_m: float | None,
+    speed_ms: float | None,
+    radius_m: float | None,
+    source: str,
+) -> dict[str, Any]:
+    """Normalized drone/UAV command. Only the fields relevant to ``command``
+    carry meaning (``goto``/``orbit``/``follow`` use lat/lon; ``takeoff`` uses
+    alt; ``rtl``/``land``/``arm``/``disarm``/``pause`` need only ``vehicle``),
+    but the shape is stable so a control server can switch on ``command``."""
+    params: dict[str, Any] = {}
+    if speed_ms is not None:
+        params["speed_ms"] = speed_ms
+    if radius_m is not None:
+        params["radius_m"] = radius_m
+    env: dict[str, Any] = {
+        "type": "drone.command",
+        "command": command,
+        "vehicle": vehicle,
+        "ts": time.time(),
+        "source": source,
+    }
+    if lat is not None and lon is not None:
+        env["waypoint"] = {"lat": lat, "lon": lon}
+        if alt_m is not None:
+            env["waypoint"]["alt_m"] = alt_m
+    elif alt_m is not None:
+        env["alt_m"] = alt_m
+    if params:
+        env["params"] = params
+    return env
+
+
+def device_envelope(
+    *,
+    device: str,
+    command: str,
+    payload: dict[str, Any],
+    source: str,
+) -> dict[str, Any]:
+    """Generic controllable-item command — any actuator behind the operator's
+    control server (camera PTZ, relay, gimbal, rover, siren…)."""
+    return {
+        "type": "device.command",
+        "device": device,
+        "command": command,
+        "payload": payload,
+        "ts": time.time(),
+        "source": source,
+    }

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -43,6 +43,12 @@ dev = [
   "httpx>=0.27.2",
   "ruff>=0.6.8",
 ]
+# MAVLink bridge sidecar (app.mavlink_bridge). Optional: without it the bridge
+# runs log-only (echoes planned commands, no vehicle uplink). Install with
+# `pip install -e '.[mavlink]'` to command a real drone / SITL.
+mavlink = [
+  "pymavlink>=2.4.40",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/apps/api/tests/test_mavlink_bridge.py
+++ b/apps/api/tests/test_mavlink_bridge.py
@@ -1,0 +1,171 @@
+"""MAVLink bridge — envelope→MAVLink translation, log-only fallback, HTTP server.
+
+Hermetic: no pymavlink, no vehicle. The translation layer (``plan_mavlink``) is
+pure; the link runs log-only (no MAVLINK_CONNECT); the HTTP server is exercised
+over 127.0.0.1 loopback against our own thread (not the network).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import httpx
+import pytest
+
+from app import mavlink_bridge as mb
+
+
+def _drone(command: str, **kw) -> dict:
+    env = {"type": "drone.command", "command": command, "vehicle": "drone-1", **kw}
+    return env
+
+
+# ── plan_mavlink (pure) ──────────────────────────────────────────────────────
+
+
+def test_plan_goto_is_position_target() -> None:
+    intents = mb.plan_mavlink(_drone("goto", waypoint={"lat": 25.1, "lon": 55.2, "alt_m": 120.0}))
+    assert len(intents) == 1
+    i = intents[0]
+    assert i.kind == "position_target_global"
+    assert (i.lat, i.lon, i.alt_m) == (25.1, 55.2, 120.0)
+
+
+def test_plan_goto_without_waypoint_is_unsupported() -> None:
+    intents = mb.plan_mavlink(_drone("goto"))
+    assert intents[0].kind == "unsupported"
+
+
+def test_plan_arm_disarm_param1() -> None:
+    assert mb.plan_mavlink(_drone("arm"))[0].params[0] == 1
+    assert mb.plan_mavlink(_drone("disarm"))[0].params[0] == 0
+    assert mb.plan_mavlink(_drone("arm"))[0].command == "MAV_CMD_COMPONENT_ARM_DISARM"
+
+
+def test_plan_takeoff_alt_in_param7() -> None:
+    i = mb.plan_mavlink(_drone("takeoff", waypoint={"alt_m": 50.0}))[0]
+    assert i.command == "MAV_CMD_NAV_TAKEOFF"
+    assert i.params[6] == 50.0
+
+
+def test_plan_rtl_and_land_commands() -> None:
+    assert mb.plan_mavlink(_drone("rtl"))[0].command == "MAV_CMD_NAV_RETURN_TO_LAUNCH"
+    assert mb.plan_mavlink(_drone("land"))[0].command == "MAV_CMD_NAV_LAND"
+
+
+def test_plan_orbit_is_command_int() -> None:
+    i = mb.plan_mavlink(_drone("orbit", waypoint={"lat": 1.0, "lon": 2.0}, params={"radius_m": 80.0}))[0]
+    assert i.kind == "command_int"
+    assert i.command == "MAV_CMD_DO_ORBIT"
+    assert i.params[0] == 80.0
+
+
+def test_plan_unknown_command_is_unsupported_not_raise() -> None:
+    i = mb.plan_mavlink(_drone("self_destruct"))[0]
+    assert i.kind == "unsupported"
+    assert "self_destruct" in i.note
+
+
+# ── MavlinkLink (log-only) ───────────────────────────────────────────────────
+
+
+def test_link_log_only_when_no_connect() -> None:
+    link = mb.MavlinkLink(connect="")
+    assert link.mode == "log-only"
+    res = link.send(_drone("goto", waypoint={"lat": 1.0, "lon": 2.0}))
+    assert res["mode"] == "log-only"
+    assert res["sent"] is False
+    assert res["planned"][0]["kind"] == "position_target_global"
+
+
+def test_link_log_only_when_pymavlink_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A connect string is set but pymavlink import fails → still log-only, no raise.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name.startswith("pymavlink"):
+            raise ModuleNotFoundError("no pymavlink")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    link = mb.MavlinkLink(connect="udpout:127.0.0.1:14550")
+    res = link.send(_drone("rtl"))
+    assert res["mode"] == "log-only"
+    assert "pymavlink" in (res.get("error") or "")
+
+
+# ── _handle_command ──────────────────────────────────────────────────────────
+
+
+def test_handle_drone_command_returns_planned() -> None:
+    state = mb._State(mb.MavlinkLink(""), token="")
+    out = mb._handle_command(state, _drone("goto", waypoint={"lat": 1.0, "lon": 2.0}))
+    assert out["ok"] is True
+    assert out["planned"][0]["kind"] == "position_target_global"
+    assert state.count == 1
+
+
+def test_handle_device_command_logged() -> None:
+    state = mb._State(mb.MavlinkLink(""), token="")
+    out = mb._handle_command(state, {"type": "device.command", "device": "relay-1", "command": "on"})
+    assert out["ok"] is True
+    assert out["mode"] == "log-only"
+
+
+# ── HTTP server (loopback) ───────────────────────────────────────────────────
+
+
+class _RunningBridge:
+    def __init__(self, token: str = "") -> None:
+        self.server = mb.build_server(0, connect="", token=token)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _RunningBridge:
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_a) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+def test_http_health_and_command() -> None:
+    with _RunningBridge() as b:
+        h = httpx.get(f"{b.base}/health", timeout=3.0).json()
+        assert h["ok"] is True
+        assert h["mode"] == "log-only"
+        r = httpx.post(
+            f"{b.base}/command",
+            json=_drone("goto", waypoint={"lat": 1.0, "lon": 2.0}),
+            timeout=3.0,
+        ).json()
+        assert r["accepted"] is True
+        assert r["planned"][0]["kind"] == "position_target_global"
+
+
+def test_http_token_enforced() -> None:
+    with _RunningBridge(token="sekret") as b:
+        # no auth → 401
+        assert httpx.post(f"{b.base}/command", json=_drone("rtl"), timeout=3.0).status_code == 401
+        # correct bearer → 200
+        ok = httpx.post(
+            f"{b.base}/command", json=_drone("rtl"),
+            headers={"Authorization": "Bearer sekret"}, timeout=3.0,
+        )
+        assert ok.status_code == 200
+        assert ok.json()["accepted"] is True
+        # health needs no auth
+        assert httpx.get(f"{b.base}/health", timeout=3.0).status_code == 200
+
+
+def test_http_bad_json_is_400_not_500() -> None:
+    with _RunningBridge() as b:
+        r = httpx.post(f"{b.base}/command", content=b"not json", timeout=3.0)
+        assert r.status_code == 400

--- a/apps/api/tests/test_workflows_control.py
+++ b/apps/api/tests/test_workflows_control.py
@@ -1,0 +1,322 @@
+"""Workflows control blocks — op.http + control.{webhook,drone,device}.
+
+Hermetic: the single network seam ``control.send`` is monkeypatched (conftest's
+no-network rule). We assert on the ENVELOPE each block builds, the safety guards
+(preview dry-run, run-wide dispatch budget, kill-switch, host allowlist), and
+the response→rows parsing — never a real socket.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.keys import UserCtx
+from app.workflows import blocks as blocks_mod
+from app.workflows import control
+from app.workflows.blocks import BlockCtx
+from app.workflows.store import WorkflowError
+
+_CTX = UserCtx(user_id="local", token="")
+
+
+def _ctx(preview: bool = False, budget: int = 200) -> BlockCtx:
+    c = BlockCtx(user_ctx=_CTX, workflow_id="wf", memory={}, preview=preview)
+    c.dispatch_budget = [budget]
+    return c
+
+
+class _Recorder:
+    """Fake ``control.send`` — records every call, returns a canned result."""
+
+    def __init__(self, result: control.HttpResult | None = None) -> None:
+        self.calls: list[dict] = []
+        self.result = result or control.HttpResult(
+            status=200, ok=True, json={"ok": True, "accepted": True}, text="", error=None
+        )
+
+    async def __call__(self, method, url, *, headers, json_body=None, timeout_s=15.0):
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "body": json_body,
+                "timeout": timeout_s,
+            }
+        )
+        return self.result
+
+
+# ── control.drone ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drone_goto_builds_waypoint_envelope_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"icao24": "abc", "lat": 25.1, "lon": 55.2, "alt_m": 120.0}]
+    out = await blocks_mod._run_control_drone(
+        {
+            "server_url": "http://127.0.0.1:9010",
+            "command": "goto",
+            "mode": "first",
+            "vehicle_col": "icao24",
+            "speed_ms": 12.0,
+        },
+        [rows],
+        _ctx(),
+    )
+    assert len(rec.calls) == 1
+    call = rec.calls[0]
+    assert call["method"] == "POST"
+    assert call["url"] == "http://127.0.0.1:9010/command"
+    env = call["body"]
+    assert env["type"] == "drone.command"
+    assert env["command"] == "goto"
+    assert env["vehicle"] == "abc"
+    assert env["waypoint"] == {"lat": 25.1, "lon": 55.2, "alt_m": 120.0}
+    assert env["params"] == {"speed_ms": 12.0}
+    assert env["source"] == "workflow:wf"
+    assert out[0]["_drone"]["dispatched"] is True
+    assert out[0]["_drone"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_drone_preview_never_fires(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"lat": 1.0, "lon": 2.0}]
+    out = await blocks_mod._run_control_drone(
+        {"server_url": "http://h/x", "command": "goto"}, [rows], _ctx(preview=True)
+    )
+    assert rec.calls == []  # no network on preview
+    assert out[0]["_drone"]["dry_run"] is True
+    assert out[0]["_drone"]["dispatched"] is False
+    assert out[0]["_drone"]["request"]["command"] == "goto"  # envelope still shown
+
+
+@pytest.mark.asyncio
+async def test_drone_per_row_respects_run_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"lat": i, "lon": i} for i in range(3)]
+    out = await blocks_mod._run_control_drone(
+        {"server_url": "http://h/x", "command": "goto", "mode": "per_row", "max_dispatch": 10},
+        [rows],
+        _ctx(budget=1),
+    )
+    assert len(rec.calls) == 1  # budget exhausted after the first
+    fired = [r for r in out if r["_drone"].get("dispatched")]
+    exhausted = [r for r in out if r["_drone"].get("reason") == "dispatch budget exhausted"]
+    assert len(fired) == 1
+    assert len(exhausted) == 2
+
+
+@pytest.mark.asyncio
+async def test_drone_max_dispatch_leaves_extra_rows_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"lat": i, "lon": i} for i in range(5)]
+    out = await blocks_mod._run_control_drone(
+        {"server_url": "http://h/x", "command": "goto", "mode": "per_row", "max_dispatch": 2},
+        [rows],
+        _ctx(),
+    )
+    assert len(rec.calls) == 2
+    assert "_drone" in out[0] and "_drone" in out[1]
+    assert "_drone" not in out[2]  # past max_dispatch → passthrough
+
+
+@pytest.mark.asyncio
+async def test_drone_rejects_unknown_command() -> None:
+    with pytest.raises(WorkflowError):
+        await blocks_mod._run_control_drone(
+            {"server_url": "http://h/x", "command": "self_destruct"},
+            [[{"lat": 1, "lon": 2}]],
+            _ctx(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_drone_takeoff_has_no_waypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    out = await blocks_mod._run_control_drone(
+        {"server_url": "http://h/x", "command": "takeoff", "alt_col": "alt_m"},
+        [[{"alt_m": 50.0}]],
+        _ctx(),
+    )
+    env = rec.calls[0]["body"]
+    assert env["command"] == "takeoff"
+    assert "waypoint" not in env
+    assert env["alt_m"] == 50.0
+    assert out[0]["_drone"]["dispatched"] is True
+
+
+# ── control.device ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_device_payload_from_named_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"id": "relay-3", "state": "on", "channel": 2, "_internal": "x"}]
+    await blocks_mod._run_control_device(
+        {
+            "server_url": "http://h",
+            "command": "set_relay",
+            "device_col": "id",
+            "payload_columns": "state,channel",
+            "mode": "per_row",
+        },
+        [rows],
+        _ctx(),
+    )
+    env = rec.calls[0]["body"]
+    assert env["type"] == "device.command"
+    assert env["device"] == "relay-3"
+    assert env["command"] == "set_relay"
+    assert env["payload"] == {"state": "on", "channel": 2}
+
+
+@pytest.mark.asyncio
+async def test_device_default_payload_drops_internal_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"a": 1, "_http": {"x": 1}}]
+    await blocks_mod._run_control_device({"server_url": "http://h", "command": "c"}, [rows], _ctx())
+    assert rec.calls[0]["body"]["payload"] == {"a": 1}  # _http dropped
+
+
+# ── control.webhook ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_webhook_batch_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"x": 1}, {"x": 2}]
+    out = await blocks_mod._run_control_webhook(
+        {"url": "http://h/hook", "mode": "batch"}, [rows], _ctx()
+    )
+    assert len(rec.calls) == 1
+    env = rec.calls[0]["body"]
+    assert env["type"] == "workflow.webhook"
+    assert env["count"] == 2
+    assert env["rows"] == rows
+    assert out == rows  # rows pass through unchanged
+
+
+# ── op.http ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_http_once_json_list_becomes_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder(control.HttpResult(200, True, [{"a": 1}, {"a": 2}], "", None))
+    monkeypatch.setattr(control, "send", rec)
+    out = await blocks_mod._run_op_http(
+        {"method": "GET", "url": "http://h/data", "response": "json"}, [], _ctx()
+    )
+    assert out == [{"a": 1}, {"a": 2}]
+    assert rec.calls[0]["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_http_json_path_drills(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder(control.HttpResult(200, True, {"result": {"items": [{"n": 1}]}}, "", None))
+    monkeypatch.setattr(control, "send", rec)
+    out = await blocks_mod._run_op_http(
+        {"url": "http://h", "response": "json", "json_path": "result.items"}, [], _ctx()
+    )
+    assert out == [{"n": 1}]
+
+
+@pytest.mark.asyncio
+async def test_http_get_executes_in_preview_but_post_dry_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rec = _Recorder(control.HttpResult(200, True, [{"a": 1}], "", None))
+    monkeypatch.setattr(control, "send", rec)
+    # GET is read-only → runs live even on preview
+    await blocks_mod._run_op_http({"method": "GET", "url": "http://h"}, [], _ctx(preview=True))
+    assert len(rec.calls) == 1
+    # POST mutates → dry-run on preview, no extra call
+    out = await blocks_mod._run_op_http(
+        {"method": "POST", "url": "http://h", "body": '{"x":1}'}, [[{"x": 1}]], _ctx(preview=True)
+    )
+    assert len(rec.calls) == 1  # unchanged
+    assert out[0]["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_http_per_row_merges_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder(control.HttpResult(201, True, {"queued": True}, "", None))
+    monkeypatch.setattr(control, "send", rec)
+    rows = [{"id": "a"}, {"id": "b"}]
+    out = await blocks_mod._run_op_http(
+        {"method": "POST", "url": "http://h/{id}", "mode": "per_row"}, [rows], _ctx()
+    )
+    assert len(rec.calls) == 2
+    assert rec.calls[0]["url"] == "http://h/a"
+    assert out[0]["id"] == "a"
+    assert out[0]["_http"]["status"] == 201
+
+
+# ── control.py guards (unit) ─────────────────────────────────────────────────
+
+
+def test_check_url_rejects_non_http() -> None:
+    with pytest.raises(WorkflowError):
+        control.check_url("ftp://host/x")
+
+
+def test_check_url_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOWS_HTTP_ALLOW_HOSTS", "good.example, localhost")
+    control.check_url("http://good.example/x")  # allowed
+    control.check_url("http://localhost:9010/x")  # allowed
+    with pytest.raises(WorkflowError):
+        control.check_url("http://evil.example/x")  # refused
+
+
+def test_kill_switch_forces_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORKFLOWS_CONTROL_ENABLED", "0")
+    assert control.control_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_dry_run_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(control, "send", rec)
+    monkeypatch.setenv("WORKFLOWS_CONTROL_ENABLED", "0")
+    res = await control.dispatch(
+        "http://h/x", {"type": "drone.command"}, budget=[10], preview=False
+    )
+    assert rec.calls == []
+    assert res["dry_run"] is True
+    assert res["reason"] == "control-disabled"
+
+
+def test_auth_headers_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_TOKEN", "sekret")
+    assert control.auth_headers("MY_TOKEN") == {"Authorization": "Bearer sekret"}
+    assert control.auth_headers("") == {}
+    assert control.auth_headers("UNSET_VAR_XYZ") == {}
+
+
+# ── catalog ──────────────────────────────────────────────────────────────────
+
+
+def test_catalog_exposes_control_category_and_new_blocks() -> None:
+    cat = {b["type"]: b for b in blocks_mod.catalog()}
+    for t in ("op.http", "control.webhook", "control.drone", "control.device"):
+        assert t in cat, f"missing block {t}"
+    assert cat["control.drone"]["category"] == "control"
+    assert cat["op.http"]["category"] == "op"
+    assert cat["op.http"]["min_inputs"] == 0
+    assert len(cat) == 20

--- a/apps/web/src/state/workflows.ts
+++ b/apps/web/src/state/workflows.ts
@@ -28,7 +28,7 @@ export interface ConfigFieldSpec {
   help?: string;
 }
 
-export type BlockCategory = 'source' | 'op' | 'sink';
+export type BlockCategory = 'source' | 'op' | 'sink' | 'control';
 
 export interface BlockCatalogEntry {
   type: string;

--- a/apps/web/src/workflows/BlocksView.tsx
+++ b/apps/web/src/workflows/BlocksView.tsx
@@ -11,8 +11,9 @@ import { EmptyState, ViewHeader } from '../foundry/ui.js';
 
 const GROUPS: Array<{ key: BlockCategory; label: string; hint: string }> = [
   { key: 'source', label: 'Sources', hint: '0 inputs — pull live platform data into the DAG' },
-  { key: 'op', label: 'Ops', hint: '1-2 inputs — transform, filter, join, or compute' },
+  { key: 'op', label: 'Ops', hint: '0-2 inputs — transform, filter, join, compute, or call an external HTTP server' },
   { key: 'sink', label: 'Sinks', hint: '1 input — act on the result, rows pass through unchanged' },
+  { key: 'control', label: 'Control', hint: '1 input — act on EXTERNAL systems: webhooks, drones, devices via your control server' },
 ];
 
 const CONTRACTS: Record<string, { title: string; body: string }> = {
@@ -83,7 +84,7 @@ function BlockCard({ block }: { block: BlockCatalogEntry }): JSX.Element {
           <div className="text-[12px] text-txt-0">{block.title}</div>
           <div className="mono text-[10px] text-txt-3">{block.type}</div>
         </div>
-        <Badge tone={block.category === 'source' ? 'accent' : block.category === 'sink' ? 'mag' : 'neutral'}>
+        <Badge tone={block.category === 'source' ? 'accent' : block.category === 'sink' ? 'mag' : block.category === 'control' ? 'warn' : 'neutral'}>
           {block.min_inputs}-{block.max_inputs} in
         </Badge>
       </div>

--- a/apps/web/src/workflows/EditorView.tsx
+++ b/apps/web/src/workflows/EditorView.tsx
@@ -131,6 +131,7 @@ function layout(blocks: WorkflowBlock[], edges: WorkflowEdge[]): { laid: Laid[];
 function nodeColors(category: BlockCategory): { fill: string; stroke: string; band: string } {
   if (category === 'source') return { fill: 'var(--accent-dim)', stroke: 'var(--accent-line)', band: 'var(--accent)' };
   if (category === 'sink') return { fill: 'var(--mag-dim)', stroke: 'var(--mag-line)', band: 'var(--mag)' };
+  if (category === 'control') return { fill: 'var(--warn-bg)', stroke: 'var(--warn-line, var(--line-2))', band: 'var(--warn)' };
   return { fill: 'var(--bg-3)', stroke: 'var(--line-2)', band: 'var(--txt-3)' };
 }
 
@@ -212,6 +213,19 @@ function LlmContractNote(): JSX.Element {
       <span className="mono">{'{memory}'}</span> — this workflow&apos;s persisted memory. per_batch
       returns one summary row; per_row processes up to 50 rows and adds an{' '}
       <span className="mono">llm</span> column per row.
+    </div>
+  );
+}
+
+function ControlContractNote(): JSX.Element {
+  return (
+    <div className="rounded-sm border border-[rgba(245,165,36,0.38)] bg-warn-bg px-2.5 py-2 text-[10.5px] text-[#fcd9a0] leading-relaxed">
+      <div className="uppercase tracking-[0.4px] text-[9.5px] mb-1">Acts on external systems</div>
+      Sends a JSON command to <em>your</em> control server. <strong>Preview never fires</strong> —
+      write commands (and drone/device dispatch) run dry and show the would-be envelope; only a real
+      run actuates. Capped at 200 dispatches/run. Set{' '}
+      <span className="mono">WORKFLOWS_CONTROL_ENABLED=0</span> to force dry-run everywhere. Wire
+      contract: <span className="mono">docs/workflows-control-blocks.md</span>.
     </div>
   );
 }
@@ -327,7 +341,7 @@ function ConfigPanel({
           <div className="text-[12px] text-txt-0 truncate">{spec.title}</div>
           <div className="mono text-[10px] text-txt-3">{block.id}</div>
         </div>
-        <Badge tone={spec.category === 'source' ? 'accent' : spec.category === 'sink' ? 'mag' : 'neutral'}>
+        <Badge tone={spec.category === 'source' ? 'accent' : spec.category === 'sink' ? 'mag' : spec.category === 'control' ? 'warn' : 'neutral'}>
           {spec.category}
         </Badge>
       </div>
@@ -336,6 +350,7 @@ function ConfigPanel({
       {block.type === 'op.python' && <PythonContractNote />}
       {block.type === 'op.sql' && <SqlContractNote />}
       {block.type === 'op.llm' && <LlmContractNote />}
+      {spec.category === 'control' && <ControlContractNote />}
 
       <div className="space-y-2.5">
         {spec.config_schema.map((f) => (
@@ -364,6 +379,7 @@ function PaletteModal({
     { key: 'source', label: 'Sources' },
     { key: 'op', label: 'Ops' },
     { key: 'sink', label: 'Sinks' },
+    { key: 'control', label: 'Control' },
   ];
   return (
     <Modal open onClose={onClose} title="Add block" width={560}>

--- a/docs/workflows-control-blocks.md
+++ b/docs/workflows-control-blocks.md
@@ -1,0 +1,179 @@
+# Workflows — control blocks (external actuation)
+
+The Workflows app can reach OUT of the platform to an operator-run endpoint:
+call an HTTP API, fire a webhook, or command a drone / robot / device. Four
+blocks do this:
+
+| Block | Category | What it does |
+|-------|----------|--------------|
+| `op.http` | op (0–1 in) | HTTP request to any server; response becomes rows, or one request per input row. The universal in/out primitive. |
+| `control.webhook` | control | POST rows to a URL — batch (all rows) or per-row. |
+| `control.drone` | control | Command a drone/UAV via your ground-control server (auto-nav `goto`, plus takeoff/land/rtl/orbit/follow/arm/disarm/pause). |
+| `control.device` | control | Command any controllable item (relay, gimbal, PTZ camera, rover, siren…). |
+
+The platform stays protocol-agnostic: a control block speaks the JSON envelope
+below to a **control server** that translates it to whatever your hardware
+speaks. For drones the repo ships a first-class one — the **MAVLink bridge**
+(see below) — so you don't have to write it; for anything else you run a small
+server that accepts the envelope.
+
+## MAVLink bridge (first-class drone control server)
+
+`apps/api/app/mavlink_bridge.py` is a ready-made control server that translates
+`drone.command` envelopes into standard MAVLink and forwards them to a vehicle
+or a SITL (ArduPilot / PX4). Two ways to run it:
+
+- **As a managed sidecar.** Set `mavlink_bridge_enabled=true` (env
+  `MAVLINK_BRIDGE_ENABLED=true`) and, for a real uplink,
+  `MAVLINK_BRIDGE_CONNECT=udpout:127.0.0.1:14550` (or `/dev/ttyACM0,57600`). The
+  API boots it on `mavlink_bridge_port` (default 9010) and tears it down on
+  shutdown, same as the AIS/ADS-B feeders. OFF by default — a bridge that
+  auto-connects to a drone at boot is not implicit.
+- **Standalone.** `PORT=9010 MAVLINK_CONNECT=udpout:127.0.0.1:14550
+  python -m app.mavlink_bridge` (from `apps/api`).
+
+Then point `control.drone.server_url` at `http://127.0.0.1:9010`.
+
+`pymavlink` is an optional extra (`pip install -e '.[mavlink]'` in `apps/api`).
+**Without pymavlink or a connect string the bridge runs "log-only"** — it plans
+the exact MAVLink each command maps to and returns it, but sends nothing, so you
+can build and rehearse a drone workflow end to end with no vehicle. Command →
+MAVLink mapping: `goto`→`SET_POSITION_TARGET_GLOBAL_INT` (GUIDED),
+`takeoff`→`MAV_CMD_NAV_TAKEOFF`, `land`→`MAV_CMD_NAV_LAND`,
+`rtl`→`MAV_CMD_NAV_RETURN_TO_LAUNCH`, `arm`/`disarm`→`MAV_CMD_COMPONENT_ARM_DISARM`,
+`orbit`→`MAV_CMD_DO_ORBIT`, `pause`→`MAV_CMD_DO_PAUSE_CONTINUE`. `GET /health`
+and `GET /status` (token-gated) report mode + recent commands. The bridge issues
+only commands your autopilot already gates (arming checks, geofence stay in
+force); `goto` assumes GUIDED, like any GCS.
+
+For non-drone hardware, or to translate the envelope yourself, run your own
+server per the contract below.
+
+## Safety model (read before pointing a block at real hardware)
+
+All safety plumbing is in `apps/api/app/workflows/control.py`:
+
+- **Preview never actuates.** In the editor's live preview, `control.*` blocks
+  and any unsafe `op.http` method (POST/PUT/PATCH/DELETE) run *dry* — the
+  envelope is built and returned so you can see exactly what would be sent, but
+  no request leaves the box. GET/HEAD preview live (read-only). Only a real
+  **run** actuates.
+- **Per-run dispatch budget.** At most `MAX_DISPATCHES_PER_RUN = 200` outbound
+  calls per run, shared across every control block, so a `per_row` loop over a
+  large table can't fire thousands of commands. Each block also has its own
+  `max_dispatch` cap.
+- **Kill-switch.** `WORKFLOWS_CONTROL_ENABLED=0` forces every control block into
+  dry-run everywhere (not just preview). Default is enabled.
+- **Host allowlist (optional).** `WORKFLOWS_HTTP_ALLOW_HOSTS=host1,host2` limits
+  outbound to those hosts; anything else is refused (403). Unset = any host
+  (BYO-compute posture). Localhost is never implicitly blocked — your control
+  server is often on the same machine.
+- **Auth without secrets in the spec.** Every control block takes an `auth_env`
+  = the *name* of an environment variable holding a bearer token. The token is
+  read at run time and sent as `Authorization: Bearer <token>`; only the env var
+  name is stored in the saved workflow.
+- Same posture as `op.python`: this is a single-operator local tool, not a
+  hostile-tenant sandbox.
+
+## Wire contract
+
+Every `control.*` envelope is a single JSON object, POSTed with
+`content-type: application/json` to `{server_url}{path}` (`path` defaults to
+`/command`). Common fields: `type`, `ts` (unix seconds), `source`
+(`workflow:{id}`).
+
+### `control.drone` → `drone.command`
+
+```json
+{
+  "type": "drone.command",
+  "command": "goto",
+  "vehicle": "drone-1",
+  "ts": 1752192000.12,
+  "source": "workflow:wf_ab12",
+  "waypoint": { "lat": 25.28, "lon": 55.32, "alt_m": 120.0 },
+  "params": { "speed_ms": 12.0, "radius_m": 80.0 }
+}
+```
+
+`command` ∈ `goto | takeoff | land | rtl | orbit | arm | disarm | follow | pause`.
+`waypoint` is present only when the row had lat/lon (goto/orbit/follow);
+`takeoff` carries `alt_m` at the top level; `rtl/land/arm/disarm/pause` need only
+`vehicle`. `params` is present only if you set speed/radius.
+
+**Auto-navigation** = wire a data source into it: e.g.
+`source.aircraft → op.geo (within_radius of a point) → control.drone (goto)`
+sends the vehicle to the detected target's coordinates. `mode=first` sends one
+command to the top row; `mode=per_row` fans out one command per row (swarm /
+multi-waypoint patrol), capped by `max_dispatch`.
+
+### `control.device` → `device.command`
+
+```json
+{
+  "type": "device.command",
+  "device": "relay-3",
+  "command": "set_relay",
+  "payload": { "state": "on", "channel": 2 },
+  "ts": 1752192000.12,
+  "source": "workflow:wf_ab12"
+}
+```
+
+`payload` is the named `payload_columns` of the row, or every non-`_`-prefixed
+column if you leave that blank.
+
+### `control.webhook`
+
+Batch: `{"type":"workflow.webhook","source":"…","count":N,"rows":[…]}` (rows
+capped at 100). Per-row: `{"type":"workflow.row","source":"…","row":{…}}`.
+
+## Response
+
+Return any JSON. `2xx` = accepted. The block annotates each dispatched row with
+the outcome under `_drone` / `_device` / `_webhook` (`dispatched`, `status`,
+`ok`, `response`, or `error`) so a downstream block can branch on it. A non-2xx
+or a transport error fails only that row, never the run.
+
+## Reference control server (~40 lines)
+
+For drones, use the built-in MAVLink bridge above. For a **device** controller
+(relay/gimbal/rover) or any custom endpoint, here is a minimal server that
+accepts every envelope and logs it — swap the `TODO`s for your GPIO/ROS/HTTP
+bridge. Run it, point a block at `http://127.0.0.1:9010`, and do a real run.
+
+```python
+# control_server.py — python control_server.py  (stdlib only, no deps)
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers.get("content-length", 0))) or b"{}")
+        kind = body.get("type")
+        if kind == "drone.command":
+            cmd, veh, wp = body.get("command"), body.get("vehicle"), body.get("waypoint")
+            print(f"[drone] {veh} {cmd} {wp or ''}")
+            # TODO: pymavlink → e.g. goto: mav.mav.set_position_target_global_int_send(...)
+        elif kind == "device.command":
+            print(f"[device] {body.get('device')} {body.get('command')} {body.get('payload')}")
+            # TODO: drive your GPIO / relay / PTZ here
+        else:
+            print(f"[webhook] {body.get('count', 1)} row(s)")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok": true, "accepted": true}')
+
+    def log_message(self, *a):  # quiet
+        pass
+
+if __name__ == "__main__":
+    print("control server on http://127.0.0.1:9010")
+    HTTPServer(("127.0.0.1", 9010), Handler).serve_forever()
+```
+
+If you protect it with a token, set `WORKFLOWS_*` nothing — instead export the
+token under a name (e.g. `export DRONE_SERVER_TOKEN=…`) and put that env var
+name in the block's **Bearer-token env var** field; the server then checks the
+`Authorization: Bearer …` header.


### PR DESCRIPTION
## What

Gives the Workflows block DAG a way to act on **external** systems (it could previously only read/transform internal platform data), plus a first-class drone control server.

### Blocks (16 → 20), new **control** category
| Block | Category | Purpose |
|-------|----------|---------|
| `op.http` | op | HTTP request to any server; response → rows (once) or one request per row. GET/HEAD run in preview; writes dry-run. |
| `control.webhook` | control | POST rows to a URL (batch or per-row). |
| `control.drone` | control | Command a drone/UAV via a ground-control server: `goto` (auto-nav to each row's lat/lon), `takeoff`/`land`/`rtl`/`orbit`/`follow`/`arm`/`disarm`/`pause`. |
| `control.device` | control | Command any controllable item (relay/gimbal/PTZ/rover). |

**Auto-navigation** = wire a data source into it, e.g. `source.aircraft → op.geo(within_radius) → control.drone(goto)` sends the vehicle to the detected target.

### Safety model (`app/workflows/control.py`)
- **Preview never actuates** — dry-run returns the would-be envelope; only a real run fires.
- Run-wide dispatch budget (200) + per-block `max_dispatch` caps.
- `WORKFLOWS_CONTROL_ENABLED=0` kill-switch; optional `WORKFLOWS_HTTP_ALLOW_HOSTS` allowlist.
- Bearer auth by **env-var name** (token never stored in the spec). IPv4-pinned client.

### MAVLink bridge (`app/mavlink_bridge.py`)
A ready-made control server that translates the `drone.command` envelope into standard MAVLink for a vehicle or SITL.
- `plan_mavlink()` — pure, testable envelope→intent mapping.
- `MavlinkLink` — lazily imports `pymavlink`; **degrades to log-only** (echoes planned commands, sends nothing) with no pymavlink or connection string, so a drone workflow can be built and rehearsed with no hardware.
- Runs as a lifespan-managed sidecar (`app/mavlink_sidecar.py`, **OFF by default**) or standalone via `python -m app.mavlink_bridge`. `pymavlink` is an optional extra (`pip install -e '.[mavlink]'`).

The frontend renders every new block from the backend `config_schema`; only the new `control` category needed wiring (palette groups, node colors, badge, safety note). Wire contract + setup: `docs/workflows-control-blocks.md`.

## Testing
- `tests/test_workflows_control.py` (19) — envelope shapes, safety guards, response parsing.
- `tests/test_mavlink_bridge.py` (14) — MAVLink translation, log-only fallback, HTTP server.
- Full suite **1196 passed + 1 skipped**; `bash scripts/verify.sh` green; typecheck + ruff + eslint clean.
- Proven end-to-end live: `control.drone(goto)` → real `python -m app.mavlink_bridge` → HTTP 200; bridge planned `SET_POSITION_TARGET_GLOBAL_INT` (25.28, 55.32, 120 m).

Base is `workflows-city-foundry-overhaul` so the diff is only this feature.