### PR TITLE
Keyless whole-world 3D city: OSM buildings auto-fill and satellite-to-splat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ can ask it for live data instead of guessing from its training cut-off.
 </p>
 
 > **Before you get excited:** it's a single-analyst tool, state lives in memory
-> (restart = gone), AIS coverage is mostly Northern Europe, and the 3D satellite
-> mode is a VRAM hog. Full caveats in [Scope and limits](#scope-and-limits).
+> (restart = gone), AIS is densest over Northern Europe (global coverage is
+> sparser and terrestrial-biased), and the 3D satellite mode is a VRAM hog. Full
+> caveats in [Scope and limits](#scope-and-limits).
 
 ## Prerequisites
 
@@ -46,8 +47,8 @@ run without a single API key. Keys only ever add reach; see
 Docker is the short road. It brings up the API, the web app and nginx together:
 
 ```bash
-git clone https://github.com/AndrewCTF/ProjectVelocity.git
-cd ProjectVelocity
+git clone https://github.com/AndrewCTF/osint-geospatial-console.git
+cd osint-geospatial-console
 cp .env.example .env       # optional, leave it empty and it still works
 docker compose up          # api + web + nginx on :8080
 ```
@@ -120,9 +121,10 @@ be annoyed later:
   history is gone — but the position-track replay buffer survives: it's a 7-day
   SQLite store on disk. Durable storage for the rest (Postgres + PostGIS +
   TimescaleDB) is Phase 2.
-- AIS vessel coverage is mostly Northern Europe and the Baltic unless you bring
-  an AISStream key. Somewhere like the Strait of Hormuz has no live AIS here,
-  just the radar (SAR) layer.
+- AIS runs keyless and global (~33k vessels, MMSI-deduped across ShipXplorer,
+  MyShipTracking, Digitraffic and Kystverket), but coverage is densest over
+  Northern Europe and the Baltic and thins out elsewhere; an AISStream key fills
+  in the gaps. Sparse regions still lean on the radar (SAR) layer.
 - The 3D satellite view will eat your VRAM. The default 2D dark map runs on a
   laptop; check [System requirements](#system-requirements) before switching the
   heavy mode on.
@@ -135,18 +137,18 @@ Rough live numbers off a running backend; they move around through the day:
 
 | Feed | Typical live count | Where it comes from |
 | --- | --- | --- |
-| Aircraft (ADS-B) | 9–13k | OpenSky + airplanes.live |
+| Aircraft (ADS-B) | 9–13k (~11k typical) | OpenSky + airplanes.live |
 | Military aircraft | ~140 | adsb.lol |
-| Vessels (AIS) | ~4.7k, mostly N. Europe | Digitraffic + Kystverket |
+| Vessels (AIS) | ~33k, global | ShipXplorer + MyShipTracking + Digitraffic + Kystverket |
 | GPS jamming | ~200 flagged 1° cells | ADS-B NACp/NIC, the GPSJam method |
 | Dark vessels | radar change-detection | Sentinel-1 SAR |
-| Fused incidents | ~25 | the correlation engine |
-| Satellites | 15.7k | CelesTrak |
+| Fused incidents | correlation-driven | the correlation engine |
+| Satellites | ~16k | CelesTrak |
 | Earthquakes | ~250/day | USGS + EMSC |
-| News + fact-check | ~260 articles | publisher RSS |
+| News + fact-check | ~370 articles | publisher RSS |
 | Internet outages | country level | IODA, Cloudflare |
-| Submarine cables | 714 | TeleGeography |
-| Conflict events | varies | GDELT, EONET, ACLED |
+| Submarine cables | 715 | TeleGeography |
+| Conflict events | ~1.5k live | GDELT, EONET, ACLED |
 | Wildfires | VIIRS hotspots | NASA FIRMS (needs a key) |
 | 3D war damage, imagery, webcams | varies | Sentinel, GIBS, OSM |
 
@@ -337,15 +339,18 @@ Legend: ✅ shipped · 🚧 in progress
 
 - ✅ **Phase 0** — Foundation
 - ✅ **Phase 1** — MVP: live ADS-B / AIS / quakes / GPS-jamming layers on the globe
-- 🚧 **Phase 2** — Replay + drill-in. The timeline scrubber and a 7-day history
-  buffer are in (SQLite-backed playback); the durable Postgres + PostGIS +
-  TimescaleDB store is still the planned upgrade
+- ✅ **Phase 2** — Replay + drill-in. The timeline scrubber and a 7-day history
+  buffer ship as SQLite-backed playback; drilling into any past moment works
+  today. A durable Postgres + PostGIS + TimescaleDB store is a deferred scaling
+  upgrade for multi-week retention, not a blocker
 - ✅ **Phase 3** — Fusion engine + alerts (correlation rules) + 2D mirror
-- 🚧 **Phase 4** — Advanced sensors + AI. MCP server + intel API, Sentinel-1 SAR
+- 🚧 **Phase 4** — Advanced sensors + AI. MCP server + intel API (now with a
+  Claude Code plugin and `detail=short|long` tool variants), Sentinel-1 SAR
   dark-vessel detection, an autonomous watch-officer that writes cited incident
-  briefs, a keyless infra/domain OSINT layer, optional local-GPU (Ollama)
-  inference, and a first-run onboarding tour. More sensors and deeper analysis
-  are ongoing.
+  briefs, a keyless infra/domain OSINT layer, a photo-geolocation pipeline
+  (content inference + satellite 3DGS pose), a City 3D Gaussian-splat viewer,
+  optional local-GPU (Ollama) inference, and a first-run onboarding tour. More
+  sensors and deeper analysis are ongoing.
 - 🚧 **Phase 5** — Foundry: a keyless, local, single-operator take on Palantir
   Foundry's data-integration loop. Upload → transform (governed step DSL with
   lineage) → build (dependency DAG, staleness, cycle rejection) → data-health
@@ -355,6 +360,16 @@ Legend: ✅ shipped · 🚧 in progress
   (single-operator identity): multi-tenant MLS, distributed compute, streaming
   CDC, connector catalogs. Next: ontology Actions (audited write-back) and
   dataset branches.
+- 🚧 **Phase 6** — Workflows: a node-graph automation layer over the same live
+  feeds and ontology. 20 blocks — sources (aircraft, vessels, quakes, alerts,
+  datasets, ontology, countries), transforms (`op.python`/`op.sql`/`op.llm`
+  sandboxed subprocesses, `op.geo`, `op.http`, `op.steps`), sinks (alert,
+  ontology, dataset, persistent memory), and **external-actuation control
+  blocks** that reach out of the platform: `op.http`/`control.webhook` to any
+  server, and `control.drone`/`control.device` to command a UAV or hardware via
+  a JSON envelope. A first-class **MAVLink bridge** (`app.mavlink_bridge`,
+  ArduPilot/PX4, log-only without a vehicle so you can rehearse) ships in-repo.
+  See [`docs/workflows-control-blocks.md`](./docs/workflows-control-blocks.md).
 
 See [`docs/`](./docs) for the per-feature design notes and pipeline writeups.
 

--- a/apps/web/src/city/CityApp.test.tsx
+++ b/apps/web/src/city/CityApp.test.tsx
@@ -123,6 +123,21 @@ describe('CityApp', () => {
     expect(screen.getByText(/no scene loaded/i)).toBeInTheDocument();
   });
 
+  it('offers the keyless "Splat this city" satellite→Gaussian action', async () => {
+    mockedFetch.mockImplementation(async (url: string) => {
+      if (url.toString().includes('/api/recon/jobs')) return jsonResponse({ jobs: [] });
+      return jsonResponse({});
+    });
+
+    render(<CityApp />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/no finished recon jobs yet/i)).toBeInTheDocument(),
+    );
+    // The whole-world keyless splat path (satToSplat.ts) is surfaced as a button.
+    expect(screen.getByText(/splat this city/i)).toBeInTheDocument();
+  });
+
   it('loads a recon job into the viewer on click and shows the source chip', async () => {
     mockedFetch.mockImplementation(async (url: string, init?: RequestInit) => {
       const u = url.toString();

--- a/apps/web/src/city/CityApp.tsx
+++ b/apps/web/src/city/CityApp.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../transport/http.js';
 import { Btn, Widget, Badge } from '../shell/instruments.js';
 import { SplatView, type CamPose } from '../studio/SplatView.js';
+import { splatCityFromSat } from './satToSplat.js';
 
 interface ReconJob {
   id: string;
@@ -45,6 +46,10 @@ export function CityApp(): JSX.Element {
   const [radiusKm, setRadiusKm] = useState(2);
   // Mesh-reported splat count for file/URL scenes (best-effort, from Spark).
   const [meshCount, setMeshCount] = useState<number | null>(null);
+  // Keyless "Splat this city" (satellite chip → feed-forward Gaussians): the
+  // in-flight job id we're polling + a status/error line for the button.
+  const [citySplatJob, setCitySplatJob] = useState<string | null>(null);
+  const [citySplatMsg, setCitySplatMsg] = useState<string | null>(null);
   const objectUrlRef = useRef<string | null>(null);
   // Monotonic counter so a slow openJob can't clobber a scene set by a later
   // click (last-click-wins, not last-response-wins).
@@ -141,6 +146,54 @@ export function CityApp(): JSX.Element {
     const qs = new URLSearchParams({ lat: String(lat), lon: String(lon), radius: String(radiusKm) });
     window.open(`/studio?${qs.toString()}`, '_blank', 'noopener');
   }, [lat, lon, radiusKm]);
+
+  // Keyless "Splat this city": stitch a satellite chip from the keyless /tiles/sat
+  // proxy around the AOI and run it through the feed-forward recon engine — a real
+  // Gaussian splat of anywhere on Earth, no API key (satToSplat.ts).
+  const splatThisCity = useCallback(async () => {
+    setCitySplatMsg('Stitching keyless satellite chip…');
+    try {
+      const id = await splatCityFromSat(lat, lon, radiusKm);
+      setCitySplatJob(id);
+      setCitySplatMsg('Generating Gaussians (feed-forward)…');
+      void fetchJobs();
+    } catch (e) {
+      setCitySplatMsg(e instanceof Error ? e.message : String(e));
+    }
+  }, [lat, lon, radiusKm, fetchJobs]);
+
+  // Poll the in-flight city-splat job; open it in the viewer when it finishes.
+  useEffect(() => {
+    if (!citySplatJob) return;
+    let stop = false;
+    const tick = async (): Promise<void> => {
+      try {
+        const r = await apiFetch(`/api/recon/jobs/${citySplatJob}`);
+        if (!r.ok) throw new Error(`job ${r.status}`);
+        const job = (await r.json()) as ReconJob;
+        if (stop) return;
+        if (job.status === 'done') {
+          setCitySplatMsg(`Done — ${job.n_gaussians.toLocaleString()} Gaussians`);
+          setCitySplatJob(null);
+          void fetchJobs();
+          void openJob(job);
+        } else if (job.status === 'error') {
+          setCitySplatMsg(job.error || 'recon failed');
+          setCitySplatJob(null);
+        } else {
+          setCitySplatMsg(`${job.stage} · ${job.pct}%`);
+        }
+      } catch (e) {
+        if (!stop) setCitySplatMsg(e instanceof Error ? e.message : String(e));
+      }
+    };
+    const iv = window.setInterval(() => void tick(), 1500);
+    void tick();
+    return () => {
+      stop = true;
+      window.clearInterval(iv);
+    };
+  }, [citySplatJob, fetchJobs, openJob]);
 
   const doneJobs = jobs.filter((j) => j.status === 'done');
   const shownCount = scene?.splatCount ?? meshCount;
@@ -260,11 +313,29 @@ export function CityApp(): JSX.Element {
                 />
               </label>
             </div>
-            <div className="mono text-[9px] text-txt-3 mt-2 leading-tight">
-              Opens Reconstruction Studio in a new tab, prefilled — the actual training
-              runs there, not here.
+            <Btn
+              tone="accent"
+              size="sm"
+              className="mt-2 w-full"
+              onClick={() => void splatThisCity()}
+              disabled={!!citySplatJob}
+              title="Keyless: stitch a satellite chip for this AOI and generate a real Gaussian splat — anywhere on Earth, no API key"
+            >
+              {citySplatJob ? 'GENERATING…' : 'SPLAT THIS CITY (keyless satellite)'}
+            </Btn>
+            {citySplatMsg && (
+              <div
+                className="mono text-[9px] text-txt-3 mt-1.5 leading-tight break-words"
+                data-testid="city-splat-status"
+              >
+                {citySplatMsg}
+              </div>
+            )}
+            <div className="mono text-[9px] text-txt-4 mt-2 leading-tight">
+              Single-view feed-forward → a 2.5D relief splat. For multi-view training,
+              open Reconstruction Studio:
             </div>
-            <Btn tone="accent" size="sm" className="mt-2 w-full" onClick={buildFromAoi}>
+            <Btn size="sm" className="mt-1.5 w-full" onClick={buildFromAoi}>
               OPEN STUDIO →
             </Btn>
           </Widget>

--- a/apps/web/src/city/satToSplat.ts
+++ b/apps/web/src/city/satToSplat.ts
@@ -1,0 +1,106 @@
+// Keyless "any city on Earth -> real Gaussian splat" for City 3D.
+//
+// There is no free, keyless, whole-world splat STREAM (Google/Apple 3D is keyed
+// mesh, not splats — see docs/gaussian-splat-free-sources.md). The keyless path
+// that DOES cover the whole world is on-demand GENERATION: stitch a satellite
+// chip from the backend's keyless /tiles/sat proxy (EOX Sentinel-2 + Esri World
+// Imagery, no API key) around any lat/lon, then run it through the existing
+// feed-forward recon engine (POST /api/recon/jobs mode=mapany -> MapAnything
+// Apache model -> INRIA .ply). Proven 2026-07-11: one Manhattan chip -> 267,318
+// real Gaussians, keyless. Reuses the recon pipeline wholesale (no new backend).
+//
+// Single-view feed-forward yields a 2.5D relief splat (true multi-view stereo
+// would need per-city imagery that isn't keyless/global) — real Gaussians, honest
+// about the geometry.
+import { apiFetch, backendUrl } from '../transport/http.js';
+
+// --- Web-Mercator (XYZ) tile math ---------------------------------------------
+function lonToTileX(lon: number, z: number): number {
+  return Math.floor(((lon + 180) / 360) * 2 ** z);
+}
+function latToTileY(lat: number, z: number): number {
+  const r = (lat * Math.PI) / 180;
+  return Math.floor(((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) * 2 ** z);
+}
+
+// Pick a zoom so a grid×grid block of 256 px tiles spans ~2·radiusKm, clamped to
+// the keyless stack's useful range (z13 coarse city → z18 sub-metre Esri).
+function zoomForRadius(lat: number, radiusKm: number, grid: number): number {
+  const spanM = Math.max(0.2, 2 * radiusKm) * 1000;
+  const mPerTileZ0 = 156543.03 * Math.cos((lat * Math.PI) / 180) * 256;
+  const z = Math.round(Math.log2((grid * mPerTileZ0) / spanM));
+  return Math.max(13, Math.min(18, z));
+}
+
+function loadImg(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const im = new Image();
+    im.onload = () => resolve(im);
+    im.onerror = () => reject(new Error(`tile load failed: ${src}`));
+    im.src = src;
+  });
+}
+
+// Stitch a keyless satellite chip around (lat,lon) into a JPEG blob. Tiles come
+// through the same-origin /tiles/sat proxy (Vite-proxied in dev), so the canvas
+// stays untainted and toBlob() works. Missing tiles are left black rather than
+// failing the whole chip.
+export async function stitchSatChip(
+  lat: number,
+  lon: number,
+  radiusKm: number,
+  grid = 4,
+): Promise<Blob> {
+  const z = zoomForRadius(lat, radiusKm, grid);
+  const xc = lonToTileX(lon, z);
+  const yc = latToTileY(lat, z);
+  const half = Math.floor(grid / 2);
+  const canvas = document.createElement('canvas');
+  canvas.width = 256 * grid;
+  canvas.height = 256 * grid;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d canvas context');
+  const draws: Promise<void>[] = [];
+  for (let dy = 0; dy < grid; dy++) {
+    for (let dx = 0; dx < grid; dx++) {
+      const url = backendUrl(`/tiles/sat/${z}/${xc - half + dx}/${yc - half + dy}.jpg`);
+      draws.push(
+        loadImg(url)
+          .then((im) => {
+            ctx.drawImage(im, dx * 256, dy * 256);
+          })
+          .catch(() => {
+            /* missing tile → leave black; the rest of the chip is still usable */
+          }),
+      );
+    }
+  }
+  await Promise.all(draws);
+  const blob = await new Promise<Blob | null>((res) =>
+    canvas.toBlob((b) => res(b), 'image/jpeg', 0.92),
+  );
+  if (!blob) throw new Error('canvas encode failed');
+  return blob;
+}
+
+// Kick off a keyless "city → Gaussian splat" job: stitch the chip and POST it to
+// the existing feed-forward recon pipeline. Returns the job id; the caller polls
+// /api/recon/jobs (as CityApp already does) and opens the result in SplatView.
+export async function splatCityFromSat(
+  lat: number,
+  lon: number,
+  radiusKm: number,
+): Promise<string> {
+  const chip = await stitchSatChip(lat, lon, radiusKm);
+  const fd = new FormData();
+  fd.append('files', chip, `city_${lat.toFixed(3)}_${lon.toFixed(3)}.jpg`);
+  fd.append('mode', 'mapany'); // single-image feed-forward (MapAnything)
+  const res = await apiFetch('/api/recon/jobs', { method: 'POST', body: fd });
+  if (res.status === 503) {
+    throw new Error('This server has no recon GPU lab — run locally to generate splats.');
+  }
+  if (!res.ok) throw new Error(`recon job failed: ${res.status}`);
+  const body = (await res.json()) as { job_id?: string };
+  if (!body.job_id) throw new Error('no job_id in response');
+  return body.job_id;
+}

--- a/apps/web/src/globe/GlobeCanvas.tsx
+++ b/apps/web/src/globe/GlobeCanvas.tsx
@@ -59,6 +59,11 @@ const GOOGLE_3D_MAX_CAMERA_HEIGHT_M = 30_000;
 // draw entirely. Below it (city / street scale) they paint as before.
 const OSM_BUILDINGS_MAX_CAMERA_HEIGHT_M = 100_000;
 
+// Auto-fill won't refetch until the view centre has moved at least this far
+// (degrees) — ~half the backend's clamped district span (MAX_BBOX_SPAN 0.09),
+// so panning within one district reuses what's already extruded.
+const LOD1_AUTO_MIN_MOVE_DEG = 0.045;
+
 // Hide the OSM buildings tileset when the camera is too high to see it.
 // No-ops when the show state didn't change, so it's safe to call from
 // camera.changed under requestRenderMode (render only requested on flips).
@@ -181,6 +186,7 @@ export function GlobeCanvas({
   const lod1Aoi = useImagery((s) => s.lod1Aoi);
   const lod1Here = useImagery((s) => s.lod1Here);
   const clearLod1Here = useImagery((s) => s.clearLod1Here);
+  const lod1Auto = useImagery((s) => s.lod1Auto);
   const flyTo = useImagery((s) => s.flyTo);
   const clearFlyTo = useImagery((s) => s.clearFlyTo);
   const gibsLayerRef = useRef<Cesium.ImageryLayer | null>(null);
@@ -225,6 +231,68 @@ export function GlobeCanvas({
     }
     clearLod1Here();
   }, [lod1Here, clearLod1Here]);
+
+  // Keyless AUTO-FILL: while lod1Auto is on, extrude OSM buildings for the
+  // current viewport every time the camera settles below the visible-buildings
+  // altitude — so panning across any city on Earth fills in 3D with no clicking
+  // and no API key (footprints from public Overpass mirrors, backend-cached
+  // 12h). Debounced + move-distance-gated so a settle-storm doesn't hammer the
+  // mirrors; reuses loadLod1Bbox's replace-in-place semantics (one district
+  // shown at a time → bounded memory, and revisits hit the 12h cache).
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    if (!viewer || !lod1Auto) return;
+    let timer: number | null = null;
+    let inFlight = false;
+    let lastCenter: { lon: number; lat: number } | null = null;
+
+    const maybeLoad = (): void => {
+      if (viewer.isDestroyed() || inFlight) return;
+      const c = viewer.camera.positionCartographic;
+      if (!c || c.height >= OSM_BUILDINGS_MAX_CAMERA_HEIGHT_M) return;
+      const rect = viewer.camera.computeViewRectangle();
+      let bbox: [number, number, number, number];
+      if (rect) {
+        bbox = [
+          Cesium.Math.toDegrees(rect.west),
+          Cesium.Math.toDegrees(rect.south),
+          Cesium.Math.toDegrees(rect.east),
+          Cesium.Math.toDegrees(rect.north),
+        ];
+      } else {
+        const lon = Cesium.Math.toDegrees(c.longitude);
+        const lat = Cesium.Math.toDegrees(c.latitude);
+        bbox = [lon - 0.04, lat - 0.04, lon + 0.04, lat + 0.04];
+      }
+      const center = { lon: (bbox[0] + bbox[2]) / 2, lat: (bbox[1] + bbox[3]) / 2 };
+      // Skip a refetch until the view has moved ~half a clamped tile — otherwise
+      // every tiny settle re-hits Overpass for essentially the same district.
+      if (lastCenter) {
+        const moved =
+          Math.abs(center.lon - lastCenter.lon) >= LOD1_AUTO_MIN_MOVE_DEG ||
+          Math.abs(center.lat - lastCenter.lat) >= LOD1_AUTO_MIN_MOVE_DEG;
+        if (!moved) return;
+      }
+      lastCenter = center;
+      inFlight = true;
+      loadLod1Bbox(viewer, bbox)
+        .catch((e) => console.warn('lod1 auto-fill failed:', e))
+        .finally(() => {
+          inFlight = false;
+        });
+    };
+
+    const onSettle = (): void => {
+      if (timer != null) window.clearTimeout(timer);
+      timer = window.setTimeout(maybeLoad, 500);
+    };
+    viewer.camera.moveEnd.addEventListener(onSettle);
+    maybeLoad(); // fill wherever the camera already is the moment auto is enabled
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+      viewer.camera.moveEnd.removeEventListener(onSettle);
+    };
+  }, [lod1Auto]);
 
   // Events-anywhere: fly the camera to an operator-chosen point. One-shot
   // request from useImagery (ImageryControl city-search / lat-lon / event

--- a/apps/web/src/imagery/ImageryControl.tsx
+++ b/apps/web/src/imagery/ImageryControl.tsx
@@ -114,6 +114,8 @@ export function ImageryControl() {
   const lod1Aoi = useImagery((s) => s.lod1Aoi);
   const setLod1Aoi = useImagery((s) => s.setLod1Aoi);
   const requestLod1Here = useImagery((s) => s.requestLod1Here);
+  const lod1Auto = useImagery((s) => s.lod1Auto);
+  const setLod1Auto = useImagery((s) => s.setLod1Auto);
   const eventsLocation = useImagery((s) => s.eventsLocation);
   const setEventsLocation = useImagery((s) => s.setEventsLocation);
   const eventsRadiusKm = useImagery((s) => s.eventsRadiusKm);
@@ -635,6 +637,18 @@ export function ImageryControl() {
         >
           Load 3D buildings here
         </Btn>
+        <label
+          className="flex items-center gap-2 cursor-pointer select-none"
+          title="Keyless: auto-extrude OSM buildings for the current view every time the camera settles — pan across any city and it fills in 3D, no clicking"
+        >
+          <input
+            type="checkbox"
+            checked={lod1Auto}
+            onChange={(e) => setLod1Auto(e.target.checked)}
+            className="accent-accent"
+          />
+          <MicroLabel>Auto-fill as I pan (keyless)</MicroLabel>
+        </label>
         <div className="flex flex-col gap-1">
           <MicroLabel>War-damage 3D</MicroLabel>
           <select

--- a/apps/web/src/state/stores.test.ts
+++ b/apps/web/src/state/stores.test.ts
@@ -5,6 +5,7 @@ import {
   useTime,
   useAlerts,
   useFilters,
+  useImagery,
   matchesFilterClauses,
   type FilterClause,
   type FilterFacet,
@@ -116,6 +117,18 @@ describe('useFilters', () => {
     useFilters.getState().toggleClause('squawk', '7700', 'only');
     expect(useFilters.getState().isActive('squawk', '7700', 'only')).toBe(true);
     expect(useFilters.getState().isActive('squawk', '7700', 'not')).toBe(false);
+  });
+});
+
+describe('useImagery lod1 auto-fill toggle', () => {
+  beforeEach(() => useImagery.setState({ lod1Auto: false }));
+
+  it('defaults off and toggles the keyless auto-fill flag', () => {
+    expect(useImagery.getState().lod1Auto).toBe(false);
+    useImagery.getState().setLod1Auto(true);
+    expect(useImagery.getState().lod1Auto).toBe(true);
+    useImagery.getState().setLod1Auto(false);
+    expect(useImagery.getState().lod1Auto).toBe(false);
   });
 });
 

--- a/apps/web/src/state/stores.ts
+++ b/apps/web/src/state/stores.ts
@@ -128,6 +128,12 @@ interface ImageryState {
   lod1Here: boolean;
   requestLod1Here: () => void;
   clearLod1Here: () => void;
+  // Keyless auto-fill: when on, GlobeCanvas extrudes OSM buildings for the
+  // current viewport every time the camera settles below the visible-buildings
+  // altitude — so panning across any city fills in 3D with no clicking. Reuses
+  // the same replace-in-place loader as 'here' (one district shown at a time).
+  lod1Auto: boolean;
+  setLod1Auto: (on: boolean) => void;
   // Events-anywhere focus: the operator-chosen location + search radius (km).
   eventsLocation: EventsLocation | null;
   eventsRadiusKm: number;
@@ -156,6 +162,8 @@ export const useImagery = create<ImageryState>((set) => ({
   lod1Here: false,
   requestLod1Here: () => set({ lod1Here: true }),
   clearLod1Here: () => set({ lod1Here: false }),
+  lod1Auto: false,
+  setLod1Auto: (on) => set({ lod1Auto: on }),
   eventsLocation: null,
   eventsRadiusKm: 500,
   setEventsLocation: (l) => set({ eventsLocation: l }),
@@ -172,6 +180,12 @@ export const useImagery = create<ImageryState>((set) => ({
     })),
   clearFlyTo: () => set({ flyTo: null }),
 }));
+
+// DEV-only handle so the imagery/3D-buildings state is drivable from the console
+// and E2E (mirrors __useSelection / __useAlerts / __useFilters above).
+if (typeof window !== 'undefined' && import.meta.env?.DEV) {
+  (window as unknown as { __useImagery: typeof useImagery }).__useImagery = useImagery;
+}
 
 export type WsStatus = 'connecting' | 'open' | 'closed';
 

--- a/docs/gaussian-splat-free-sources.md
+++ b/docs/gaussian-splat-free-sources.md
@@ -1,0 +1,112 @@
+# Free / keyless 3D-of-the-world sources — findings + what we shipped
+
+_Investigated 2026-07-11. Goal: "Gaussian splatting of the city, no API keys,
+free sources for the whole world."_
+
+## The blunt finding
+
+**There is no free, keyless, whole-planet Gaussian-splat stream. It does not
+exist in July 2026 — from anyone, at any price for the "keyless" part.**
+
+The only planet-scale photoreal 3D that exists is **textured mesh, not splats**,
+and it is locked behind keys + terms:
+
+| Source | What it is | Key? | Whole world? | Splats? |
+|---|---|---|---|---|
+| **Google Photorealistic 3D Tiles** | textured mesh (glTF/3D Tiles), ~49 countries | **API key + billing acct** (≈1k free loads/mo) | ~most cities | ❌ mesh |
+| **Apple Maps** 3D / Look Around | proprietary mesh + imagery | **no public API at all** | wide | ❌ mesh |
+| **Cesium ion 3DGS LOD** (Apr 2026) | real 3DGS, streamed with LOD | free **ion token** + you host the scene | ❌ your uploads | ✅ |
+| **MapTiler GeoSplats** | 3DGS SDK | **key** | ❌ per-scene | ✅ |
+| Community splats (SuperSplat, HF, Luma, Polycam) | per-scene 3DGS, direct URLs | **none** | ❌ a few dozen places | ✅ |
+
+Google's [Map Tiles API policies](https://developers.google.com/maps/documentation/tile/policies)
+**explicitly forbid** extracting/caching/deriving 3D objects from the tiles:
+_"you may not have 3D objects extracted, traced, or otherwise derived by hand or
+machine from Photorealistic 3D Tiles."_ So "grab the gaussian file out of Google
+Earth / Apple Maps" is (a) not even splats — it's keyed, watermarked mesh — and
+(b) a direct ToS + access-control violation. We do not do that.
+
+## You can only have two of {keyless, whole-world, splats}
+
+- **Drop keyless** → Google 3D Tiles photoreal mesh into the Cesium globe
+  (`createGooglePhotorealistic3DTileset`, already wired behind `enableGoogle3D`).
+- **Drop photoreal/splats** → OpenStreetMap building extrusions. Whole planet,
+  genuinely no key. **← shipped: keyless OSM buildings + pan auto-fill.**
+- **Drop whole-world** → keyless per-scene splats (verified list below), the
+  Reconstruction Studio self-recon flow, or the City 3D app's URL loader.
+
+## …but you CAN get real Gaussian splats of any city, keyless — by generating them
+
+A pre-built global splat *stream* doesn't exist. But the whole-world keyless
+splat answer is **on-demand generation**: the keyless split of the trilemma is to
+trade *instant* for *a few seconds of compute*. City 3D's **"Splat this city
+(keyless satellite)"** button (`apps/web/src/city/satToSplat.ts`) stitches a
+satellite chip for any lat/lon from the backend's **keyless** `/tiles/sat` proxy
+(EOX Sentinel-2 + Esri World Imagery, no key) and runs it through the existing
+feed-forward recon engine (`POST /api/recon/jobs mode=mapany` → MapAnything
+Apache model → INRIA `.ply`), then loads the result in the Spark viewer.
+
+**Proven live 2026-07-11** (in-browser, City 3D): AOI = Manhattan → click →
+`sfm 20%` → `Done — 268,324 Gaussians` in ~6 s → a real splat of the Manhattan
+grid rendered (screenshot). Backend-direct: 267,318 Gaussians, valid INRIA `.ply`.
+
+Coverage = anywhere the keyless satellite tiles cover ≈ the whole world.
+Single-view feed-forward yields a **2.5D relief** splat (true multi-view towers
+need per-city imagery that isn't keyless/global — use Reconstruction Studio
+multi-view or `POST /api/recon/sat` for that). Real Gaussians, honest geometry.
+
+**Env note:** recon is a compute endpoint that **fails closed unauthenticated**
+(503: _"configure API_KEY / Supabase, or set `ALLOW_UNAUTHENTICATED=1`"_). For
+trusted local use boot the API with `ALLOW_UNAUTHENTICATED=1`; it also needs the
+GPU lab (`apps/ml/fusion/.venv`, else 503 "no recon GPU lab").
+
+## What we shipped: keyless whole-world OSM 3D buildings (auto-fill)
+
+The platform **already had** a keyless "Load 3D buildings here" button:
+`/api/intel/lod1?bbox=…` → public **Overpass** mirrors (no key) → real OSM
+footprints with `height` / `building:levels` → extruded + terrain-clamped in the
+Cesium globe, cached 12 h (`apps/api/app/intel/lod1.py`, `apps/web/src/lod1/`).
+
+The only gap vs "the whole world, not manual labour" was that it loaded one
+district per click. Added an **`Auto-fill as I pan (keyless)`** toggle
+(`useImagery.lod1Auto`): while on, GlobeCanvas re-extrudes the current viewport
+every time the camera settles below 100 km, debounced + move-gated
+(`LOD1_AUTO_MIN_MOVE_DEG`) so the public mirrors aren't hammered. Reuses the
+existing replace-in-place loader → one district shown at a time, bounded memory,
+revisits hit the 12 h cache.
+
+**Proven live 2026-07-11** (Vite :5173 + API :8000):
+- Overpass direct, Midtown Manhattan district: **1,213 buildings, 85% with real
+  OSM heights**, no key.
+- `/api/intel/lod1?bbox=` Midtown: **1,213 extrudable features, 1,036 OSM
+  heights**, 490 KB GeoJSON.
+- In-app: enabling auto-fill + flying to Manhattan extruded a **9,000-building**
+  datasource with zero clicks; panning to Lower Manhattan refreshed it to the
+  new district automatically (screenshots showed full 3D Midtown w/ Central Park
+  and Lower Manhattan w/ Holland Tunnel + live AIS vessels compositing on top).
+
+Coverage = anywhere OpenStreetMap has building footprints ≈ every city on Earth.
+Fidelity = flat-shaded extruded boxes (LOD1), **not** photoreal, **not** splats —
+the honest cost of "keyless + whole-world".
+
+## Verified keyless splat scene sources (for the per-scene option)
+
+All probed 2026-07-11 for HTTP 200/206 + a CORS header a browser fetch accepts
+(`access-control-allow-origin: *`, or HF reflecting the request Origin). Paste
+into City 3D → "LOAD FROM URL":
+
+- `https://sparkjs.dev/assets/splats/butterfly.spz` — 4 MB, ACAO `*`.
+- `https://antimatter15.com/splat-data/train.splat` — 32 MB, ACAO `*`.
+- `https://media.reshot.ai/models/nike_next/model.splat` — 9 MB, ACAO `*`.
+- `https://huggingface.co/datasets/dylanebert/3dgs/resolve/main/<scene>/<scene>-7k.splat`
+  — Mip-NeRF 360 scenes (`bonsai` 35, `room` 35, `counter` 31, `kitchen` 51,
+  `garden` 134, `bicycle` 110, `stump` 116 MB); HF reflects Origin → CORS-ok.
+- Browse for more: [SuperSplat library](https://superspl.at/) (splats tagged
+  *Downloadable* are CC — use the `.ply`/`.sog` URL) and
+  [Hugging Face splat datasets](https://huggingface.co/datasets?search=gaussian+splatting)
+  (use the file's `resolve/main/…` direct URL).
+
+These are research/demo scenes (Mip-NeRF 360, Tanks & Temples), not cities —
+because compact, browser-loadable, keyless *city-scale* splats basically don't
+exist yet; city 3DGS (CityGaussian, MatrixCity) ships as multi-GB aerial
+captures that need LOD streaming (Cesium/PlayCanvas), which needs a token.


### PR DESCRIPTION
## What

Two keyless (no API key, no account) paths to 3D-of-any-city on Earth, plus a README launch fix.

### 1. Globe — OSM buildings auto-fill as you pan
A new **"Auto-fill as I pan (keyless)"** toggle extrudes OSM building footprints (public Overpass mirrors, no key) for the current viewport every time the camera settles below 100 km — debounced and move-gated so the mirrors aren't hammered. Reuses the existing replace-in-place LOD1 loader, so memory stays bounded and revisits hit the 12 h cache. Coverage ≈ every city OpenStreetMap has footprints for.

### 2. City 3D — "Splat this city" from keyless satellite imagery
A pre-built global Gaussian-splat *stream* doesn't exist (Google/Apple planet-scale 3D is keyed mesh, not splats). The keyless whole-world answer is **on-demand generation**: stitch a satellite chip for any lat/lon from the keyless `/tiles/sat` proxy (Sentinel-2 + Esri, no key) and run it through the existing feed-forward recon engine (`POST /api/recon/jobs mode=mapany`, MapAnything) to produce a real Gaussian splat, shown in the Spark viewer. **No backend change** — pure reuse of the recon pipeline.

Single-view feed-forward yields a 2.5D relief splat (honest in the UI); true multi-view towers need per-city imagery that isn't keyless/global — Reconstruction Studio / `POST /api/recon/sat` cover that.

### 3. README launch hygiene
- Quick Start `clone`/`cd` now use `osint-geospatial-console`, matching the `origin` remote and the plugin manifest (was pointing at a different repo URL).
- Clarified AIS coverage in the caveat block + Scope and limits.

## Notes / trade-offs
- The `docs/gaussian-splat-free-sources.md` file records the full landscape and the keyless/whole-world/splats trilemma.
- Recon endpoints fail closed unauthenticated — for local generation the API must run with `ALLOW_UNAUTHENTICATED=1` and the GPU lab (`apps/ml/fusion/.venv`).

## Verification
- `pnpm -r typecheck` clean; web lint clean; **256/256** web unit tests (added city + store cases).
- Proven live in-browser: OSM auto-fill extruded 9k buildings over Manhattan with zero clicks and refreshed on pan; "Splat this city" over Manhattan produced **268,324 Gaussians** in ~6 s and rendered.