### PR TITLE
Rot fixes and launch campaign plan: dead vessel probe, compose loopback, email channel, 5k-star playbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,12 +101,13 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1539 passed + 1 skipped** (the skip is the opt-in live probe;
-  measured 2026-07-12 on branch infra-country-facility-wave after the
-  bug-hunt fix wave — evidence-locker SSRF/XSS/tamper-export/custody-prune
-  hardening — up from 1536 after the selection-brief enrichment-fusion wave,
-  1533 after the evidence-locker + case-export wave, 1507 after the bug-fix
-  wave (PR #38) and 1294 on w5-places-airspace-enrichment).
+  Baseline: **1540 passed + 1 skipped** (the skip is the opt-in live probe;
+  measured 2026-07-12 on branch rot-fixes-launch-plan after the rot-fix wave
+  — dead vessel probe, compose loopback binding, email-channel rejection —
+  up from 1539 after the evidence-locker hardening wave, 1536 after the
+  selection-brief enrichment-fusion wave, 1533 after the evidence-locker +
+  case-export wave, 1507 after the bug-fix wave (PR #38) and 1294 on
+  w5-places-airspace-enrichment).
   Never commit below the baseline you inherited; update this number when you raise it.
 - `pnpm -r typecheck` green at every commit boundary. `bash scripts/verify.sh`
   = typecheck + lint + web unit + api tests in one command.

--- a/apps/api/app/routes/alert_rules.py
+++ b/apps/api/app/routes/alert_rules.py
@@ -12,10 +12,10 @@ a minimum severity + a delivery channel. Two backends, selected by the same
     cloud project can still define + persist a watch rule (W3, 2026-07-11:
     docs/decisions.md).
 
-``channel`` now includes ``discord`` / ``webhook`` (a ``sink_url`` — a Discord
-webhook URL or a generic endpoint) alongside the existing ``inapp`` / ``email``;
-delivery is performed by the watch evaluator (``intel/watch.py``), not this
-route — this module is CRUD-only.
+``channel`` is ``inapp`` / ``discord`` / ``webhook`` (the latter two take a
+``sink_url`` — a Discord webhook URL or a generic endpoint); delivery is
+performed by the watch evaluator (``intel/watch.py``), not this route — this
+module is CRUD-only. ``email`` is rejected at creation until a sender exists.
 """
 
 from __future__ import annotations
@@ -39,7 +39,9 @@ KINDS = {
 # discord/webhook deliver a firing to a sink_url; the watch evaluator does the
 # actual POST (see intel/watch.py::_deliver_sinks) reusing the Workflows
 # control.py HTTP primitive — no new client, no new dependency.
-CHANNELS = {"inapp", "email", "discord", "webhook"}
+# "email" is deliberately absent: nothing sends email yet, and a rule that
+# silently never delivers is worse than a 400 at creation (2026-07-12).
+CHANNELS = {"inapp", "discord", "webhook"}
 
 
 def _use_local(s: Settings) -> bool:
@@ -76,6 +78,11 @@ def _validate(body: AlertRuleIn) -> None:
     bad = [k for k in body.kinds if k not in KINDS]
     if bad:
         raise HTTPException(status_code=400, detail=f"unknown kinds: {bad}")
+    if body.channel == "email":
+        raise HTTPException(
+            status_code=400,
+            detail="email delivery is not implemented yet — use 'discord' or 'webhook'",
+        )
     if body.channel not in CHANNELS:
         raise HTTPException(status_code=400, detail="unknown channel")
     if body.channel in ("discord", "webhook"):

--- a/apps/api/tests/test_alert_rules.py
+++ b/apps/api/tests/test_alert_rules.py
@@ -69,6 +69,17 @@ def test_create_rejects_bad_channel(client: TestClient) -> None:
     assert r.status_code == 400
 
 
+def test_create_rejects_email_until_a_sender_exists(client: TestClient) -> None:
+    # "email" used to be accepted and then silently never delivered (nothing
+    # sends it). Accepted-but-dead is worse than an honest 400 at creation.
+    r = client.post(
+        "/api/alerts/rules",
+        json={"label": "x", "lat": 1, "lon": 2, "channel": "email"},
+    )
+    assert r.status_code == 400
+    assert "not implemented" in r.json()["detail"]
+
+
 def test_create_rejects_discord_without_sink_url(client: TestClient) -> None:
     r = client.post(
         "/api/alerts/rules",

--- a/apps/web/src/timeline/CoverageStrip.test.tsx
+++ b/apps/web/src/timeline/CoverageStrip.test.tsx
@@ -1,9 +1,8 @@
 // Component tests for the coverage heat-strip. apiFetch is mocked at the
 // transport boundary (mirrors CountriesPanel.test.tsx / OsintEntityPanel.test.tsx),
-// routed by URL — no real network involved. The backend for
-// GET /api/history/coverage is being built in a parallel slice, so these tests
-// exercise the frontend purely against the documented response shape
-// (docs/replay-flagship-plan.md §2).
+// routed by URL — no real network involved. The GET /api/history/coverage
+// backend is live (routes/history.py); these tests exercise the frontend
+// against its response shape (docs/replay-flagship-plan.md §2).
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,10 @@ services:
       # Single-box DEV default: serve the compute/LLM endpoints on a keyless
       # boot instead of 503-ing them. Without this the advertised quickstart
       # hits dead Reports tabs and any LLM-backed feature. Safe here because
-      # this stack is loopback-only and explicitly "do NOT expose to the
-      # internet" (see banner above). A .env with API_KEY/Supabase makes this
-      # irrelevant (real auth takes over). The UI shows an open-mode banner.
+      # nginx publishes on 127.0.0.1 only (see the ports mapping below) and
+      # the stack is explicitly "do NOT expose to the internet" (banner
+      # above). A .env with API_KEY/Supabase makes this irrelevant (real
+      # auth takes over). The UI shows an open-mode banner.
       # For a hardened deployment (docker-compose.prod.yml) leave it UNSET so
       # compute endpoints fail closed until a credential is configured.
       ALLOW_UNAUTHENTICATED: 1
@@ -85,7 +86,11 @@ services:
     image: nginx:1.27-alpine
     runtime: runc
     ports:
-      - "8080:80"
+      # Loopback only: this dev stack runs with ALLOW_UNAUTHENTICATED=1, so a
+      # bare "8080:80" would hand open-mode compute routes (LLM, Workflows
+      # dispatch) to the whole LAN. Override to "8080:80" deliberately — or
+      # use docker-compose.prod.yml, which fails closed without a credential.
+      - "127.0.0.1:8080:80"
     volumes:
       - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:

--- a/docs/audits/2026-07-12-state-of-project.md
+++ b/docs/audits/2026-07-12-state-of-project.md
@@ -1,0 +1,221 @@
+# State of project — 2026-07-12
+
+Read-only audit. Working tree `evidence-locker-hardening-pr` @ `caa5eae`,
+content-identical to `origin/master` (`git diff HEAD origin/master` empty;
+HEAD is 0 ahead / 2 merge-commits behind). All evidence in this file was
+produced live this session unless a citation says otherwise.
+
+## Phase 0 — Ground truth
+
+**verify.sh: ALL GREEN, baseline matches exactly.** typecheck + lint pass,
+web unit 320/320 (52 files), ruff clean, **pytest 1539 passed + 1 skipped**
+— exactly the CLAUDE.md baseline (1539+1). No drift.
+
+**Live probes** (backend already up on :8000, so the `--live` additions were
+run standalone): `/api/adsb/global` returned 20 000 features (limit-capped;
+floor is 8 000) with **80% of 19 942 common ids refreshing `seen_pos_s` over
+8 s** — feeds healthy, blob not frozen. Sidecar :8093 serving vessels JSON;
+:8090 and :8000 listening. Finding: **verify.sh's `--live` vessel probe is
+dead** — it GETs `/api/ais/global` (`scripts/verify.sh:84`), which does not
+exist (AIS is WebSocket-push only, `routes/ais.py:204`); the probe has
+"skipped" on every run since it was written and will forever.
+
+**Branches: nothing is stranded.** All 40 PRs are merged; zero open
+(`gh pr list`). Every local branch is content-merged (squash-superseded;
+`git log --cherry-pick` right-only shows only patch-equivalent or
+squash-duplicated commits):
+
+| branch | merged as | status |
+|---|---|---|
+| evidence-locker-hardening-pr (HEAD) | PR #40 | merged 2026-07-12 |
+| evidence-locker-hardening | PR #39 | merged |
+| infra-country-facility-wave | PRs #37, #38 | merged |
+| local-ai-engine-model-manager | PR #36 | merged |
+| w5-places-airspace-enrichment | PR #35 | merged |
+| w4-ontology-autopopulation | PR #34 | merged |
+| roadmap-first-users | PR #33 | merged |
+| keyless-city-splats | PR #32 | merged |
+| workflows-city-foundry-overhaul | PRs #27, #31 | merged |
+| workflows-external-control | PRs #29, #30 | merged |
+| add-photo-geolocation-pipeline | PR #26 | merged |
+| mcp-context-variants-plugin | PR #25 | merged |
+| fix-flaky-dossier-age-assert / fix-readme-phase-status | PRs #28, #23 | merged |
+| sense-making-cycle / foundry-data-layer | PRs #20–#22 | merged |
+| gotham-* / feat/deepseek-* / backup/* | PRs #1–#2 era | historical snapshots |
+
+Local `master` is stale at `540a13a` (PR #32 tip, 8 PRs behind). No stashes.
+**The only uncommitted artifact in the entire repo is
+`docs/launch-posts-draft.md`** (386 lines, untracked).
+
+**Memory-index reconciliation** — every "UNCOMMITTED / NOT committed" flag
+checked against git: globe-toolbar-detach-panels, ai-overview-enrichment-
+fusion, evidence-locker-case-export → **ACTUALLY-MERGED** (PRs #39/#40,
+today); local-llm-engine → merged #36; dashboard-workflows-overhaul → merged
+#27/#29/#30/#31; mcp-plugin → #25; osint-source-expansion, foundry-layer,
+ontology-local-spine, gaussian-splat, roadmap-first-users → all merged
+(docs tracked: `roadmap-users-2026-07.md`, `osint-sources-plan.md`,
+`gaussian-splat-free-sources.md` all in `git ls-files`). **Nothing LOST.**
+MEMORY.md updated this session.
+
+**Invariants easiest to regress with a careless cleanup** (from
+`docs/decisions.md`):
+1. Live-path teleport vs **sanctioned replay interpolation**
+   (`decisions.md:567-580`) — twin traps: "fixing" replay to teleport breaks
+   trail rendering; citing replay to justify live-path glide is banned.
+2. `PollGeoJsonAdapter` upsert-by-id, never `removeAll()+add()` (eslint +
+   `invariants.test.ts`).
+3. `objects.props` wholesale-replace with provenance in append-only
+   assertions — the evidence locker's custody chain now rides this exact
+   contract (`intel/evidence.py:221-237`); a "helpful" merge-on-upsert would
+   silently break chain-of-custody.
+4. Hot-blob discipline: internal callers use `global_snapshot()`, semaphore
+   stays 8, `_parse_ac` rejects non-JSON (`tests/test_invariants.py`).
+5. `allow_unauthenticated` defaults **False** (`config.py:163`) — fail-closed
+   everywhere except the dev compose stack (see Phase 2).
+
+## Phase 1 — Built vs trusted
+
+| subsystem | status | evidence |
+|---|---|---|
+| Globe feeds (ADS-B/AIS/sats) | **proven-live** | this-turn probe: 20k aircraft, 80% refresh/8 s; :8093 vessels JSON |
+| Evidence locker (backend) | proven by tests | 20 tests `test_evidence.py`; SSRF guard `evidence.py:335-352` incl. `::ffff:` metadata bypass; tamper-409 re-hash `:154-163` |
+| Evidence locker (frontend) | **plumbed-unverified** | mounted at `reports/ReportsApp.tsx:19`; never browser-driven |
+| Case export (HTML/JSON/PPTX) | **plumbed-unverified** | 8 tests `test_case_export.py`; export button never clicked in a real browser |
+| Replay/archive | **plumbed-unverified** (new parts) | `ARCHIVE_MODE` lifts clamp (`history.py:89`), coverage endpoint (`routes/history.py:69`) + "recording since · GB · fixes" chip (`Timeline.tsx:319-320`) exist; archive default OFF, compose sets 48 h retention; base replay validated 2026-06-20 warsim, the new scrubber dressing is not |
+| Keyless alerts + sinks | proven-live (2026-07-11) | real POST logged, `decisions.md:629-632`; guards in `test_watch.py`/`test_alert_rules.py`. Email channel = **not-built** (validated at route, nothing sends) |
+| Ontology spine + auto-mint | proven by tests | `ontology_local.py:142`; mint callers in 9 files (watch, evidence, situations, osint, extract, countries, maps, workflows, actions). 24 h "graph fills itself" live probe never run |
+| Foundry | plumbed-unverified (FE) | backend tested; Workshop FE never browser-verified |
+| Workflows + control blocks | proven-live (2026-07-10) | 21 block types; 49 tests; drone/device dry-run in preview (`blocks.py:90`, `EditorView.tsx:228`); control path proven live per memory |
+| Watch-officer | built | briefs are an in-memory dict `watch_officer.py:45` — **documented design, not rot** (docstring `:8-12`: the loop re-derives briefs next cycle; `incident_store` diff state is also process-memory, so post-restart incidents re-file as "new"). Corrected from this audit's first draft. |
+| Local-LLM brief fusion | plumbed-unverified | route + 13 tests (`ai_selection.py`); requires an active local engine to prove |
+| 3DGS satToSplat | proven-live once | 268 324 Gaussians, `decisions.md:561-562`; GPU-lab-gated |
+| Docker self-host | **plumbed-unverified** | compose exists; a stranger's clean-clone boot has never been demonstrated |
+
+**Moat thesis** (`docs/roadmap-users-2026-07.md`, one sentence): *the fusion
+globe is commoditized (World Monitor et al.); the moat is self-hosted +
+keyless + unlimited locally-owned history/replay + a provenance-first
+investigation layer.*
+
+**Trace test** — 198 commits on origin/master in the last 30 days. The
+pre-roadmap month split between moat depth (foundry, ontology, workflows,
+local-LLM, replay substrate) and commoditized surface the roadmap itself
+later banned (§5.5): country catalog #24, places/airspace #35, infra layers
+#37, city splats #32. Since the roadmap landed (2026-07-11 06:27), the trace
+is clean: #36 (self-hosted LLM = identity), #38 (launch polish), #39/#40
+(evidence locker + case export = demand-rank #6 + the provenance substrate,
+plus the W2 README rebuild). **But the roadmap's own top item — W1 archive
+flagship + W2 "be seen" — is at 0% executed**: archive mode is default-off
+even in compose, the launch posts exist only as an untracked draft, and the
+launch gate (stars/engagement in 30 days) hasn't started counting. Effort is
+converging on the moat; the step that converts it into users hasn't been
+taken.
+
+## Phase 2 — Rot, risk, debt
+
+1. **Most likely to break in front of a real user this week: the stranger's
+   `docker compose up`.** It is the entire launch funnel and it is
+   plumbed-unverified. Known failure shape: datacenter/VPS egress is blocked
+   by exactly the feeds that make the globe look alive (airplanes.live /
+   adsb.fi Cloudflare-block datacenter IPs; adsb.lol 451s non-browser UAs —
+   `decisions.md:730-732`), so a VPS user boots to a near-empty globe and
+   posts "it's fake" — the community-calls-out-fakery failure the roadmap's
+   own research flags (§2 red flags).
+2. **Permissive-default gap:** `docker-compose.yml:34-36` justifies
+   `ALLOW_UNAUTHENTICATED: 1` as "safe here because this stack is
+   loopback-only" — but `ports: "8080:80"` (`:87-88`) publishes nginx on
+   **all interfaces**. A LAN peer (or a port-forwarded box) reaches open-mode
+   compute routes including Workflows external-actuation blocks
+   (`control.drone`/`control.device` dispatch on a real run; SSRF-guarded and
+   dispatch-capped, but open). One-line fix: `127.0.0.1:8080:80`.
+3. **Silent no-ops** (siblings of the deleted-Supabase-backend precedent):
+   the dead `--live` vessel probe (`verify.sh:84`, nonexistent endpoint,
+   reports "skipped" forever); the `email` alert channel (accepted at rule
+   creation, nothing ever sends — `decisions.md:639-641`); stale test
+   comment `CoverageStrip.test.tsx:4` claiming the coverage endpoint is
+   unbuilt (it's live). (Watch-officer brief volatility was listed here in
+   the first draft — reclassified as documented design; see Phase 1.)
+4. **Loss/collision risk: minimal.** Sole uncommitted file is the launch
+   draft (386 lines — cheap to lose, trivial to save). 16 stale local
+   branches + a local master 8 PRs behind are confusion risk (branching from
+   stale master), not data loss.
+5. **Hardening wave: finished vs open.** Shipped: SSRF guard with
+   IPv6-mapped-metadata handling (`evidence.py:335-352`), tamper-409 blob
+   verify (`:154-163`), custody-event uuid nonce (`:221-237`),
+   `test_security_hardening.py`. Open: no retry/backoff on failed alert
+   sinks (named-deferred), email channel, **MCP rate-limiting (W5's explicit
+   precondition before any public listing — not started)**, and the archive
+   disk-math ("GB/day, measured not guessed") never measured.
+
+## Phase 3 — Converge
+
+**Primary: launch-readiness sprint, then launch (roadmap W2, ~3–5 days).**
+Concretely: (a) stranger-boot test — clean clone on a fresh machine/VM,
+`docker compose up`, fix what breaks, bind nginx to loopback, add/verify the
+empty-globe diagnostic path for egress-blocked hosts; (b) browser-verify the
+two headline flows once each — replay scrubber with coverage chip, and
+evidence capture → case export download; (c) measure the GB/day archive
+math and decide the compose default (48 h vs archive profile) so the pitch
+matches the boot; (d) commit `docs/launch-posts-draft.md` and post
+r/selfhosted + Show HN.
+*Leverage:* maximal — the moat thesis is only tested by contact with users,
+and the roadmap's own decision gate cannot start until the posts exist.
+*Risk retired:* the fake/broken first-contact failure (#1 above) and the
+LAN-open default (#2). *Cost of delay:* World Monitor ships weekly against
+the same audience; every depth-week widens a moat nobody can see. *Skip:*
+PPTX polish, multi-domain scrub perf edge cases (aircraft-first per the W1
+kill criterion), any new layer or feed.
+
+**Secondary 1 (half a day): repo + guard hygiene.** Delete the 16
+content-merged local branches, fast-forward local master, fix the dead
+vessel probe (point it at a real signal — :8093 `vessels.json` count or a
+new HTTP count route), fix the stale CoverageStrip test comment.
+
+**Secondary 2 (one day): close the launch-surface silent no-ops.** Reject
+`email` at rule creation until it sends. (Watch-officer persistence was
+listed here in the first draft; dropped after verifying the volatility is
+documented, self-healing design.)
+
+**Rejected candidates and why:** dark-fleet productization (W6 is
+demand-gated by the roadmap itself; FleetLeaks sets an explainability bar we
+shouldn't rush); Ontology Home / analyst workspace (roadmap §5.1 — zero
+users, hollow graph); MCP marketplace listing (W5's own ordering: rate-limit
+first, and it's parity not moat); more feeds/layers (§5.5 — the last month
+already overspent here); flipping archive-on-by-default blind (do the disk
+measurement inside the primary instead).
+
+## Phase 4 — First action
+
+First command (not executed — this audit turn is read-only outside
+`docs/audits/` and memory): on a `launch-w2` branch,
+`git add docs/launch-posts-draft.md` + commit, then on a clean VM
+`git clone … && docker compose up` and watch :8080. **Proof of success:**
+the globe renders aircraft within ~60 s of a keyless boot on a machine with
+no repo `.env`, and `git status` no longer lists the draft. **Invariant most
+at risk while doing it:** the fail-closed `allow_unauthenticated` default —
+any "fix" to the compose stack must keep `docker-compose.prod.yml` failing
+closed (`config.py:163` stays False; only the dev stack opts in), and the
+jemalloc/`LD_PRELOAD` sidecar scrub must survive any Dockerfile edit
+(`tests/test_invariants.py` guards it).
+
+## Addendum (same day) — rot fixes applied
+
+Branch `rot-fixes-launch-plan` (off the fast-forwarded master):
+- `--live` vessel probe now reads keyless `/api/status` `vessel_count`
+  (55,080 live at fix time) instead of the nonexistent `/api/ais/global`.
+- Compose nginx binds `127.0.0.1:8080:80`; the "loopback-only" safety
+  comment is now true.
+- `email` alert channel rejected at rule creation with an explicit message
+  (+ guard test in `test_alert_rules.py`; baseline 1539 → 1540).
+- `CoverageStrip.test.tsx` stale comment corrected.
+- Watch-officer left untouched (documented design, above). Stale local
+  branches pruned; local master fast-forwarded.
+- Advertising plan for the 5k-star target: `docs/star-campaign-2026-07.md`.
+
+## Read-only probes executed this turn
+
+- `bash scripts/verify.sh` → ALL GREEN (1539+1s / 320 web / lint / typecheck).
+- ADS-B freshness probe → 20 000 features, 80% refresh over 8 s.
+- `/api/ais/global` → SPA HTML (route absent) — dead-probe finding.
+- :8090/:8093 listeners confirmed; :8093 returns vessels JSON.
+- Branch/PR reconciliation: `git branch --no-merged`, `--cherry-pick`
+  right-only scans, `gh pr list` (40 merged, 0 open).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -704,6 +704,34 @@ was no chain-of-custody capture primitive. Both now exist, backend-first.
   drafting is client-driven (frontend generates + human edits, export only
   renders the labeled result) so export stays deterministic + keyless.
 
+## Rot-fix wave: dead probe, compose binding, email channel (2026-07-12)
+
+Findings from the same-day state-of-project audit
+(`docs/audits/2026-07-12-state-of-project.md`), all small and behavioral:
+
+- **verify.sh `--live` vessel probe was dead since birth**: it GET
+  `/api/ais/global`, which has never existed (AIS is WS-push only,
+  `routes/ais.py`), so its bare `except` printed "skipped" on every run — a
+  guard that could never fire. Now reads keyless `/api/status`
+  `vessel_count` (the unified store's live count) and FAILS if the field
+  disappears. Lesson repeated from the Supabase-backend deletion: a probe
+  that can only skip is not a probe.
+- **docker-compose.yml published nginx on all interfaces** while its own
+  comment justified `ALLOW_UNAUTHENTICATED: 1` as "loopback-only". Now
+  `127.0.0.1:8080:80`; exposing wider is a deliberate operator override or
+  `docker-compose.prod.yml` (which fails closed). Open-mode compute routes
+  (LLM, Workflows dispatch) were LAN-reachable on any `docker compose up`
+  before this.
+- **`email` alert channel rejected at creation** (400 with an explicit
+  message) instead of accepted-and-never-delivered — closes the "Not done"
+  named in the 2026-07-11 keyless-alerts entry the honest direction until a
+  sender exists. Guard: `test_alert_rules.py::
+  test_create_rejects_email_until_a_sender_exists`. Baseline 1539 → 1540.
+- NOT changed, deliberately: watch-officer in-memory briefs (docstring
+  documents restart-rederivation and `incident_store` diff state is also
+  process-memory, so the story holds — the audit's first draft misread this
+  as rot); replay interpolation; anything guarded above.
+
 ## Lessons from past sessions (post-mortems)
 
 ### Never claim coverage/parity without a measurement

--- a/docs/launch-posts-draft.md
+++ b/docs/launch-posts-draft.md
@@ -1,0 +1,386 @@
+# Launch posts — draft (human voice, 90% info / 10% ad)
+
+Positioning discipline (from docs/roadmap-users-2026-07.md):
+lead with self-hosted + keyless + unlimited replay you own; never "AI-powered";
+label automation honestly; caveat the keyless feeds. Audience spots hype fast.
+
+---
+
+## 1. r/selfhosted
+
+**Title:** I got tired of flight/ship trackers paywalling history, so I self-hosted the whole thing — one Docker box, no API keys
+
+I run a little home-lab habit of watching planes and ships over conflict zones,
+and the same wall kept showing up: Flightradar24 gives you 7 days of history
+free, MarineTraffic quietly cut its free window from 72h to 24h last year, and
+ADS-B Exchange killed its free API tier. The live view is great right up until
+you want to ask "what was over here *yesterday*" — and then it's a paywall or
+it's just gone.
+
+So I built a self-hosted situation console that fuses live aircraft, ships,
+satellites and hazards (quakes, fires) onto one 3D globe, and — this is the part
+I actually care about — records everything locally so you can scrub back in time.
+Your archive lives on your disk. No vendor can shrink the window, filter it, or
+sell the company out from under you.
+
+Some notes for anyone who wants to poke at it:
+
+- **Keyless by default.** ADS-B comes from the community grid (airplanes.live /
+  adsb.lol), AIS from public sources, quakes from USGS, satellites from CelesTrak.
+  You can run the core with zero accounts and zero API keys. A few extras (NASA
+  FIRMS fire data, satellite imagery) want a free key but degrade gracefully
+  without one.
+- **History is the whole point.** Positions get written to a local SQLite/WAL
+  store with retention you configure by disk budget, not by someone's pricing
+  tier. Rewind the globe, replay a window, watch a track build up.
+- **It's a real box, so be honest about cost.** At full firehose it's ~13k
+  aircraft + tens of thousands of vessels; storage adds up over weeks. You size
+  the retention to whatever disk you're willing to give it.
+- **Runs on one machine.** FastAPI backend + a React/Cesium frontend + a couple
+  of scraper sidecars. Watch-lists and queries never leave your hardware.
+
+Caveats I'd want to know as a reader: the keyless feeds are community/public
+sources, so coverage is best where feeders are dense (Europe/US great, open
+ocean patchy). It's a heavy frontend — Cesium wants a GPU to feel smooth. And
+it's early; I'm mostly looking for people to break it and tell me what's missing.
+
+Not trying to replace your Grafana or your Frigate — this is a different itch
+(geospatial OSINT + a time machine). If that's your kind of thing, happy to
+share the compose file and answer setup questions in the comments.
+
+---
+
+## 2. r/OSINT
+
+**Title:** The most under-appreciated OSINT capability isn't a new source — it's owning your own history
+
+A pattern I keep hitting doing geospatial OSINT: the analysis you actually want
+is temporal. "This vessel went dark here — when, and what was nearby?" "This
+aircraft's pattern over three weeks." "Rewind to the hour of the incident."
+Almost every live tracker is built to show you *now* and monetizes the past.
+FR24 gates history, RadarBox charges for a year of it, ADSB-X removed its free
+API, MarineTraffic trimmed its free window. The moment your question has a
+timestamp, you're renting.
+
+So I've been building a self-hosted console around the opposite assumption: the
+live feed is table stakes, and the *archive you own* is the product. It fuses
+aircraft + ships + satellites + hazards on one globe, records positions locally,
+and lets you scrub back through whatever window your disk holds.
+
+Things that matter to this crowd specifically:
+
+- **Provenance over vibes.** Everything the tool derives is stored as
+  assertions with a source and a timestamp, in an append-only local table.
+  Anything automated is labeled automated. I deliberately did *not* build a
+  "the AI thinks this is suspicious" black box — after watching the practitioner
+  backlash against unlabeled AI "insights," that felt like a liability, not a
+  feature. If a detector flags something, you can see why.
+- **Evidence you can export.** There's a chain-of-custody-style evidence locker
+  so a finding carries its sourcing when it leaves the tool — built with
+  journalists/legal use in mind.
+- **A real investigation layer.** Local ontology (entities, relationships,
+  dossiers), detectors for things like AIS gaps / loitering, all on your box.
+- **Keyless.** No account to start. The ADS-B/AIS/quake/satellite spine works
+  with no API keys.
+
+Honest limits: coverage follows the public/community feeders, so it's strongest
+over land in dense-feeder regions and thin over open ocean; dark-vessel
+detection is a helper, not a verdict — treat it as a lead, corroborate with
+imagery. And I'm one person; the depth is real but the polish is uneven.
+
+I'm posting mostly to sanity-check the premise with people who do this seriously:
+is "unlimited local history you own" the thing, or am I over-indexing on it?
+Would genuinely like the pushback. Can share the repo/compose if there's interest.
+
+---
+
+## 3. X / Twitter (thread)
+
+1/
+Flightradar24: 7 days of history free.
+MarineTraffic: cut its free window 72h → 24h.
+ADS-B Exchange: killed its free API tier.
+
+The live map is never the paywall. Your *past* is. So I self-hosted a tracker
+that records everything locally and lets you rewind. 🧵
+
+2/
+It fuses live aircraft ✈️ ships 🚢 satellites 🛰️ and hazards 🔥 onto one 3D
+globe — the fused "conflict globe" is a commodity now, plenty of those exist.
+
+The part nobody self-hostable offers: unlimited local history. Scrub back to any
+hour your disk can hold. You own the archive.
+
+3/
+Keyless by default. ADS-B from the community grid, AIS from public sources,
+quakes from USGS, sats from CelesTrak. No account, no API key to boot the core.
+
+Watch-lists and queries never leave your machine. No vendor can filter, shrink,
+or rug-pull the data.
+
+4/
+Design choice I'll defend: no unlabeled "AI thinks this is sus" box. Everything
+derived is stored as a sourced, timestamped assertion; anything automated is
+labeled automated. This audience (rightly) distrusts magic. Provenance > vibes.
+
+5/
+Honest caveats, because you'd find them anyway:
+– coverage follows public feeders (great over land, patchy mid-ocean)
+– Cesium globe wants a GPU
+– storage grows with retention — you size it to your disk
+– it's early and rough
+
+6/
+Runs on one box: FastAPI + React/Cesium + a couple sidecars, `docker compose up`.
+
+Not trying to out-feature the cloud trackers. Competing on the one axis they
+structurally can't: local-first, private, and replayable — the open world,
+recorded, that you actually own.
+
+Repo + setup in replies if you want to break it. 👇
+
+---
+
+## 4. Hacker News — Show HN
+
+**Title:** Show HN: A self-hosted live world tracker that records unlimited local history
+
+I built a self-hosted situation console: live aircraft, ships, satellites and
+hazards fused on one 3D globe, recording every position to a local store so you
+can rewind and replay any window your disk holds.
+
+The fused live globe itself isn't novel — there are several open-source ones and
+at least one polished commercial product (World Monitor). What I couldn't find
+anywhere was the thing I actually wanted: **unlimited history that I own.** Every
+commercial tracker paywalls the past — FR24 at 7 days, RadarBox at a paid year,
+ADS-B Exchange removed its free API, MarineTraffic cut its free window in 2025.
+A cloud vendor structurally can't give away unlimited history; a self-hosted
+tool can, because it's your disk.
+
+How it's built:
+- FastAPI backend, React + CesiumJS frontend, a couple of scraper sidecars.
+- Keyless core: airplanes.live/adsb.lol for ADS-B, public AIS, USGS quakes,
+  CelesTrak for satellites (client-side SGP4 propagation). Optional free keys
+  for NASA FIRMS and satellite imagery; degrades gracefully without them.
+- Positions written to SQLite/WAL with retention sized by a disk budget you set.
+- An investigation layer on top: a local ontology with sourced, append-only
+  assertions (provenance is first-class), detectors, dossiers, evidence export.
+
+Two opinions baked in that I'd be happy to argue about:
+1. No unlabeled AI "insights." Anything automated is labeled automated and
+   carries its source. The target audience treats black-box "this looks
+   suspicious" output as a liability, and I agree.
+2. The archive is the product, not the live view. The live view is table stakes.
+
+Honest limitations: coverage tracks the public/community feeders, so it's strong
+over dense-feeder regions (Europe, US) and thin over open ocean; the Cesium
+frontend needs a GPU to feel good; storage grows with retention; and it's the
+work of essentially one person, so depth is uneven and there are rough edges.
+There's no public demo instance on purpose — feed-redistribution ToS and the
+OPSEC/DDoS surface aren't worth it — so it's video/GIF + self-host for now.
+
+I'd love feedback on one question in particular: is "own your history" the right
+hill, or is the live fusion enough for most people? Repo and a docker-compose in
+the comments.
+
+---
+
+## 5. Mastodon / short-form (fediverse, low-key)
+
+Self-hosted OSINT thing I've been building: live planes/ships/sats/hazards on
+one 3D globe, but it records everything locally so you can rewind time.
+
+The pitch is boring on purpose — every cloud tracker paywalls history (FR24 = 7
+days, ADSB-X killed its free API). Self-hosting means the archive is yours, sized
+to your disk, no API key to start.
+
+Keyless core, provenance-first (no black-box "AI says sus"), runs in one compose
+file. Early and rough. Coverage follows public feeders so it's patchy over open
+ocean — being upfront about that.
+
+Boosts welcome if you know someone who'd want to break it. 🌍
+
+---
+
+## 6. r/DataHoarder  (written in the format of the pinned "Gaza archive" post — numbers-forward title, preservation framing, NOT an ad)
+
+**Title:** Self-hosting the timeline of the physical world: ~13,000 aircraft + ~50,000 ships tracked live, every position written to local disk, rewind/replay any window, keyless (no API key, no account), append-only SQLite/WAL you own, GB/day you control | Built it because every flight & ship tracker paywalls or deletes its own history — this keeps it.
+
+The single most hoardable dataset on Earth is *where everything is, minute by
+minute* — and every company collecting it throws it away or paywalls it.
+Flightradar24 keeps 7 days of history for free users. MarineTraffic cut its free
+window from 72h to 24h in 2025. ADS-B Exchange removed its free API tier in
+March 2025. RadarBox charges for a year of it. The live world scrolls past and
+the past is deleted or rented back to you.
+
+So I've been building a self-hosted recorder that captures it locally, forever
+(or until your disk says stop), and lets you scrub back through it. Sharing it
+here because this is the one sub that gets *why* that matters.
+
+What it captures, continuously, to your machine:
+
+- **Aircraft:** the community ADS-B grid (airplanes.live / adsb.lol) — on the
+  order of ~13,000 aircraft airborne worldwide at any moment.
+- **Ships:** public AIS sources, roughly ~50,000 distinct vessels (MMSI-deduped
+  union of the keyless feeds).
+- **Satellites:** CelesTrak TLEs, propagated with real SGP4 orbital mechanics.
+- **Hazards:** USGS earthquakes, NASA FIRMS fire hotspots (optional free key).
+
+The storage/archival specifics — the part that matters here:
+
+- **Append-only local SQLite + WAL.** Every position is a row. Nothing phones
+  home; the archive is a file you can back up, move, and grep like any other.
+- **Retention = a disk budget YOU set**, not a pricing tier. Set the ceiling to
+  `0` and it never prunes — hoard indefinitely.
+- **Rewind/replay:** a timeline scrubber replays any window still on disk — watch
+  a track rebuild, an AIS gap open, an incident hour play back.
+- **Keyless core:** no account, no API key to start recording. Runs on one box
+  via `docker compose up`.
+- **Byte math (honest estimate, measurements pending):** at full firehose it's
+  on the order of a few GB/day depending on dedup/retention settings. I'll post
+  real measured numbers rather than guesses — but the point is *you* choose the
+  fidelity/size tradeoff, not a vendor.
+
+Caveats, up front so nobody feels sold to: coverage is only as good as the public
+community feeders — dense over land and populated coasts, sparse over open ocean;
+it's compute-heavier than a text scrape (the Cesium globe wants a GPU on the
+client); and the exact GB/day figures are still being nailed down. This is a tool
+I built, not a finished dataset dump — flagging that plainly because rule 6, and
+because you'd (rightly) call it out otherwise. If "own the recorded timeline of
+everything that moves" is your kind of hoard, I'd love storage-tuning ideas and
+someone to sanity-check my byte math. Repo + compose file in the comments.
+
+---
+
+## 7. r/ADSB
+
+**Title:** Built a keyless self-hosted globe that overlays the community ADS-B grid with ships/sats and records it all for replay
+
+Most of us here already feed and already stare at tar1090/dump1090. This is a
+layer on top of that world, not a replacement for it, so I'll keep it technical.
+
+It pulls the community aggregators (airplanes.live, adsb.lol) for global breadth
+plus grid overlays, dedups, and renders category icons on a Cesium globe with
+proper track/heading rotation — then fuses ships (public AIS), satellites
+(CelesTrak, client-side SGP4) and hazards on the same view. Keyless: no account,
+no API key for the core feeds.
+
+The reason I built it, and the r/ADSB-relevant bit:
+
+- **It records.** Every position goes to a local store so you can rewind the
+  globe and replay a window — an aircraft's pattern over hours/days, not just the
+  live sweep. Retention sized by your disk, not a tier.
+- **Honest about the upstream rules.** adsb.lol 451s non-browser UAs;
+  airplanes.live throttles with HTTP 200 + text/plain (I reject non-JSON bodies);
+  CelesTrak 403s on bursts (cached 2h). The scraper respects all of that with a
+  burst semaphore so it's a polite consumer, not a hammer.
+- World payload is a pre-rendered gzipped blob served on a 1s poll + WS push, so
+  the globe stays live without pounding the aggregators per-client.
+
+Not competing with tar1090 — different job (multi-domain fusion + local replay).
+Genuinely want feedback from people who know these feeds cold: am I being a good
+citizen to the aggregators, and is local replay something you'd use? Compose file
++ repo in comments.
+
+---
+
+## 8. r/homelab
+
+**Title:** Weekend-ish homelab project: a live world-tracking globe that records its own history, one compose file, keyless
+
+Filing this under "things to run on the box that's already on." It's a
+self-hosted situation console — live aircraft, ships, satellites and hazards
+fused on a 3D globe — that records every position locally so you can rewind and
+replay. Think of it as a Frigate-for-the-outdoors: instead of NVR footage, it's
+the recorded movement of the physical world, on your hardware.
+
+Deployment shape:
+
+- `docker compose up` brings the FastAPI backend, the React/Cesium frontend, and
+  a couple of scraper sidecars up together.
+- Keyless core — community ADS-B, public AIS, USGS quakes, CelesTrak sats — so no
+  secrets management just to boot it. Optional free keys (NASA FIRMS fire data,
+  imagery) if you want them.
+- Stateful bit is a local SQLite/WAL positions store; back it up like any volume.
+  Retention sized to whatever disk you allocate.
+- Resource honesty: the backend is fine on modest hardware, but the Cesium
+  frontend wants a GPU on the *client* to be smooth, and storage grows with
+  retention. Not a Pi-zero job at full firehose.
+
+It's early and there are rough edges — mostly posting to find homelabbers who'll
+run it, tell me the deploy friction, and file issues about their setup. Compose
+file in comments; happy to help anyone get it booting.
+
+---
+
+## 9. r/Python
+
+**Title:** Show and Tell: a keyless, self-hosted OSINT globe (FastAPI + Cesium) that records the live world for replay
+
+Sharing a project that's grown into a decent-sized Python codebase and might be
+interesting to poke at architecturally.
+
+It's a self-hosted console that fuses live aircraft/ships/satellites/hazards on a
+3D globe and records every position locally so you can rewind time. The Python
+side is where most of the interesting problems live:
+
+- **FastAPI backend** serving a pre-rendered, gzipped world snapshot on a 1s poll
+  + WebSocket push, with a sticky-snapshot pattern so N clients don't multiply
+  upstream load.
+- **Polite scraping** of rate-limited community feeds: burst semaphore, per-host
+  UA rules, rejecting throttle responses that come back as HTTP 200 + text/plain,
+  IPv4-pinned httpx clients. Lots of "the upstream lies to you" defensive code.
+- **Satellites** via client-side SGP4 propagation (real orbital mechanics, not
+  faked motion) fed from CelesTrak TLEs.
+- **A local ontology** in SQLite: append-only assertions with provenance,
+  detectors, dossiers — the investigation layer.
+- ~1500 pytest tests gating a set of hard invariants (the feed quirks above are
+  each pinned by a guard test, because every one of them regressed at least once).
+
+Keyless by default; runs on one box via docker compose. It's opinionated
+(provenance-first, no black-box AI output) and still rough in places. Mostly
+looking for Python folks to critique the scraping/snapshot architecture and the
+test strategy. Repo in comments.
+
+---
+
+## 10. r/gis / r/geospatial
+
+**Title:** A self-hosted CesiumJS globe that fuses live ADS-B/AIS/satellite/hazard feeds and records them for temporal replay
+
+Geospatial-flavored share. It's a self-hosted situation console built on CesiumJS
+that pulls multiple real-time feeds onto one 3D globe and — the part I think is
+under-served in this space — persists the positions locally so you can scrub
+backward through time.
+
+Feed/geo specifics for this crowd:
+
+- Live layers: community ADS-B (aircraft), public AIS (vessels), CelesTrak
+  satellites propagated client-side via SGP4, USGS earthquakes, NASA FIRMS fire
+  hotspots (optional free key), plus basemaps from Carto.
+- Rendering: category SVG icons with correct bearing rotation (track for
+  aircraft, COG/heading for vessels), selection polylines, world-view decimation
+  by stable hashing so the entity set doesn't churn on zoom.
+- **Temporal:** every position is written to a local store; a timeline scrubber
+  replays any window your disk retains. Most live map tools are stateless — this
+  one keeps its own history.
+- Keyless core, self-hosted, one compose file. Data stays on your machine.
+
+Honest limits: coverage is bounded by public/community feeders (dense over
+land, thin over open ocean), and Cesium wants a GPU. Looking for GIS folks to
+critique the rendering/decimation approach and tell me what temporal-geo
+workflows you'd want. Repo in comments.
+
+---
+
+## 11. r/geopolitics & r/CredibleDefense — NOTE, don't hard-sell
+
+These subs ban/heavily moderate self-promotion and low-effort links. Do **not**
+drop an ad. Two legitimate routes:
+- Post genuinely useful *analysis* that happens to use the tool (e.g., an
+  annotated replay of a real air/maritime event), with the tool mentioned only as
+  methodology in a comment if asked. Value first, link maybe.
+- Answer existing "how do I track X" questions with a real, sourced how-to and
+  mention the self-hosted option as one of several, alongside FR24/ADSB-X/etc.
+Anything that reads as marketing will (correctly) get removed. Skip these until
+you have a concrete, shareable analysis artifact.

--- a/docs/star-campaign-2026-07.md
+++ b/docs/star-campaign-2026-07.md
@@ -1,0 +1,332 @@
+# Star campaign — 5,000 GitHub stars (2026-07-12)
+
+Operator target: **5,000 stars.** This plan is the distribution half of
+`docs/roadmap-users-2026-07.md` (W2), expanded into an executable playbook:
+the math, the assets, the channel sequence with dates, the copy, the
+measurement loop, and the anti-patterns that would get the project banned or
+laughed at. Positioning discipline is inherited and non-negotiable: lead with
+**self-hosted + keyless + unlimited replay you own**; never "AI-powered";
+label automation; caveat the feeds; human voice everywhere.
+
+---
+
+## 1. The honest math of 5,000 stars
+
+5,000 stars puts a repo in roughly the top 0.5% of GitHub. It is reachable
+for a self-hosted tool with a strong demo — Uptime Kuma, Dawarich,
+ArchiveBox, SpiderFoot (~13k) all cleared it — but not from one launch post.
+The realistic decomposition:
+
+| Source | Stars (realistic range) | When |
+|---|---|---|
+| Show HN, front page (top-10 for hours) | 800–2,500 | launch week |
+| Show HN, modest (page 2, 30–80 points) | 100–400 | launch week |
+| r/selfhosted strong post (500+ upvotes) | 150–500 | launch week |
+| r/OSINT + r/ADSB + r/homelab variants | 50–200 | weeks 1–3 |
+| GitHub Trending (daily/weekly) — triggered by launch velocity | ×1.5–2 multiplier on the wave | launch week, if >~150 stars/day |
+| awesome-selfhosted + awesome-OSINT + directory drip | 10–40/week, compounding | from week 3, indefinitely |
+| Newsletters (Self-Host Weekly, Week in OSINT, Console.dev) | 50–300 each | weeks 2–6 |
+| One YouTube review from a self-hosted channel | 100–600 | weeks 3–8 |
+| Timely case-study posts (replay of a real event) | 50–400 each | ongoing |
+| Second Show HN at a major release (new headline feature) | 300–1,200 | month 3–5 |
+| Baseline drip once >1k stars (search, similar-repo, trending residue) | 100–300/month | ongoing |
+
+**Median path: ~1,000–1,800 stars in month 1, 5,000 around month 4–7.**
+A first-launch flop (sub-200 total) triggers the roadmap's 30-day gate:
+stop building, fix positioning, relaunch. Do not spend the gate window
+adding features. Anything promising 5k in "2 weeks" involves fraud (§9).
+
+Two structural facts to exploit:
+1. **Velocity's demo is intrinsically viral-shaped.** A dark 3D globe with
+   20k live aircraft that *rewinds time* GIFs better than 95% of self-hosted
+   tools (a dashboard can't do this). The GIF is the campaign.
+2. **The audiences already exist and already hate the paywalls** (FR24 7-day
+   history, MarineTraffic 72h→24h cut, ADS-B Exchange API kill). The pitch
+   isn't "new tool", it's "the thing you're angry about, solved, on your box."
+
+## 2. Pre-launch: make the repo convert (week 0, gate for everything else)
+
+A launch post is a firehose pointed at the README for ~6 hours. Visitors
+star or bounce in ~20 seconds. Everything here is about that 20 seconds.
+
+**2.1 The funnel target.** Post → repo visit converts at 5–15%. A front-page
+HN day is 30–80k views → 5–15k repo visits → 500–1,500 stars *if the README
+lands*. Halving README quality halves the campaign. This is the highest-ROI
+work in the whole plan.
+
+**2.2 README surgery** (current README is feature-complete but depth-first;
+launch needs conversion-first):
+- **Above the fold:** one hero GIF (≤10 MB, 15–25 s loop): globe spins →
+  zoom to a hotspot → click an aircraft → dossier opens → **scrub the
+  timeline backwards, tracks rewind**. The rewind IS the differentiator —
+  it must be in the first screenful. Record at 1440p, encode with gifski
+  (or an `<video>`-in-README mp4, which GitHub now renders — smaller and
+  sharper than GIF).
+- Three sentences, verbatim discipline from the roadmap's value statement:
+  self-hosted situation console; live aircraft/ships/satellites/hazards on
+  one 3D globe; unlimited local history you can rewind — no account, no API
+  key, no vendor able to paywall your archive.
+- `git clone … && docker compose up` → `http://localhost:8080` as the third
+  block. Nothing before it but the GIF and the pitch.
+- **Comparison table** (converts skeptics; keep it factual, cite dates):
+  history depth / self-hosted / API keys / replay — Velocity vs FR24 vs
+  MarineTraffic vs ADS-B Exchange vs World Monitor. Every cell verifiable.
+- **Honest-caveats block** (this audience stars honesty): community feeds =
+  dense over EU/US, patchy open ocean; Cesium wants a GPU; VPS datacenter
+  IPs get blocked by some ADS-B mirrors (link the FAQ entry); satellite
+  imagery layers need free keys.
+- Badges: CI green, license, latest release, Docker. No star-count badge
+  yet (looks needy under 1k), add at ~2k.
+- Move the current deep feature tour below the fold; it's good retention
+  content, wrong first impression.
+
+**2.3 Repo furniture** (GitHub's own distribution surfaces):
+- **Name check (decide once, before launch):** repo is
+  `osint-geospatial-console`, product says "Velocity". Pick the memorable
+  one, make the other a tagline. A rename after launch burns inbound links.
+  ("Velocity" has collisions in dev tooling; verify searchability — if
+  keeping it, always pair as "Velocity — self-hosted OSINT console".)
+- Social preview image (Settings → set the hero frame; this is what every
+  Slack/Discord/Twitter unfurl shows).
+- Topics: `self-hosted`, `osint`, `adsb`, `ais`, `flight-tracking`,
+  `ship-tracking`, `cesium`, `geoint`, `situational-awareness`, `docker`.
+  These feed GitHub topic pages and Explore.
+- `LICENSE` prominent; `CONTRIBUTING.md` (build, verify.sh, PR
+  expectations); issue templates (bug / feed-problem / feature); enable
+  Discussions (Q&A category for setup help — keeps issues clean).
+- Seed **8–12 `good-first-issue`s** (real, small: a panel polish, a doc
+  gap, a new keyless connector from the skip-list). Contributors are
+  super-stargazers: each PR author brings watchers.
+- Community space: one Discord server (or Matrix bridge), three channels
+  max (#setup-help, #showcase, #dev). Link in README. Empty is fine; it
+  fills during launch week.
+- Tag a release: `v1.0.0` if the stranger-boot test passes cleanly, else
+  `v0.10.0` — with real release notes. HN respects honest versioning.
+
+**2.4 The stranger-boot gate** (from the state-of-project audit — this is
+the launch precondition, not a parallel task):
+- Clean VM, fresh clone, `docker compose up`, no `.env`: globe shows
+  aircraft within ~60 s. Fix what breaks.
+- The VPS/datacenter-egress case: boot on a cheap VPS, observe what a
+  cloud-hosting user sees. Ship the **empty-globe diagnostic** (feed-status
+  panel already exists — make the failure mode self-explanatory: "0
+  aircraft: this host's IP is blocked by community ADS-B mirrors; see
+  FAQ") so the worst first-contact outcome is an explained limitation, not
+  "it's fake".
+- Decide the archive default: measure GB/day at full firehose, then either
+  ship archive-mode-on with a disk budget, or keep 48 h and make the README
+  say exactly that ("unlimited *if you turn the dial*"). The pitch and the
+  boot must match — this community diffs claims against behavior for sport.
+
+**2.5 Asset kit** (produce once, reuse everywhere):
+- Hero GIF/mp4 (above) + 3 short GIFs: (a) replay scrub, (b) click→dossier
+  →evidence capture, (c) dark-vessel/AIS-gap detection view.
+- 90-second silent screen-capture video with captions (YouTube unlisted —
+  for embedding in posts and sending to reviewers).
+- 6–8 stills at 1440p (the `docs/media/` set is already strong).
+- A one-paragraph project boilerplate + the comparison table as an image
+  (for newsletters that don't render markdown).
+- Press-kit page in the repo: `docs/press-kit.md` linking all of it.
+
+## 3. Launch week (week 1) — sequence and mechanics
+
+Post drafts already exist in `docs/launch-posts-draft.md` (r/selfhosted,
+r/OSINT, +more) and follow the right voice. Mechanics:
+
+**Day −7 to −1:** join the communities you'll post in (r/selfhosted,
+r/OSINT, Trace Labs Discord, OSINT Curious, a couple of self-hosted
+Discords) and *participate normally* — answer two or three questions,
+comment on other tools. Drive-by self-promo from a fresh account is the #1
+cause of removed posts on r/selfhosted. Check each subreddit's self-promo
+rules the week of posting (r/selfhosted requires clear author-disclosure
+and interaction; some subs have "Show-off Saturday"-style windows).
+
+**Day 1 (Tuesday) — r/selfhosted.** Post the existing draft (title leads
+with the paywall pain, not the product name — correct). 9–11 am US Eastern.
+Author-disclose in the first line. Then **live in the comments for 8–10
+hours**: setup help, honest limitation answers, "good idea, filed as
+issue #N" (and actually file them — visible responsiveness converts
+lurkers). Do not link-drop the repo more than the post itself does.
+
+**Day 2 — r/OSINT** with its own draft (the "owning your history" angle —
+different thesis, not a crosspost). Same presence rules.
+
+**Day 3 or 4 (Wed/Thu) — Show HN.** 8–10 am ET (max weekday traffic window).
+- Title: `Show HN: Self-hosted flight/ship tracker with unlimited history
+  and replay` — concrete, no adjectives, no "AI", under 80 chars. Two
+  fallback titles pre-written (different angle: the paywall story; the
+  "one Docker box" story).
+- URL = the GitHub repo. First comment (yours, immediately): the personal
+  story — why built, what's hard (feed politeness, Cesium perf, keeping
+  13k aircraft at 60 fps), honest caveats, what feedback you want. HN
+  rewards builders who talk engineering, punishes marketing voice.
+- Stay in the thread all day. Prepared answers (write these before
+  posting) for the predictable questions:
+  1. *Feed ToS/legality* — community feeds, polite pull cadences, no
+     redistribution, that's why no public demo instance.
+  2. *"How is this different from FR24 / World Monitor / ADS-B Exchange?"*
+     — the comparison table, especially history + self-host + keyless.
+  3. *"Why is my globe empty?"* (VPS egress) — the FAQ link.
+  4. *OPSEC/misuse concerns* — serious answer: it fuses already-public
+     broadcasts; watch-lists stay on the user's hardware, which is the
+     privacy-preserving direction.
+  5. *The AI features* — labeled, optional, local-only inference; never
+     auto-asserted as fact (assertion/provenance schema).
+  6. *Cesium perf on old hardware* — the low-end banner + quality presets.
+- **Do not** ask anyone to upvote, ever (HN voting-ring detection is real
+  and permanent). If the post dies (<20 points): one relaunch is
+  acceptable ~2 weeks later with a different title/angle; also email
+  hn@ycombinator.com — mods occasionally re-up good Show HNs via the
+  second-chance pool.
+
+**Day 5–7:** Trace Labs Discord #tools, OSINT Curious community, one or two
+self-hosted Discords — shared as a member ("I posted this on HN this week,
+r/selfhosted thread here, feedback welcome"), not as an announcement blast.
+Mastodon (infosec.exchange) + Bluesky thread with the replay GIF; tag
+#selfhosted #OSINT #ADSB. Watch GitHub Trending — if the repo appears,
+screenshot it (asset for later posts) and expect a second wave.
+
+**All week:** respond to every issue within hours. Label the good ones
+`launch-feedback`. Ship two or three tiny fixes *during* the week and say
+so in the threads ("fixed in v1.0.1") — visible momentum is the strongest
+star-converter there is.
+
+## 4. Weeks 2–4 — directories, newsletters, reviewers
+
+**Directories** (slow, permanent, compounding — file all of them):
+- **awesome-selfhosted** PR (read their contributing rules: needs license,
+  active maintenance, docs; put it under "Maps & GPS" or closest category).
+  Expect nitpicks; comply fast.
+- **awesome-osint** PR, **awesome-geospatial**, an ADS-B/awesome-aviation
+  list, awesome-docker-compose examples if applicable.
+- **selfh.st** app directory submission; **alternativeto.net** entries as
+  alternative to Flightradar24, MarineTraffic, ADS-B Exchange (these pages
+  rank on exactly the searches disappointed users make); **LibHunt**;
+  **Awesome-Selfhosted's** sibling lists as discovered.
+- **Bellingcat toolkit** submission (their GitHub/form) — the evidence
+  locker + provenance story is precisely their bar. Expect weeks of lag;
+  file early.
+
+**Newsletters** (one personalized paragraph + press kit link each):
+- **Self-Host Weekly / selfh.st** (submission form; high conversion for
+  this exact audience).
+- **Sector035 "Week in OSINT"** — pitch as a tool note; the replay-of-a-
+  real-event angle lands better than a feature list.
+- **Console.dev** (they curate dev tools; the pitch is the engineering).
+- **The OSINT Newsletter**, **OSINT Combine**-adjacent letters as found.
+- tldr.tech / Changelog News are long shots; submit anyway (5 minutes).
+
+**Reviewers** (self-hosted YouTube is the highest-variance channel: one
+video can be 500 stars):
+- Shortlist: DB Tech, Awesome Open Source, Techno Tim, Jim's Garage,
+  Christian Lempa, Hardware Haven, NetworkChuck (long shot; the "track
+  planes from your homelab" angle is his shape).
+- One personalized email each: what it is in two sentences, the hero mp4,
+  the compose one-liner, an offer to help with setup. No follow-up spam;
+  one polite nudge after two weeks. Expect 1–2 conversions from 7 pitches.
+
+**Product Hunt: deliberately skipped** for launch. Dev/self-hosted
+infrastructure underperforms there relative to prep cost, and a mediocre PH
+day is public. Revisit only if a major release needs a second wave and the
+HN/Reddit channels are exhausted.
+
+## 5. Weeks 2–8+ — the content engine (what carries you from ~1.5k to 5k)
+
+One launch ≠ 5k. The compounding loop is **timely case studies using
+replay on real events** — content nobody without a local archive can make:
+- Template: event happens (airspace closure, naval incident, GPS-jamming
+  spike, mystery drone wave) → within 24–48 h publish a 60–90 s replay GIF
+  + a 300-word "what the archive shows" write-up → post to the relevant
+  subreddit (r/OSINT, r/ADSB, r/CredibleDefense-adjacent where allowed),
+  Mastodon, Bluesky. Each carries one quiet repo link. 90% info, 10% ad.
+- Cadence: 1–2/month minimum; opportunistic when news breaks. These double
+  as the demand research for W6 (which detector do people ask about?).
+- **Monthly release ritual:** one headline feature per month (aligned with
+  the product roadmap: archive profile → alert sinks → dark-fleet
+  explainability), real release notes, posted to r/selfhosted's monthly
+  "what's new" thread and the Discord. GitHub's release-follower feed and
+  the "recently updated" surfaces do quiet work.
+- **SEO floor:** a `docs/`-based GitHub Pages site with three pages —
+  "self-hosted Flightradar24 alternative", "self-hosted ship tracker",
+  "flight history without a subscription". These are typed into Google
+  verbatim by the target user; alternativeto + a Pages site owns them
+  within a couple of months.
+- **The second Show HN** (month 3–5): tied to the biggest release (e.g.
+  "30 days of world history in 40 GB, scrub any hour" once archive mode is
+  proven, or the dark-fleet explainability release). New headline = new
+  post, legitimately. This is typically another 300–1,200 stars.
+
+## 6. Community ops (stars follow believers)
+
+- **Issue SLA:** <24 h first response for months 1–2. Nothing converts a
+  visitor like an issue tracker full of fast, kind, technical answers.
+- Merge the first external PRs fast and generously; credit contributors in
+  release notes by handle. Each contributor is a permanent evangelist.
+- Pin a **public roadmap issue** (the 90-day plan, trimmed); check items
+  off visibly. "They ship what they say" is the retention story.
+- Convert launch feedback into named releases within days where cheap
+  ("v1.0.2 — the r/selfhosted feedback release").
+- Add a star-history chart to the README at ~2k (social proof; needy
+  before that).
+
+## 7. Measurement (weekly, 20 minutes, in a pinned issue or docs/)
+
+Track weekly: stars (+delta), GitHub traffic (uniques, referrers), clones,
+open/closed issues, Discord members, newsletter/directory placements live.
+Funnel sanity: referrer views → uniques → stars should hold ≥5%; if a big
+referrer converts <2%, the README (not the channel) is the problem.
+
+Milestones against the median path:
+- Week 1: ≥400 (front-page HN) or ≥150 (modest launch). **<100 total by
+  day 30 = the roadmap's gate fires: freeze features, rework positioning,
+  relaunch. Do not pass the gate by adding channels.**
+- Month 2: 1,500–2,000 (drip + first case studies + a reviewer video).
+- Month 3–5: 2,500–4,000 (second Show HN wave + directory compounding).
+- **5,000: month ~4 (everything hits) to month ~9 (grind path).** Both are
+  wins; only the flop-and-ignore-the-gate path loses.
+
+## 8. Division of labor
+
+Agent-executable: README surgery, comparison table, FAQ, press kit,
+CONTRIBUTING/templates/labels, good-first-issue seeding, directory PRs,
+newsletter/reviewer pitch drafts, case-study write-ups + GIF pipeline
+(screenshot-panel.mjs exists), release notes, weekly metrics digest.
+Operator-only: posting under their own accounts (HN/Reddit norms require
+the human author, and voting/posting by proxy is ban territory), Discord
+presence, final say on name/version, sending outreach email from a real
+address, being "the builder" in threads — the single most credibility-
+bearing asset in the whole plan.
+
+## 9. Do-not list (each of these has ended a launch)
+
+- **No paid/exchanged/botted stars, ever** — GitHub purges them and the
+  graph shape (cliff + foreign burst) is publicly visible; HN threads
+  screenshot it. 5k fraudulent stars is worth less than 500 real ones.
+- No upvote solicitation, vote rings, or alt accounts on HN/Reddit.
+- No public live demo instance (feed ToS, OPSEC, DDoS — settled in the
+  roadmap). The GIF is the demo.
+- Never "AI-powered" in a title; never unlabeled AI output in a
+  screenshot (the PRISM-dashboard backlash is the cautionary tale).
+- No "Palantir alternative / killer" framing — it's cringe to the OSINT
+  crowd, invites exactly the wrong scrutiny, and undersells the actual
+  differentiator (ownership, not vibes).
+- No coverage overclaims: every count in public copy must be a measured
+  number with a date (repo rule anyway; doubly so in marketing).
+- Don't argue with hostile comments; answer the technical substance once,
+  concede real limitations, move on. Threads reward the calm builder.
+
+## 10. Launch-week runbook (condensed)
+
+| Day | Action |
+|---|---|
+| T−7…−1 | Community participation; stranger-boot gate passes; README surgery done; assets recorded; release tagged |
+| Tue | r/selfhosted post (existing draft), all-day presence; file feedback issues |
+| Wed | r/OSINT post (its draft); fix + ship one small feedback item |
+| Wed/Thu | Show HN 8–10 am ET; first comment = builder story; all-day presence |
+| Fri | Discords + Mastodon/Bluesky thread; v1.0.1 with launch-week fixes |
+| Sat/Sun | r/ADSB / r/homelab variants if energy; weekly metrics entry #1 |
+| Week 2+ | §4 directories/newsletters/reviewers; §5 content engine starts |
+
+The single sentence to keep on the monitor while doing all of it: **does
+this turn what we already see into something a stranger can run, trust,
+and keep?** Stars are the echo of "yes".

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -75,19 +75,14 @@ EOF
 
   step "vessel count" "$PY" - <<'EOF'
 import json
-import os
 import urllib.request
 
-headers = {}
-if os.environ.get("OSINT_PROBE_KEY"):
-    headers["X-API-Key"] = os.environ["OSINT_PROBE_KEY"]
-req = urllib.request.Request("http://127.0.0.1:8000/api/ais/global?limit=50000", headers=headers)
-try:
-    with urllib.request.urlopen(req, timeout=30) as r:
-        n = len(json.load(r).get("features", []))
-    print(f"vessels: {n}")
-except Exception as exc:  # endpoint name may differ per deployment
-    print(f"vessel probe skipped: {exc}")
+# AIS has no HTTP snapshot route (vessels are WS-push via /ws/ais); the keyless
+# /api/status endpoint carries the unified store's live vessel_count instead.
+with urllib.request.urlopen("http://127.0.0.1:8000/api/status", timeout=30) as r:
+    body = json.load(r)
+assert "vessel_count" in body, "/api/status lost its vessel_count field"
+print(f"vessels: {body['vessel_count']} ({body.get('parked_count', 0)} parked)")
 EOF
 
   step "sidecar health" bash -c '


### PR DESCRIPTION
Follow-ups from the 2026-07-12 state-of-project audit (included in this PR at docs/audits/).

**Fixes**
- `verify.sh --live` vessel probe targeted `/api/ais/global`, which has never existed (AIS is WebSocket-push only) — it printed "skipped" on every run since it was written. It now reads the keyless `/api/status` `vessel_count` and fails if the field disappears. Proven live: 54,982 vessels at fix time.
- `docker-compose.yml` published nginx on all interfaces (`8080:80`) while running `ALLOW_UNAUTHENTICATED=1`, contradicting its own "loopback-only" safety rationale. Now binds `127.0.0.1:8080:80`; wider exposure is a deliberate override or `docker-compose.prod.yml`.
- The `email` alert channel was accepted at rule creation but nothing sends email. It is now rejected with an explicit 400 until a sender exists (guard test added; pytest baseline 1539 → 1540, CLAUDE.md updated).
- Stale `CoverageStrip.test.tsx` comment corrected (the coverage endpoint is live).
- Deliberately NOT changed: watch-officer in-memory briefs — the volatility is documented, self-healing design (docstring + in-memory incident_store diff), recorded in docs/decisions.md.

**Docs**
- `docs/audits/2026-07-12-state-of-project.md` — full audit: branch/PR reconciliation (PRs #1–#40 all merged, nothing stranded), built-vs-verified inventory, risk list, convergence on executing the W2 launch.
- `docs/star-campaign-2026-07.md` — the 5,000-star campaign playbook: star math, README conversion surgery, launch-week runbook, directories/newsletters/reviewers, content engine, metrics gates, do-not list.
- `docs/launch-posts-draft.md` — the r/selfhosted and r/OSINT post drafts, previously untracked.

**Verification**
`bash scripts/verify.sh` ALL GREEN: typecheck, lint, web 320/320, ruff, pytest **1540 passed + 1 skipped**. New vessel probe exercised against the live backend.