### PR TITLE
Raise type floor, fix muted-text contrast to WCAG-AA, make the inspector extendable

### DIFF
--- a/apps/web/src/entity-panel/DossierNarrativeCard.tsx
+++ b/apps/web/src/entity-panel/DossierNarrativeCard.tsx
@@ -60,7 +60,7 @@ export function DossierNarrativeCard({ id, kind }: Props): JSX.Element | null {
       }
     >
       <div className="space-y-2">
-        <Caveat level="ANALYTIC ASSESSMENT" note="grounded in observed track" tone="warn" />
+        <Caveat level="ANALYTIC ASSESSMENT" note="grounded" tone="warn" />
         {!data && (
           <p className="text-[10.5px] text-txt-3">
             Reasoning model summarises this entity's observed pattern-of-life. Every claim cites the

--- a/apps/web/src/entity-panel/EntityPanel.tsx
+++ b/apps/web/src/entity-panel/EntityPanel.tsx
@@ -247,18 +247,25 @@ export function EntityPanel({ viewer }: Props = {}): JSX.Element {
   );
 
   return (
-    <div className="p-4 space-y-5">
+    // ep-stack: single column by default; reflows to two columns when the rail is
+    // widened (theme/reflow.css @container). ep-span keeps identity + assessment
+    // full-width across the top so they never split mid-thought.
+    <div className="p-4 ep-stack">
       {isSim && (
-        <Caveat level="SIMULATED" note="notional war-game entity — not a real contact" tone="warn" />
+        <div className="ep-span">
+          <Caveat level="SIMULATED" note="notional war-game entity — not a real contact" tone="warn" />
+        </div>
       )}
-      <Header
-        snap={snap}
-        id={id}
-        enrichment={enrichment}
-        lastRefreshMs={lastRefreshRef.current}
-      />
+      <div className="ep-span">
+        <Header
+          snap={snap}
+          id={id}
+          enrichment={enrichment}
+          lastRefreshMs={lastRefreshRef.current}
+        />
+      </div>
 
-      {aiPosition === 'top' && aiCard}
+      {aiPosition === 'top' && <div className="ep-span">{aiCard}</div>}
 
       <ProfileCard enrichment={enrichment} snap={snap} />
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,4 +1,5 @@
 @import './theme/tokens.css';
+@import './theme/reflow.css';
 
 @tailwind base;
 @tailwind components;

--- a/apps/web/src/shell/ConsoleShell.tsx
+++ b/apps/web/src/shell/ConsoleShell.tsx
@@ -1,10 +1,17 @@
-import { useEffect, useMemo, useState, type ReactNode, type PointerEvent as ReactPointerEvent, type CSSProperties } from 'react';
-import { X } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactNode, type PointerEvent as ReactPointerEvent, type KeyboardEvent as ReactKeyboardEvent, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
+import { X, PanelRightClose, PanelLeftClose, PanelRightOpen } from 'lucide-react';
 import type { TabDef } from './TabbedPanel.js';
 import { ErrorBoundary } from './ErrorBoundary.js';
 import { useIsMobile } from './useIsMobile.js';
 import { StatusDot, MicroLabel } from './instruments.js';
+import { FloatingPanel } from './FloatingPanel.js';
 import { useConnection, useFeeds, useTime, useSim } from '../state/stores.js';
+import { useRailWidth, RIGHT_MIN, RIGHT_MAX } from '../state/railWidth.js';
+import { useFloatingPanels } from '../state/floatingPanels.js';
+
+// Stable id for the inspector's detached-window rect in the floatingPanels store.
+const INSPECTOR_PANEL_ID = 'inspector';
 
 // Desktop: five-zone layout (frontend.md §4) — 42px command bar, globe with a
 // 296px left rail + 336px right rail absolutely over it, 158px timeline footer.
@@ -45,13 +52,12 @@ const ICON_RAIL_W = 44;
 
 const RAIL_BG = 'rgba(8,10,15,0.95)';
 
-// Resizable rails — widths persist to localStorage, clamped to sane bounds.
+// Resizable rails — widths persist to localStorage, clamped to sane bounds. The
+// LEFT rail keeps its local width state; the RIGHT rail's bounds (RIGHT_MIN/MAX)
+// and value now live in state/railWidth.ts (shared with the in-rail Wide toggle).
 const LS_LEFT = 'csl.leftW';
-const LS_RIGHT = 'csl.rightW';
 const LEFT_MIN = 220;
 const LEFT_MAX = 620;
-const RIGHT_MIN = 260;
-const RIGHT_MAX = 680;
 const clampN = (n: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, n));
 function readW(key: string, def: number): number {
   try {
@@ -64,18 +70,26 @@ function readW(key: string, def: number): number {
 
 // Thin draggable edge on a rail's INNER border. Drag updates the width live; the
 // listeners attach to window so the drag survives the cursor leaving the handle.
+// Keyboard-operable (WAI-ARIA window-splitter pattern): focus it and use the
+// arrows / Home / End so a mouse isn't required. A visible grip-dot column on
+// hover/focus fixes the old "invisible 5px strip nobody knew was draggable".
+const KEY_STEP = 16;
 function RailResizer({
   side,
+  width,
   set,
 }: {
   side: 'left' | 'right';
+  width: number;
   set: (w: number) => void;
 }): JSX.Element {
+  const lo = side === 'left' ? LEFT_MIN : RIGHT_MIN;
+  const hi = side === 'left' ? LEFT_MAX : RIGHT_MAX;
   const onDown = (e: ReactPointerEvent): void => {
     e.preventDefault();
     const move = (ev: PointerEvent): void => {
       const raw = side === 'left' ? ev.clientX : window.innerWidth - ev.clientX;
-      set(clampN(raw, side === 'left' ? LEFT_MIN : RIGHT_MIN, side === 'left' ? LEFT_MAX : RIGHT_MAX));
+      set(clampN(raw, lo, hi));
     };
     const up = (): void => {
       window.removeEventListener('pointermove', move);
@@ -86,15 +100,40 @@ function RailResizer({
     window.addEventListener('pointermove', move);
     window.addEventListener('pointerup', up);
   };
+  const onKey = (e: ReactKeyboardEvent): void => {
+    // On the RIGHT rail the panel grows toward the screen's left edge, so
+    // ArrowLeft = wider; the left rail is the mirror. Home/End jump to bounds.
+    const grow = side === 'left' ? KEY_STEP : -KEY_STEP;
+    let next: number | null = null;
+    if (e.key === 'ArrowLeft') next = width - grow;
+    else if (e.key === 'ArrowRight') next = width + grow;
+    else if (e.key === 'Home') next = lo;
+    else if (e.key === 'End') next = hi;
+    if (next !== null) {
+      e.preventDefault();
+      set(clampN(next, lo, hi));
+    }
+  };
   return (
     <div
       onPointerDown={onDown}
+      onKeyDown={onKey}
       role="separator"
       aria-orientation="vertical"
       aria-label={`Resize ${side} panel`}
-      title="Drag to resize"
-      className={`absolute top-0 bottom-0 ${side === 'left' ? 'right-0' : 'left-0'} w-[5px] cursor-col-resize z-30 hover:bg-accent-line/50 active:bg-accent-line/70`}
-    />
+      aria-valuenow={Math.round(width)}
+      aria-valuemin={lo}
+      aria-valuemax={hi}
+      tabIndex={0}
+      title="Drag, or focus and use arrow keys, to resize"
+      className={`group absolute top-0 bottom-0 ${side === 'left' ? 'right-0' : 'left-0'} w-[7px] cursor-col-resize z-30 flex items-center justify-center hover:bg-accent-line/40 focus-visible:bg-accent-line/50 focus:outline-none`}
+    >
+      {/* grip dots — subtle until hover/focus, then clearly a handle */}
+      <span
+        aria-hidden
+        className="h-7 w-[3px] rounded-full bg-txt-4 opacity-40 group-hover:opacity-90 group-focus-visible:opacity-100 transition-opacity"
+      />
+    </div>
   );
 }
 
@@ -117,7 +156,17 @@ export function ConsoleShell({
   const [menuOpen, setMenuOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [leftW, setLeftW] = useState(() => clampN(readW(LS_LEFT, 296), LEFT_MIN, LEFT_MAX));
-  const [rightW, setRightW] = useState(() => clampN(readW(LS_RIGHT, 360), RIGHT_MIN, RIGHT_MAX));
+  // Right-rail width lives in a store (state/railWidth.ts) so the in-rail Wide
+  // toggle and the resizer share one source; the store owns clamp + persistence.
+  const rightW = useRailWidth((s) => s.rightW);
+  const setRightW = useRailWidth((s) => s.setRightW);
+  const toggleWide = useRailWidth((s) => s.toggleWide);
+  const wide = useRailWidth((s) => s.rightW) >= 520;
+  // Inspector detach — reuses the same floating-window substrate the left rail
+  // uses (state/floatingPanels.ts + FloatingPanel). Presence of the id === floating.
+  const inspectorFloating = useFloatingPanels((s) => Boolean(s.panels[INSPECTOR_PANEL_ID]));
+  const detachInspector = useFloatingPanels((s) => s.detach);
+  const redockInspector = useFloatingPanels((s) => s.redock);
   useEffect(() => {
     try {
       localStorage.setItem(LS_LEFT, String(leftW));
@@ -125,13 +174,6 @@ export function ConsoleShell({
       /* ignore */
     }
   }, [leftW]);
-  useEffect(() => {
-    try {
-      localStorage.setItem(LS_RIGHT, String(rightW));
-    } catch {
-      /* ignore */
-    }
-  }, [rightW]);
 
   const timelinePanel: TabDef = { id: 'timeline', label: 'Timeline', content: bottom };
   const mobilePanels: TabDef[] =
@@ -234,19 +276,62 @@ export function ConsoleShell({
                 style={{ background: RAIL_BG, width: leftW }}
               >
                 {left}
-                <RailResizer side="left" set={setLeftW} />
+                <RailResizer side="left" width={leftW} set={setLeftW} />
               </aside>
             )}
-            {right && (
+            {right && !inspectorFloating && (
               <aside
+                data-rail="right"
                 className={`absolute right-0 top-0 bottom-0 border-l border-line-2 overflow-hidden z-20 flex-col ${bleed ? 'hidden' : 'flex'}`}
                 aria-label="Selection"
                 style={{ background: RAIL_BG, width: rightW }}
               >
-                {right}
-                <RailResizer side="right" set={setRightW} />
+                {/* rail header — Wide + Detach live where the operator looks, so the
+                    resize/expand affordances aren't hidden behind a 7px edge. */}
+                <div className="flex items-center justify-end gap-0.5 h-7 shrink-0 px-1.5 border-b border-line-2">
+                  <button
+                    type="button"
+                    onClick={toggleWide}
+                    aria-pressed={wide}
+                    aria-label={wide ? 'Collapse inspector to default width' : 'Widen inspector for two-column detail'}
+                    title={wide ? 'Collapse to default width' : 'Widen — two-column detail'}
+                    className="text-txt-3 hover:text-txt-0 px-1 h-5 flex items-center rounded-sm hover:bg-bg-3"
+                  >
+                    {wide ? (
+                      <PanelRightClose size={14} strokeWidth={1.75} aria-hidden />
+                    ) : (
+                      <PanelLeftClose size={14} strokeWidth={1.75} aria-hidden />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => detachInspector(INSPECTOR_PANEL_ID, { w: Math.max(rightW, 420) })}
+                    aria-label="Detach inspector into a floating window"
+                    title="Detach — pop out into a movable window"
+                    className="text-txt-3 hover:text-accent px-1 h-5 flex items-center rounded-sm hover:bg-bg-3"
+                  >
+                    <PanelRightOpen size={14} strokeWidth={1.75} aria-hidden />
+                  </button>
+                </div>
+                <div className="flex-1 min-h-0 overflow-auto">{right}</div>
+                <RailResizer side="right" width={rightW} set={setRightW} />
               </aside>
             )}
+            {/* Detached inspector — same content node, floated free over the globe.
+                Portalled to <body> so the rail's stacking context can't clip it. */}
+            {right && inspectorFloating &&
+              createPortal(
+                <FloatingPanel
+                  id={INSPECTOR_PANEL_ID}
+                  title="Selection"
+                  onClose={() => redockInspector(INSPECTOR_PANEL_ID)}
+                >
+                  <div data-rail="right" className="h-full overflow-auto">
+                    {right}
+                  </div>
+                </FloatingPanel>,
+                document.body,
+              )}
           </>
         )}
 

--- a/apps/web/src/shell/instruments.tsx
+++ b/apps/web/src/shell/instruments.tsx
@@ -9,7 +9,10 @@
 import type { CSSProperties, ReactNode } from 'react';
 
 // ── section divider label (.seclbl) ────────────────────────────────────────
-// Mono 9px uppercase title, a hairline that fills the row, optional count.
+// Section title + optional count. Sentence case (frontend.md §type-scale
+// mandates "sentence case everywhere except machine codes"); the old
+// uppercase + 0.09em tracking read as "AI-dashboard" chrome. A hair more weight
+// carries the structural role now that it isn't shouting in caps.
 export function SectionLabel({
   title,
   count,
@@ -23,7 +26,7 @@ export function SectionLabel({
 }): JSX.Element {
   return (
     <div className={`flex items-center justify-between gap-2 ${className}`} style={style}>
-      <span className="text-[11px] font-semibold tracking-[0.09em] uppercase text-txt-2">{title}</span>
+      <span className="text-[12px] font-semibold text-txt-1">{title}</span>
       {count !== undefined && count !== '' && (
         <span className="mono text-[11px] text-txt-3 tabular-nums">{count}</span>
       )}
@@ -34,7 +37,7 @@ export function SectionLabel({
 // ── micro caps label (.lbl) ─────────────────────────────────────────────────
 export function MicroLabel({ children, className = '' }: { children: ReactNode; className?: string }): JSX.Element {
   return (
-    <span className={`text-[10px] font-medium tracking-[0.08em] uppercase text-txt-2 ${className}`}>{children}</span>
+    <span className={`text-[11px] font-medium tracking-[0.06em] uppercase text-txt-2 ${className}`}>{children}</span>
   );
 }
 
@@ -135,7 +138,7 @@ export function Badge({
 }): JSX.Element {
   return (
     <span
-      className={`mono text-[10px] tracking-[0.6px] uppercase px-[7px] py-[3px] rounded-sm whitespace-nowrap ${BADGE_TONE[tone]} ${className}`}
+      className={`mono text-[11px] tracking-[0.5px] uppercase px-[7px] py-[3px] rounded-sm whitespace-nowrap ${BADGE_TONE[tone]} ${className}`}
     >
       {children}
     </span>
@@ -146,7 +149,7 @@ export function Badge({
 export function KV({ children, className = '' }: { children: ReactNode; className?: string }): JSX.Element {
   return (
     <div
-      className={`grid items-baseline gap-x-3 gap-y-[5px] text-[10.5px] ${className}`}
+      className={`grid items-baseline gap-x-3 gap-y-[5px] text-[12px] ${className}`}
       style={{ gridTemplateColumns: 'minmax(0, auto) minmax(0, 1fr)' }}
     >
       {children}
@@ -154,9 +157,11 @@ export function KV({ children, className = '' }: { children: ReactNode; classNam
   );
 }
 export function KVRow({ k, v, warn = false }: { k: string; v: ReactNode; warn?: boolean }): JSX.Element {
+  // Field key = sentence-case label voice (readable, not shouted); the VALUE
+  // keeps the mono/tabular machine voice so figures still align and scan.
   return (
     <>
-      <span className="mono text-[10px] tracking-[0.4px] uppercase text-txt-2">{k}</span>
+      <span className="text-[11px] text-txt-2">{k}</span>
       <span className={`mono text-right min-w-0 break-words ${warn ? 'text-alert-fg' : 'text-txt-0'}`}>{v}</span>
     </>
   );
@@ -193,7 +198,7 @@ export function Btn({
       aria-label={ariaLabel ?? title}
       className={[
         'mono tracking-[0.3px] rounded-sm border transition-colors disabled:opacity-40',
-        size === 'sm' ? 'text-[10px] px-2 py-1' : 'text-[10px] px-[10px] py-[6px]',
+        size === 'sm' ? 'text-[11px] px-2 py-1' : 'text-[11px] px-[10px] py-[6px]',
         tone === 'accent'
           ? 'border-accent-line bg-accent-dim text-accent-fg hover:text-accent'
           : 'border-line-2 bg-bg-2 text-txt-1 hover:border-accent-line',
@@ -233,7 +238,7 @@ export function Hero({
     >
       <span className="absolute left-0 top-0 bottom-0 w-[2px]" style={{ background: c.bar }} />
       <div className="flex items-center gap-2 mb-2">
-        <span className="mono text-[10px] tracking-[0.8px] uppercase" style={{ color: c.t }}>
+        <span className="mono text-[11px] tracking-[0.7px] uppercase" style={{ color: c.t }}>
           {title}
         </span>
       </div>
@@ -317,7 +322,7 @@ export function Brand({ name = 'VELOCITY', version }: { name?: string; version?:
     <div className="flex items-center gap-2 mono font-semibold tracking-[1.5px] text-[12px] text-txt-0">
       <span className="w-2 h-2 bg-accent rotate-45 shrink-0" />
       {name}
-      {version && <span className="font-normal tracking-[0.5px] text-[10px] text-txt-3">{version}</span>}
+      {version && <span className="font-normal tracking-[0.5px] text-[11px] text-txt-3">{version}</span>}
     </div>
   );
 }
@@ -343,7 +348,7 @@ export function Caveat({
 }): JSX.Element {
   return (
     <span
-      className={`inline-flex items-center gap-[5px] mono text-[10px] tracking-[0.7px] uppercase px-[6px] py-[2px] rounded-sm border whitespace-nowrap ${CAVEAT_TONE[tone]}`}
+      className={`inline-flex items-center gap-[5px] mono text-[11px] tracking-[0.6px] uppercase px-[6px] py-[2px] rounded-sm border whitespace-nowrap ${CAVEAT_TONE[tone]}`}
     >
       {level}
       {note && (

--- a/apps/web/src/state/railWidth.ts
+++ b/apps/web/src/state/railWidth.ts
@@ -1,0 +1,60 @@
+// Right-rail (inspector) width — lifted out of ConsoleShell-local useState so a
+// header control INSIDE the rail (Wide toggle) and the drag/keyboard resizer can
+// both drive it, and so the value survives remounts within a session. Persists
+// to the same localStorage key ConsoleShell has always used (`csl.rightW`) so a
+// user's existing width carries over. ConsoleShell still publishes it as the
+// `--rail-right-w` CSS var (guard-tested) — this store is only the source value.
+import { create } from 'zustand';
+
+const LS_RIGHT = 'csl.rightW';
+export const RIGHT_MIN = 260;
+export const RIGHT_MAX = 680;
+const DEFAULT = 360;
+// The "Wide" reading width — enough for the EntityPanel card stack to reflow to
+// two columns (see theme/reflow.css `@container` breakpoint at 500px content).
+export const RIGHT_WIDE = 560;
+
+const clamp = (n: number): number => Math.max(RIGHT_MIN, Math.min(RIGHT_MAX, n));
+
+function read(): number {
+  try {
+    const v = Number(localStorage.getItem(LS_RIGHT));
+    return Number.isFinite(v) && v > 0 ? clamp(v) : DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+function persist(w: number): void {
+  try {
+    localStorage.setItem(LS_RIGHT, String(w));
+  } catch {
+    /* ignore */
+  }
+}
+
+interface RailWidthState {
+  rightW: number;
+  /** Set an explicit width (clamped + persisted). */
+  setRightW: (w: number) => void;
+  /** Snap between the default and the wide reading width. */
+  toggleWide: () => void;
+  /** Whether the rail is currently at/above the wide reading width. */
+  isWide: () => boolean;
+}
+
+export const useRailWidth = create<RailWidthState>((set, get) => ({
+  rightW: read(),
+  setRightW: (w) => {
+    const next = clamp(w);
+    persist(next);
+    set({ rightW: next });
+  },
+  toggleWide: () => {
+    // Anything within ~40px of wide counts as "already wide" → collapse back.
+    const next = get().rightW >= RIGHT_WIDE - 40 ? DEFAULT : RIGHT_WIDE;
+    persist(next);
+    set({ rightW: next });
+  },
+  isWide: () => get().rightW >= RIGHT_WIDE - 40,
+}));

--- a/apps/web/src/theme/contrast.test.ts
+++ b/apps/web/src/theme/contrast.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// WCAG-AA contrast guard (added 2026-07-13). The text ramp previously shipped
+// muted tiers that failed AA (dark txt-3 2.81:1, txt-4 1.71:1) while carrying
+// live text. This test parses tokens.css and asserts every text tier clears the
+// AA bar for NORMAL text (4.5:1) against BOTH the panel bg (bg-1) and the lighter
+// card bg (bg-2, where most dossier text actually sits) — in both themes. If a
+// future palette tweak dims a tier below AA, this fails loud instead of silently
+// regressing accessibility. See docs/decisions.md (typography & WCAG-AA pass).
+
+// vitest runs with cwd = apps/web; tokens.css is the source of truth this guards.
+const CSS = readFileSync(join(process.cwd(), 'src/theme/tokens.css'), 'utf8');
+
+// Pull `--name: #hex;` decls out of a single `:root {…}` / `:root[…] {…}` block.
+function parseBlock(selector: string): Record<string, string> {
+  const start = CSS.indexOf(selector);
+  if (start < 0) throw new Error(`selector not found: ${selector}`);
+  const open = CSS.indexOf('{', start);
+  const close = CSS.indexOf('}', open);
+  const body = CSS.slice(open + 1, close);
+  const out: Record<string, string> = {};
+  for (const m of body.matchAll(/(--[\w-]+):\s*(#[0-9a-fA-F]{3,8})\s*;/g)) {
+    const [, name, hex] = m;
+    if (name && hex) out[name] = hex;
+  }
+  return out;
+}
+
+function toRgb(hex: string): [number, number, number] {
+  let h = hex.replace('#', '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as [number, number, number];
+}
+function relLum(hex: string): number {
+  const lin = (c: number): number => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  const [r, g, b] = toRgb(hex);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+function ratio(fg: string, bg: string): number {
+  const a = relLum(fg);
+  const b = relLum(bg);
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const AA = 4.5;
+// txt-4 is the dimmest live-text tier; hold it to AA too (it carries hints/notes,
+// not only disabled controls, so it is NOT WCAG-exempt).
+const TEXT_TIERS = ['--txt-0', '--txt-1', '--txt-2', '--txt-3', '--txt-4'] as const;
+
+describe.each([
+  [':root {', 'dark'],
+  [":root[data-theme='light'] {", 'light'],
+])('WCAG-AA text contrast — %s theme', (selector, _label) => {
+  const tokens = parseBlock(selector);
+  const tok = (name: string): string => {
+    const v = tokens[name];
+    if (!v) throw new Error(`token ${name} not found in ${selector}`);
+    return v;
+  };
+  // Most panel/card text sits on bg-1 (rail) or bg-2 (card). Guard the harder one
+  // per tier by taking the MINIMUM ratio across both surfaces.
+  for (const tier of TEXT_TIERS) {
+    it(`${tier} clears AA on both bg-1 and bg-2`, () => {
+      const fg = tok(tier);
+      const rBg1 = ratio(fg, tok('--bg-1'));
+      const rBg2 = ratio(fg, tok('--bg-2'));
+      expect(Math.min(rBg1, rBg2)).toBeGreaterThanOrEqual(AA);
+    });
+  }
+
+  it('the muted ramp stays monotonic (txt-2 ≥ txt-3 ≥ txt-4 contrast)', () => {
+    const c = (t: string): number => ratio(tok(t), tok('--bg-1'));
+    expect(c('--txt-2')).toBeGreaterThanOrEqual(c('--txt-3'));
+    expect(c('--txt-3')).toBeGreaterThanOrEqual(c('--txt-4'));
+  });
+});

--- a/apps/web/src/theme/reflow.css
+++ b/apps/web/src/theme/reflow.css
@@ -1,0 +1,42 @@
+/* Inspector reflow — when the operator widens the right rail, the dossier card
+   stack should USE the width (two columns) instead of stretching one cramped
+   column. Pure CSS: the rail is a `container`, and the EntityPanel stack opts in
+   with `.ep-stack`. No JS width plumbing — the rail's own inline width drives the
+   container query. Added 2026-07-13 with the "extend the sidebar to see all the
+   info" usability pass. `.ep-stack` owns ALL vertical rhythm (no Tailwind
+   space-y-*, which fights CSS columns). */
+
+/* The right rail aside becomes the query container (named so unrelated nested
+   containers can't accidentally match). ConsoleShell tags it `data-rail="right"`. */
+[data-rail='right'] {
+  container-type: inline-size;
+  container-name: inspector;
+}
+
+/* Single-column (default): stack cards with a consistent gap. */
+.ep-stack > * + * {
+  margin-top: 20px;
+}
+
+/* At a genuine reading width, flow cards into two columns. Cards keep their own
+   borders/spacing; `break-inside: avoid` keeps a card whole. The Header, any
+   SIMULATED caveat, and the AI card stay full-width (`.ep-span`) so the primary
+   identity + assessment read across the top, not split mid-thought. */
+@container inspector (min-width: 500px) {
+  .ep-stack {
+    column-count: 2;
+    column-gap: 16px;
+  }
+  /* Reset the single-column top-margin; columns use per-card bottom margin so a
+     card never starts flush against the top of the second column. */
+  .ep-stack > * + * {
+    margin-top: 0;
+  }
+  .ep-stack > * {
+    break-inside: avoid;
+    margin-bottom: 16px;
+  }
+  .ep-stack > .ep-span {
+    column-span: all;
+  }
+}

--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -14,12 +14,15 @@
   --line: rgba(255, 246, 234, 0.08);
   --line-2: rgba(255, 246, 234, 0.15);
 
-  /* text — warm greys, a real contrast ramp */
+  /* text — warm greys, a real contrast ramp. WCAG-AA pass (2026-07-13): every
+     tier now clears 4.5:1 on both bg-1 and the lighter card bg-2, including the
+     muted txt-3/txt-4 tiers that previously failed (2.81:1 / 1.71:1) and were
+     carrying live text. txt-2 lifted to open headroom for a descending ramp. */
   --txt-0: #f5f2ed;
   --txt-1: #c0b9ae;
-  --txt-2: #8e8880;
-  --txt-3: #6a645b;
-  --txt-4: #494440;
+  --txt-2: #a8a29c;
+  --txt-3: #96908a;
+  --txt-4: #948e88;
 
   /* accent — soft sky-steel blue (interactive / focus / active). Lighter than
      the old cobalt so it sits comfortably on the warmer substrate. */
@@ -89,11 +92,12 @@
   --z-wizard: 700; /* first-run gates: onboarding tour + AI setup wizard */
   --z-toast: 800; /* transient toasts — always on top */
 
-  /* ── type scale with a FLOOR (design §6.2 — nothing below 10px). Migrate the
-     205 sub-10px literals onto these; captions are the smallest allowed. */
-  --fs-body: 12px; /* default body / row text */
-  --fs-dense: 11px; /* dense tabular rows */
-  --fs-caption: 10px; /* captions, eyebrows, section labels — the FLOOR */
+  /* ── type scale with a FLOOR (WCAG-AA legibility pass 2026-07-13 — nothing
+     below 11px; the old 10px floor read as "AI-dashboard" density and pushed
+     muted text below AA). Migrate sub-11px literals onto these. */
+  --fs-body: 13px; /* default body / row text */
+  --fs-dense: 12px; /* dense tabular rows */
+  --fs-caption: 11px; /* captions, eyebrows, machine codes — the FLOOR */
 
   /* classification banner (§6.2 hex amnesty) — the marking chrome, tokenized so
      it's no longer hardcoded green literals scattered in ConsoleShell. */
@@ -125,8 +129,10 @@
   --txt-0: #10151c;
   --txt-1: #33414f;
   --txt-2: #5d6776;
-  --txt-3: #8b95a2;
-  --txt-4: #aab2bd;
+  /* txt-3/txt-4 darkened to clear AA on white AND the pale card bg-2 (were
+     3.04:1 / 2.14:1 — both failed while carrying live text). See contrast.test.ts */
+  --txt-3: #636d79;
+  --txt-4: #66707c;
   --accent: #2575c0;
   --accent-dim: rgba(37, 117, 192, 0.12);
   --accent-line: rgba(37, 117, 192, 0.4);
@@ -164,7 +170,7 @@ body,
   background: var(--bg-0);
   color: var(--txt-0);
   font-family: var(--font-sans);
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1.45;
   -webkit-font-smoothing: antialiased;
   font-variant-numeric: tabular-nums; /* numerics don't jitter */
@@ -207,8 +213,8 @@ body,
 /* micro-label utility — frontend.md §3 */
 .micro {
   font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.5px;
+  font-size: 11px; /* WCAG floor 2026-07-13 — was 10px */
+  letter-spacing: 0.4px;
   color: var(--txt-3);
   text-transform: uppercase;
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -810,3 +810,42 @@ Human-style commit messages; a global commit-msg hook strips AI attribution.
 Write what was measured ("union climbs to ~14k"), not marketing ("now
 global"). Repo root tidy: no dev screenshots committed, docs under `docs/`,
 app art is SVG in code.
+
+### Typography & WCAG-AA legibility pass (2026-07-13)
+Operator feedback: the UI "looks AI", newcomers/older users struggle, the
+sidebar won't extend to show all the info, and WCAG rules aren't followed.
+Three findings, all fixed surgically (not a rebuild):
+
+1. **"Looks AI" was the type system, not the face.** Body was 11px on a 10px
+   floor with uppercase 0.8px-tracked eyebrow labels applied nearly everywhere
+   (~1,368 literals). Inter stays (Stripe/GitHub ship it). The floor went to
+   11px (`--fs-body 13 / -dense 12 / -caption 11`; html/body 13px), and the two
+   STRUCTURAL instrument primitives — `SectionLabel` and `KVRow` keys — became
+   sentence case (`shell/instruments.tsx`). This actually enforces the existing
+   `frontend.md` spec ("sentence case everywhere except machine codes"), which
+   the code had drifted from. `MicroLabel`/`Badge`/`Caveat` KEEP mono-caps —
+   they are the sanctioned machine/status voice (MMSI, UNCLAS, units). The
+   ~203 inline `uppercase tracking-[…]` leaf sites (LayerRail groups, Foundry,
+   Inbox, …) are a deliberate phase-2 follow-up, not done here.
+2. **WCAG-AA contrast.** Only `--txt-3`/`--txt-4` failed, in BOTH themes (dark
+   2.81:1 / 1.71:1; light 3.04:1 / 2.14:1) while carrying LIVE text (not just
+   disabled controls, so not WCAG-exempt). The whole muted ramp (`--txt-2/3/4`)
+   was re-solved to clear 4.5:1 on both bg-1 and the lighter card bg-2, keeping
+   a monotonic txt-0>1>2>3>4 ramp. Guarded by `theme/contrast.test.ts` (parses
+   tokens.css, asserts AA per tier per theme) — the executable invariant.
+3. **Sidebar "extend to see all the info".** The right rail always resized
+   (260–680px) but had no visible affordance and the EntityPanel didn't reflow.
+   Added: a visible + keyboard-operable resize grip (`RailResizer`, WAI-ARIA
+   separator: arrows/Home/End), an in-rail header with a **Wide** toggle
+   (snaps to a 560px reading width) and a **Detach** button that pops the
+   inspector into a floating window — reusing the existing `floatingPanels`
+   store + `FloatingPanel` (same substrate the left rail uses). Right-rail width
+   lifted into `state/railWidth.ts` (still persists `csl.rightW`, still
+   publishes `--rail-right-w`). At ≥500px content the EntityPanel card stack
+   reflows to two columns via a pure `@container` query (`theme/reflow.css`,
+   `.ep-stack`/`.ep-span`) — no JS width plumbing. Verified live: sentence-case
+   cards, wide-mode 2-col, detach, light-theme all screenshotted.
+
+Known follow-ups (not regressions): the right rail bg is still a hardcoded dark
+`RAIL_BG` (not tokenized) so light theme shows light text on a dark rail;
+phase-2 leaf-site sentence-case sweep.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -60,10 +60,16 @@ lifted well off black, with a soft sky-steel accent — not the old cool-blue.
 }
 ```
 
-Type scale (tokens `--fs-body/-dense/-caption`, floor 10px): 10px mono
-(micro-labels, units), 11px (IDs, ticker), 12px (body/secondary), 13–14px
-(entity names, headings). Weights 400/500/600. **Sentence case everywhere**
-except machine codes (UNCLAS, MMSI). Letter-spacing 0.5px on mono micro-labels.
+Type scale (tokens `--fs-body/-dense/-caption`, floor **11px** — raised from
+10px in the 2026-07-13 WCAG/legibility pass): 11px mono (micro-labels, units,
+machine codes), 12px (dense tabular rows, field keys), 13px (body/secondary),
+13–15px (entity names, headings). Weights 400/500/600. **Sentence case
+everywhere** except machine codes (UNCLAS, MMSI, ICAO24) — this is enforced by
+the shared instrument primitives (`SectionLabel`, `KVRow` keys are sentence
+case; `MicroLabel`/`Badge`/`Caveat` keep mono-caps for the machine voice). Do
+NOT reintroduce blanket `uppercase tracking-[…]` on structural labels; it reads
+as templated "AI-dashboard" chrome. Muted text tiers (`--txt-2/3/4`) are pinned
+to WCAG-AA (4.5:1 on both bg-1 and card bg-2) by `theme/contrast.test.ts`.
 
 Shared feedback primitives live in `src/shell/`: `InlineAlert`
 (tone=info|warn|alert|ok) for inline rows and `toast.ok/warn/error()` +


### PR DESCRIPTION
## Why

Three pieces of user feedback on the console UI: it reads as templated/"AI-generated", newcomers and older users struggle with the density, the sidebar can't be extended to see all the info, and WCAG rules aren't followed. All three are fixed surgically — Inter stays, the dense expert identity stays.

## What changed

**Typography — de-AI by enforcing the existing spec.** The 10px floor plus blanket uppercase, letter-spaced eyebrow labels (~1,368 sites) were the tell. `frontend.md` already mandated "sentence case everywhere except machine codes"; the code had drifted. Raised the floor to 11px (body 13px) and made the two structural instrument primitives — `SectionLabel` and `KVRow` keys — sentence case. `MicroLabel`/`Badge`/`Caveat` keep mono-caps (the sanctioned machine/status voice: MMSI, UNCLAS, units).

**WCAG-AA contrast.** `--txt-3`/`--txt-4` failed AA in **both** themes (dark 2.81:1 / 1.71:1, light 3.04:1 / 2.14:1) while carrying live text — not just disabled controls, so not WCAG-exempt. Re-solved the whole muted ramp to clear 4.5:1 on both the panel bg and the lighter card bg, keeping a monotonic txt-0>1>2>3>4 ramp. New `theme/contrast.test.ts` guard parses `tokens.css` and asserts AA per tier per theme.

**Sidebar — extend to see all the info.** The right rail always resized (260–680px) but had no visible affordance and the inspector never reflowed, so dragging just stretched cramped cards. Added:
- a visible + keyboard-operable resize grip (`RailResizer`, WAI-ARIA separator: arrows / Home / End)
- an in-rail header with a **Wide** toggle (snaps to a 560px reading width) and a **Detach** button that pops the inspector into a floating window — reusing the existing `floatingPanels` store + `FloatingPanel` (same substrate the left rail uses)
- a pure `@container` two-column reflow of the EntityPanel card stack (`theme/reflow.css`) — no JS width plumbing; widening now surfaces the Track / Connections / Enrichment cards that were previously buried

Right-rail width lifted into `state/railWidth.ts` (still persists `csl.rightW`, still publishes `--rail-right-w` — guard-tested).

## Verification

- `bash scripts/verify.sh` → **ALL GREEN**: typecheck + lint clean, API **1630 passed + 1 skipped** (baseline held — changes are frontend-only), web unit **355 passed** (incl. +12 contrast guard). `ConsoleShell` `--rail-right-w` contract test still green.
- Live browser check (dark + light): sentence-case cards, wide-mode 2-column reflow, detach-to-floating-window all confirmed. Fixed one badge that clipped in the narrower reflow column.

## Deliberately deferred (named in `docs/decisions.md`)

- ~203 inline `uppercase tracking-[…]` leaf sites (LayerRail group headers, Foundry, Inbox, …) — phase-2 sentence-case sweep.
- Right rail bg is a hardcoded dark `RAIL_BG` (not tokenized), so light theme shows light text on a dark rail — separate tokenization change.