### PR TITLE
Aircraft predicted motion: exact reported speed, never in reverse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,19 @@ Refresh / motion:
   Sanctioned opt-in exceptions — do NOT delete as regressions:
   `aircraftDeadReckon` toggle (OFF default) and `continuousRenderGovernor`
   toggle (OFF default), both in `state/settings.ts`. → `docs/decisions.md`
+- With `aircraftDeadReckon` ON the motion model is ANALYTIC
+  (`globe/adapters/deadReckon.ts`): `pos(t) = advance(anchor, track_deg,
+  velocity_ms * max(0, t - t0))`. Speed is EXACTLY the reported `velocity_ms`
+  and it can NEVER reverse — both structural, both operator requirements
+  (2026-07-14). Never ease/interpolate TOWARD a fix (makes speed arbitrary +
+  glides backwards); never fit velocity from consecutive fixes (only 13.5% land
+  within ±10% of reported). → `globe/adapters/deadReckon.test.ts`
+- The snapshot union is FRESHEST-OBSERVATION-wins (`seen_at - seen_pos_s`), not
+  merge-order — a cached tier must never clobber a fresher fix — and a fix that
+  flies a fast airborne contact backwards along its own `track_deg` is dropped.
+  Raw `seen_pos_s` is the age at UPSTREAM serve time and a cached tier reports
+  it as fresh forever; never compare it across tiers.
+  → `tests/test_adsb_no_reverse.py`
 - Position-unchanged SKIP still refreshes the entity PropertyBag; only the
   restyle is skipped. Vessels keep their `SampledPositionProperty` glide.
 - `requestRenderMode: true` + `maximumRenderTimeChange: 0` in GlobeCanvas
@@ -101,22 +114,12 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1662 passed + 1 skipped** (the skip is the opt-in live probe;
-  measured 2026-07-14 on branch ui-typography-wcag-sidebar after the AI-workspace
-  wave — dedicated AI hub app (agent + Watch Officer + engine/models), Watch
-  Officer status/elaborate routes, sharper selection-brief prompt, and
-  end-to-end AI-route tests — up from 1645 after the keyless
-  data-layers wave — 12 new feeds (hazards/env/oceans/space-weather/energy-infra/
-  aviation) wired across route + MCP + globe layer + ontology, up from 1630 after
-  the real-place
-  strike-areas wave — geoBoundaries admin-polygon resolver + feed iso3/
-  shape_level enrichment + AreaAdapter polygon rendering — up from 1583
-  after the intel-depth wave, 1540 after the rot-fix wave, 1539 after the
-  evidence-locker hardening wave, 1536 after the selection-brief
-  enrichment-fusion wave, 1533 after the evidence-locker + case-export wave,
-  1507 after the bug-fix wave (PR #38) and 1294 on
-  w5-places-airspace-enrichment).
-  Never commit below the baseline you inherited; update this number when you raise it.
+  Baseline: **1675 passed + 1 skipped** (skip = opt-in live probe; measured
+  2026-07-14, branch ui-typography-wcag-sidebar, aircraft predicted-motion
+  wave). Never commit below the baseline you inherited. When you raise it,
+  update the number/date/wave here and move the displaced line to
+  `docs/decisions.md#backend-test-baseline-history` — this bullet stays a
+  three-line fact, not a changelog.
 - `pnpm -r typecheck` green at every commit boundary. `bash scripts/verify.sh`
   = typecheck + lint + web unit + api tests in one command.
 - Boot: `bash scripts/run-api.sh` from repo ROOT (:8000, jemalloc preload —
@@ -139,6 +142,14 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 One file, one owner — serialize edits to shared files. A subagent touching
 `styles.ts`, `PollGeoJsonAdapter`, `tracks.ts` dedup, or `requestRenderMode`
 must preserve the invariants above (the guards fail loud regardless).
+
+Match model to judgment density, not prestige (operator directive 2026-07-14;
+sunset when default routing catches up): breadth exploration and signature
+extraction go to Explore/Plan agents on the inherited/default model — haiku
+handles "return the exact def lines, file:line, NOT FOUND if absent" fine.
+Pin a heavy model (opus/fable) only for judgment-dense stages — adversarial
+review, invariant-adjacent design, debugging that resists you — and say why.
+Never default every subagent to the biggest model.
 
 ## Verification before claiming done
 

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,90 @@
+# Disclaimer
+
+**Velocity is provided as-is, with no warranty. You use it, and everything it
+collects, entirely at your own risk.**
+
+Read this before you run the platform, point it at an upstream, or rely on
+anything it shows you.
+
+## No warranty, no liability
+
+This software is distributed under the [AGPL-3.0-or-later](./LICENSE), whose
+Sections 15–17 govern and are restated here in plain terms: the software comes
+with **absolutely no warranty** of any kind, express or implied, including
+merchantability, fitness for a particular purpose, and non-infringement.
+
+**The authors and contributors accept no responsibility or liability for any
+use of this software or of the data it retrieves** — including how you collect
+data, what you collect, what you do with it, and any direct, indirect,
+incidental, or consequential damages, data loss, service suspension, account
+termination, legal claim, or regulatory action arising from that use.
+
+You are the operator. Every request this software sends is **your** request,
+from your infrastructure, under your IP address, in your legal jurisdiction.
+Responsibility for it is yours alone.
+
+## Data collection, scraping, and upstream terms
+
+Velocity aggregates public data from many third-party sources. Some are
+documented public APIs. **Others are fetched by scraping or by browser-emulating
+sidecars** that send origin/referer headers to retrieve data an ordinary browser
+would receive — including, at various times, ADS-B aggregators, AIS providers,
+and assorted web sources.
+
+Consequences you accept by running it:
+
+- **No upstream has authorised this project.** No endorsement, partnership, or
+  permission is claimed or implied by any source named in [`NOTICE`](./NOTICE)
+  or anywhere in this repository.
+- **Each upstream carries its own licence and terms of service, and those terms
+  bind you, not this project.** Several are non-commercial or academic-only
+  (ACLED, OpenSky, community ADS-B feeds, and others). The AGPL covers this
+  repository's *source code* and relicenses no upstream data whatsoever.
+- **Scraping may breach a source's terms of service, and terms change without
+  notice.** Verify each upstream's *current* terms yourself before you rely on
+  it, and before any commercial or redistributive use. That a connector exists
+  here is not advice that using it is lawful or permitted for you.
+- **Rate limits, blocks, bans, and legal demands are yours to absorb.** Default
+  cadences are tuned to be polite, not to guarantee compliance with any
+  upstream's policy.
+- Depending on where you are, automated collection may implicate computer-misuse,
+  contract, copyright, database, or data-protection law. **If you are unsure,
+  get your own legal advice.** Nothing here is legal advice.
+
+## Personal data
+
+Public feeds carry information about identifiable people — vessel and aircraft
+operators, station owners, facility contacts, individuals named in news and
+conflict reporting. Reference datasets bundled in this repo are scrubbed of
+contact addresses on a best-effort basis, and that is **not** a compliance
+control.
+
+If you process personal data with this software, **you are the data controller**
+under the GDPR, the UK GDPR, and comparable regimes, and the obligations —
+lawful basis, minimisation, retention, subject rights — fall on you.
+
+## Accuracy and fitness
+
+The data is **frequently incomplete, delayed, spoofed, or simply wrong.**
+Aircraft and vessel transponders can be falsified or switched off; feeds gap
+without warning; conflict and hazard reporting is contested and revised;
+AI-generated summaries in this platform **can be confidently incorrect** and are
+not a substitute for a human analyst reading the source.
+
+**This is not certified for safety-of-life, navigation, air traffic control,
+emergency response, or any operational use where being wrong hurts someone.**
+It is not a targeting system. Do not use it as the sole basis for a decision
+affecting a person's safety, liberty, or rights.
+
+## Prohibited use
+
+Do not use this software to stalk, harass, surveil, dox, or target any
+individual or group; to violate anyone's privacy or human rights; or to break
+any applicable law, sanction, or export control. If that describes your use
+case, you do not have permission to use this project.
+
+## Reporting
+
+Found personal data in this repository that should not be here, or a connector
+that breaches an upstream's terms? Open an issue and it will be removed —
+[github.com/AndrewCTF/osint-geospatial-console/issues](https://github.com/AndrewCTF/osint-geospatial-console/issues).

--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,12 @@ Copyright 2026 Velocity contributors
 This product is licensed under the GNU Affero General Public License, Version 3.0 (see LICENSE).
 The AGPL-3.0 license covers Velocity's SOURCE CODE ONLY.
 
+NO WARRANTY, AND NO LIABILITY FOR YOUR USE OF THIS SOFTWARE OR THE DATA IT
+RETRIEVES. Some data is obtained by SCRAPING sources that have not authorised,
+endorsed, or partnered with this project; doing so may breach their terms. You
+run it, so the requests, the rate limits, the bans, and the legal exposure are
+yours. See DISCLAIMER.md — read it before running or redistributing.
+
 Velocity consumes data from third-party upstream feeds, EACH UNDER ITS OWN
 LICENSE AND TERMS. The code license does not relicense that data. Before any
 commercial or redistributive use, verify each upstream's CURRENT terms — some

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ labelled as automated output, not sold as "AI insight."
 > Europe (global coverage is sparser and terrestrial-biased), and the 3D
 > satellite mode is a VRAM hog.
 
+> **Use at your own risk.** No warranty; the authors take no responsibility for
+> your use of this tool or the data it pulls. Velocity scrapes third-party
+> sources that have not authorised it — **their** terms bind **you**, the
+> requests come from **your** IP, and rate limits, bans, and legal exposure are
+> yours to absorb. Feeds are often incomplete, delayed, or spoofed, and the AI
+> summaries can be confidently wrong. Not for safety-of-life, navigation, or any
+> use where being wrong hurts someone. Read [`DISCLAIMER.md`](./DISCLAIMER.md)
+> before you run it.
+
 ## Prerequisites
 
 Honestly, not much. There are two ways to run it, pick whichever you're set up for:
@@ -587,3 +596,7 @@ carries its own licenses**; several feeds are non-commercial / academic (e.g.
 ACLED, adsb.fi, OpenSky). See [`NOTICE`](./NOTICE) for per-source attribution and
 terms, and verify each upstream's current terms before any commercial or
 redistributive use.
+
+No warranty, and no liability for how you collect or use the data — see
+[`DISCLAIMER.md`](./DISCLAIMER.md), which also covers scraping, upstream terms,
+personal data, and prohibited uses.

--- a/apps/api/app/routes/adsb.py
+++ b/apps/api/app/routes/adsb.py
@@ -39,7 +39,7 @@ import hashlib
 import json
 import threading
 import time
-from math import cos, radians
+from math import cos, radians, sin, sqrt
 from typing import Any
 
 import httpx
@@ -893,6 +893,12 @@ async def _opensky_cached() -> dict[str, Any] | None:
 # raw list instantly. Downstream `_merge_with_previous` (180s) ages out a stale
 # cached firehose if the host later goes dark.
 _FIREHOSE_DEAD_SKIP_S = 30.0
+# Re-pull cadence after a SUCCESSFUL pull. Without this only the failure path
+# armed _FIREHOSE_NEXT_TRY, so a working firehose was re-kicked on every fan-out
+# tick — a back-to-back 5-6MB download loop against a host CLAUDE.md documents as
+# rate-limiting bursts. The tier is breadth, not freshness (the 1s feeds own
+# freshness), so a 15s cadence loses nothing.
+_FIREHOSE_OK_INTERVAL_S = 15.0
 _FIREHOSE_NEXT_TRY: float = 0.0
 _FIREHOSE_RAW: list[dict[str, Any]] = []  # last good raw aircraft list
 _FIREHOSE_REFRESH_TASK: asyncio.Task[None] | None = None
@@ -906,6 +912,7 @@ async def _firehose_refresh_once() -> None:
     fh = await _try_firehose()
     if fh:
         _FIREHOSE_RAW = fh
+        _FIREHOSE_NEXT_TRY = time.monotonic() + _FIREHOSE_OK_INTERVAL_S
     else:
         _FIREHOSE_NEXT_TRY = time.monotonic() + _FIREHOSE_DEAD_SKIP_S
 
@@ -1197,13 +1204,71 @@ async def _readsb_feeds() -> list[dict[str, Any]]:
     return [v[1] for v in best.values()]
 
 
+def _feat_obs_at(f: dict[str, Any]) -> float | None:
+    """Wall-clock time this feature's POSITION was actually observed, or None.
+
+    `seen_at` = when WE received the body; `seen_pos_s` = how old the position
+    already was INSIDE it. Their difference is the only stamp comparable ACROSS
+    tiers, because it ages a cached tier honestly: the firehose serves
+    `_FIREHOSE_RAW` (stamped `_seen_at` once, at pull time) until the next
+    successful pull, so its features get older as the cache sits, while a
+    1 s-cadence feed re-stamps `_seen_at` every pull and stays fresh.
+
+    Comparing raw `seen_pos_s` instead is the trap: it is the age at UPSTREAM
+    serve time, so a slow/cached tier reports 0.3 s forever no matter how long
+    the body has been sitting in our cache.
+    """
+    p = f.get("properties") or {}
+    seen_at = p.get("seen_at")
+    if not isinstance(seen_at, (int, float)):
+        return None
+    sp = p.get("seen_pos_s")
+    return float(seen_at) - (float(sp) if isinstance(sp, (int, float)) else 0.0)
+
+
 def _merge_raw_into(by_id: dict[Any, dict[str, Any]], raw: list[dict[str, Any]]) -> None:
     """Convert raw aggregator aircraft dicts → features and union into by_id,
-    overwriting any existing entry for the same id (caller orders sources so the
-    freshest source is merged last)."""
+    keeping the FRESHEST OBSERVATION per id.
+
+    Was: overwrite unconditionally, relying on the caller to merge the freshest
+    tier last. That ordering assumption is what made aircraft fly BACKWARDS.
+    Tier 3 (firehose) serves a CACHED list — `_FIREHOSE_RAW` only changes when a
+    pull SUCCEEDS and never expires — and from this egress the only reachable
+    firehose verb (adsb.lol /v2/point) takes >60 s to download, so a
+    minutes-old fix overwrote the 0.1 s-old sidecar fix on every 1 s cycle. It
+    then flipped back whenever an aircraft fell outside the firehose's smaller
+    (~8-9k vs ~20k) coverage → position alternated stale↔live = visible reverse.
+    Measured before this change: 9.2% of airborne moves regressed along the
+    aircraft's own track_deg (median -3.8 km, worst -161 km).
+
+    Comparing observation time makes the union ORDER-INDEPENDENT — the same
+    freshest-wins rule `_readsb_feeds` already applies WITHIN the feeds tier.
+    An id nobody has yet is always taken, so breadth is unchanged.
+
+    Freshness only overrides tier order where it is actually KNOWN. Every real
+    tier stamps `_seen_at` at pull time (`_pull_one_feed`, `_try_firehose`,
+    `_grid_fanout`) and OpenSky stamps `seen_at`/`seen_pos_s` as it renders, so
+    in production the comparison always governs. When NEITHER side carries a
+    stamp there is no freshness signal to act on, and merge order is the only
+    remaining editorial signal (the caller orders tiers fresher-last), so we keep
+    the historical last-writer-wins. An unstamped newcomer never displaces a
+    stamped incumbent — that would be trading a known age for an unknown one.
+    """
     for f in _aircraft_geojson(raw).get("features") or []:
         fid = f.get("id")
-        if fid is not None:
+        if fid is None:
+            continue
+        cur = by_id.get(fid)
+        if cur is None:
+            by_id[fid] = f
+            continue
+        new_obs = _feat_obs_at(f)
+        cur_obs = _feat_obs_at(cur)
+        if new_obs is None and cur_obs is None:
+            by_id[fid] = f  # no freshness signal either side → tier order decides
+        elif new_obs is None:
+            continue  # unjudgeable → don't displace a stamped incumbent
+        elif cur_obs is None or new_obs > cur_obs:
             by_id[fid] = f
 
 
@@ -1371,6 +1436,71 @@ async def _do_global_fanout() -> dict[str, Any]:
     return {"type": "FeatureCollection", "features": list(by_id.values())}
 
 
+# Along-track regression guard. An AIRBORNE aircraft cannot move backwards along
+# its own reported track_deg; when the served position does, it is upstream noise
+# (a stale tier winning a cycle), and the icon visibly flies in reverse — which the
+# operator rejects outright. So a new fix that puts a fast, airborne contact more
+# than _BACKWARD_REJECT_M BEHIND the last SERVED one is dropped and the previous
+# fix is held. Same idea as tracks.ts's time-regression guard on the trail
+# polyline, applied one layer earlier so every consumer (globe, MCP, brief) sees a
+# monotone track.
+#
+# 250 m: a real forward step is ~250 m per 1 s cycle at 250 m/s and ADS-B position
+# noise is ~10-30 m, so 250 m of REVERSE is unphysical. Turning is safe too — the
+# projection only goes negative past 90° of turn, which needs ~30 s at a 3°/s
+# standard rate, and _BACKWARD_MAX_HOLD_S releases the hold well before that.
+_BACKWARD_REJECT_M = 250.0
+_BACKWARD_MIN_SPEED_MS = 60.0
+# Escape hatch: never hold a rejected position for longer than this. If the fix we
+# are holding ages past it we accept whatever upstream says, so a genuine
+# reposition/reacquisition (or a corrected bad fix) still lands instead of the
+# guard pinning a contact to a wrong spot forever.
+_BACKWARD_MAX_HOLD_S = 30.0
+# WGS84 radii of curvature — local N/E metres per radian. Exact enough that the
+# along-track projection is metre-accurate over a single fix interval.
+_WGS84_A = 6378137.0
+_WGS84_E2 = 6.69437999014e-3
+
+
+def _along_track_delta_m(prev_f: dict[str, Any], new_f: dict[str, Any]) -> float | None:
+    """Signed along-track metres from prev's position to new's, projected on
+    prev's reported track. Negative = the contact moved BACKWARD."""
+    try:
+        pc = (prev_f.get("geometry") or {}).get("coordinates") or []
+        nc = (new_f.get("geometry") or {}).get("coordinates") or []
+        trk = (prev_f.get("properties") or {}).get("track_deg")
+        if len(pc) < 2 or len(nc) < 2 or not isinstance(trk, (int, float)):
+            return None
+        lat = radians(float(pc[1]))
+        s = sin(lat)
+        w2 = 1.0 - _WGS84_E2 * s * s
+        m_rad = _WGS84_A * (1.0 - _WGS84_E2) / (w2 * sqrt(w2))  # meridional
+        n_rad = _WGS84_A / sqrt(w2)  # prime vertical
+        d_north = radians(float(nc[1]) - float(pc[1])) * m_rad
+        d_east = radians(float(nc[0]) - float(pc[0])) * n_rad * cos(lat)
+        t = radians(float(trk))
+        return d_north * cos(t) + d_east * sin(t)
+    except (TypeError, ValueError):
+        return None
+
+
+def _regresses(prev_f: dict[str, Any], new_f: dict[str, Any], now: float) -> bool:
+    """True when new_f moves a fast, airborne contact BACKWARD along its own
+    track vs the last served fix — i.e. the new fix should be dropped."""
+    p = prev_f.get("properties") or {}
+    n = new_f.get("properties") or {}
+    if p.get("on_ground") or n.get("on_ground"):
+        return False
+    v = p.get("velocity_ms")
+    if not isinstance(v, (int, float)) or v < _BACKWARD_MIN_SPEED_MS:
+        return False
+    prev_obs = _feat_obs_at(prev_f)
+    if prev_obs is None or now - prev_obs > _BACKWARD_MAX_HOLD_S:
+        return False  # holding too long → accept upstream
+    d = _along_track_delta_m(prev_f, new_f)
+    return d is not None and d < -_BACKWARD_REJECT_M
+
+
 def _merge_with_previous(
     new_fc: dict[str, Any], prev_fc: dict[str, Any], max_age_s: float = 180.0
 ) -> dict[str, Any]:
@@ -1388,11 +1518,25 @@ def _merge_with_previous(
     (~30 s) plus several missed OpenSky pulls (15 s pacing + backoff) —
     shorter windows made oceanic OpenSky-only contacts flicker."""
     now = time.time()
+    prev_by_id: dict[Any, dict[str, Any]] = {}
+    for f in prev_fc.get("features") or []:
+        fid = f.get("id")
+        if fid is not None:
+            prev_by_id[fid] = f
     by_id: dict[Any, dict[str, Any]] = {}
     for f in new_fc.get("features") or []:
         fid = f.get("id")
-        if fid is not None:
-            by_id[fid] = f
+        if fid is None:
+            continue
+        # Hold the last SERVED fix when the new one would fly the contact
+        # backwards along its own track (see _regresses). The live tiers keep
+        # delivering FORWARD fixes, so only the regressing ones are dropped and
+        # the contact keeps advancing — it does not freeze.
+        prev = prev_by_id.get(fid)
+        if prev is not None and _regresses(prev, f, now):
+            by_id[fid] = prev
+            continue
+        by_id[fid] = f
     for f in prev_fc.get("features") or []:
         fid = f.get("id")
         if fid is None or fid in by_id:

--- a/apps/api/tests/test_adsb_no_reverse.py
+++ b/apps/api/tests/test_adsb_no_reverse.py
@@ -1,0 +1,227 @@
+"""Guards: the served ADS-B snapshot must never fly an aircraft BACKWARDS.
+
+Measured on a warm backend 2026-07-14, BEFORE these guards: 9.2% of airborne
+consecutive moves in /api/adsb/global regressed along the aircraft's own
+track_deg (median -3.8 km, worst -161 km), across 5,531 distinct aircraft in
+60 s. Root cause: the snapshot tier merge was last-writer-wins, and tier 3
+(firehose) serves a CACHED list that never expires — from this egress the only
+reachable firehose verb takes >60 s to download, so a minutes-old fix overwrote
+the 0.1 s-old sidecar fix, then flipped back whenever the aircraft fell outside
+the firehose's smaller coverage.
+
+Two independent guards, both exercised here:
+  1. _merge_raw_into keeps the FRESHEST OBSERVATION → the union is
+     order-independent, so no tier can clobber a fresher one by merging later.
+  2. _regresses / _merge_with_previous drop a fix that moves a fast airborne
+     contact backwards along its own track, whatever tier produced it.
+
+See docs/decisions.md and the module comments in routes/adsb.py.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+
+from app.routes.adsb import (
+    _BACKWARD_MAX_HOLD_S,
+    _along_track_delta_m,
+    _feat_obs_at,
+    _merge_raw_into,
+    _merge_with_previous,
+    _regresses,
+)
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+_LAT = 40.0
+_LON = -75.0
+
+
+def _raw(hexid="abc123", lon=_LON, lat=_LAT, seen_pos=0.1, seen_at=1000.0, gs=485.0, track=90.0):
+    """A readsb-shaped raw aircraft dict (the shape _aircraft_geojson parses)."""
+    return {
+        "hex": hexid,
+        "lat": lat,
+        "lon": lon,
+        "gs": gs,  # knots
+        "track": track,
+        "alt_baro": 35000,
+        "category": "A3",
+        "flight": "TEST123",
+        "seen_pos": seen_pos,
+        "_seen_at": seen_at,
+    }
+
+
+def _feat(lon=_LON, lat=_LAT, seen_at=None, seen_pos=0.1, gs_ms=250.0, track=90.0, ground=False):
+    """A snapshot feature (the shape _merge_with_previous handles).
+
+    seen_at defaults to REAL now: _merge_with_previous reads time.time() itself,
+    so a fixed epoch would look decades stale and trip the escape hatch.
+    """
+    if seen_at is None:
+        seen_at = time.time()
+    return {
+        "type": "Feature",
+        "id": "aircraft:abc123",
+        "geometry": {"type": "Point", "coordinates": [lon, lat, 10000.0]},
+        "properties": {
+            "icao24": "abc123",
+            "velocity_ms": gs_ms,
+            "track_deg": track,
+            "on_ground": ground,
+            "seen_at": seen_at,
+            "seen_pos_s": seen_pos,
+        },
+    }
+
+
+def _shift_east(lon, lat, metres):
+    """Move a lon/lat east by `metres` (small-step, good enough for a fixture)."""
+    n = 6378137.0 / math.sqrt(1 - 6.69437999014e-3 * math.sin(math.radians(lat)) ** 2)
+    return lon + math.degrees(metres / (n * math.cos(math.radians(lat)))), lat
+
+
+# ── guard 1: the union is freshest-wins, not last-writer-wins ──────────────────
+
+
+def test_stale_tier_merged_last_does_not_clobber_a_fresher_fix():
+    """THE REGRESSION. Tier 3 (a cached firehose) must not overwrite tier 2's
+    fresher fix just by merging later."""
+    by_id: dict = {}
+    # Fresh: received at t=1000, position was 0.1s old inside → observed ~999.9.
+    _merge_raw_into(by_id, [_raw(lon=_LON, seen_at=1000.0, seen_pos=0.1)])
+    fresh_lon = by_id["aircraft:abc123"]["geometry"]["coordinates"][0]
+    # Stale cached tier: pulled 90s ago; it still CLAIMS seen_pos=0.3 (the lie —
+    # that is the age at UPSTREAM serve time, not at our use time).
+    stale_lon, _ = _shift_east(_LON, _LAT, -20_000)
+    _merge_raw_into(by_id, [_raw(lon=stale_lon, seen_at=910.0, seen_pos=0.3)])
+    assert by_id["aircraft:abc123"]["geometry"]["coordinates"][0] == fresh_lon, (
+        "a cached tier merged last overwrote a fresher fix — the reverse bug"
+    )
+
+
+def test_fresher_tier_merged_last_does_win():
+    """The flip side: freshness, not order, decides — a genuinely fresher fix
+    merged later must still land (otherwise we'd just freeze the map)."""
+    by_id: dict = {}
+    _merge_raw_into(by_id, [_raw(lon=_LON, seen_at=910.0, seen_pos=0.3)])
+    newer_lon, _ = _shift_east(_LON, _LAT, 20_000)
+    _merge_raw_into(by_id, [_raw(lon=newer_lon, seen_at=1000.0, seen_pos=0.1)])
+    assert by_id["aircraft:abc123"]["geometry"]["coordinates"][0] == newer_lon
+
+
+def test_merge_order_does_not_change_the_result():
+    """Order-independence is the actual invariant — assert it directly."""
+    a = _raw(lon=_LON, seen_at=1000.0, seen_pos=0.1)
+    b_lon, _ = _shift_east(_LON, _LAT, -20_000)
+    b = _raw(lon=b_lon, seen_at=910.0, seen_pos=0.3)
+    ab: dict = {}
+    _merge_raw_into(ab, [a])
+    _merge_raw_into(ab, [b])
+    ba: dict = {}
+    _merge_raw_into(ba, [b])
+    _merge_raw_into(ba, [a])
+    assert (
+        ab["aircraft:abc123"]["geometry"]["coordinates"]
+        == ba["aircraft:abc123"]["geometry"]["coordinates"]
+    )
+
+
+def test_merge_still_adds_aircraft_nobody_else_has():
+    """Breadth must be unchanged: an id with no incumbent is always taken."""
+    by_id: dict = {}
+    _merge_raw_into(by_id, [_raw(hexid="aaa111", seen_at=1000.0)])
+    _merge_raw_into(by_id, [_raw(hexid="bbb222", seen_at=500.0, seen_pos=99.0)])
+    assert set(by_id) == {"aircraft:aaa111", "aircraft:bbb222"}
+
+
+def test_feat_obs_at_ages_a_cached_tier():
+    """_feat_obs_at must age a cached tier by its ORIGINAL receipt stamp."""
+    fresh = _feat(seen_at=1000.0, seen_pos=0.1)
+    cached = _feat(seen_at=910.0, seen_pos=0.3)  # same claimed seen_pos, 90s stale
+    assert _feat_obs_at(fresh) > _feat_obs_at(cached)
+    assert _feat_obs_at({"properties": {}}) is None
+
+
+# ── guard 2: along-track regression is rejected ────────────────────────────────
+
+
+def test_regressing_fix_is_dropped_and_previous_held():
+    """A fix that puts a fast airborne contact 3 km behind its last served
+    position is upstream noise — hold the previous fix."""
+    now = time.time()
+    prev = _feat(lon=_LON, seen_at=now)
+    back_lon, _ = _shift_east(_LON, _LAT, -3000)
+    new = _feat(lon=back_lon, seen_at=now + 1)
+    merged = _merge_with_previous({"features": [new]}, {"features": [prev]})
+    assert merged["features"][0]["geometry"]["coordinates"][0] == _LON
+
+
+def test_forward_fix_is_always_accepted():
+    """The guard must not freeze the map: forward motion always lands."""
+    now = time.time()
+    prev = _feat(lon=_LON, seen_at=now)
+    fwd_lon, _ = _shift_east(_LON, _LAT, 1500)
+    new = _feat(lon=fwd_lon, seen_at=now + 1)
+    merged = _merge_with_previous({"features": [new]}, {"features": [prev]})
+    assert merged["features"][0]["geometry"]["coordinates"][0] == fwd_lon
+
+
+def test_small_backward_jitter_is_tolerated():
+    """ADS-B position noise is ~10-30 m — under the 250 m threshold it must not
+    trip the guard, or we'd hold on noise."""
+    now = time.time()
+    prev = _feat(lon=_LON, seen_at=now)
+    jitter_lon, _ = _shift_east(_LON, _LAT, -30)
+    new = _feat(lon=jitter_lon, seen_at=now + 1)
+    merged = _merge_with_previous({"features": [new]}, {"features": [prev]})
+    assert merged["features"][0]["geometry"]["coordinates"][0] == jitter_lon
+
+
+def test_guard_releases_once_the_held_fix_goes_stale():
+    """Escape hatch: never pin a contact to a wrong spot forever. Past
+    _BACKWARD_MAX_HOLD_S the new fix is accepted even if it regresses."""
+    now = time.time()
+    prev = _feat(lon=_LON, seen_at=now - _BACKWARD_MAX_HOLD_S - 5)
+    back_lon, _ = _shift_east(_LON, _LAT, -3000)
+    new = _feat(lon=back_lon, seen_at=now)
+    assert _regresses(prev, new, now) is False
+
+
+def test_on_ground_and_slow_contacts_are_exempt():
+    """Taxiing aircraft legitimately move against a stale track_deg; pushback is
+    literally backwards. The guard is for FAST AIRBORNE contacts only."""
+    now = time.time()
+    back_lon, _ = _shift_east(_LON, _LAT, -3000)
+    grounded_prev = _feat(lon=_LON, seen_at=now, ground=True)
+    assert _regresses(grounded_prev, _feat(lon=back_lon, ground=True), now + 1) is False
+    slow_prev = _feat(lon=_LON, seen_at=now, gs_ms=10.0)
+    assert _regresses(slow_prev, _feat(lon=back_lon, gs_ms=10.0), now + 1) is False
+
+
+def test_regresses_tolerates_malformed_features():
+    """Never 500 the snapshot on a junk upstream record."""
+    assert _regresses({"properties": {}}, _feat(), time.time()) is False
+    assert _along_track_delta_m({"geometry": {"coordinates": []}}, _feat()) is None
+    assert _along_track_delta_m(_feat(), {"geometry": {"coordinates": [None, None]}}) is None
+
+
+def test_along_track_delta_sign_and_magnitude():
+    """Sanity-check the projection itself: east-bound contact, moved 1 km east."""
+    prev = _feat(lon=_LON, track=90.0)
+    east_lon, _ = _shift_east(_LON, _LAT, 1000)
+    d = _along_track_delta_m(prev, _feat(lon=east_lon))
+    assert d is not None and abs(d - 1000.0) < 5.0
+    west_lon, _ = _shift_east(_LON, _LAT, -1000)
+    d_back = _along_track_delta_m(prev, _feat(lon=west_lon))
+    assert d_back is not None and abs(d_back + 1000.0) < 5.0
+
+
+def test_carry_forward_still_works():
+    """The guard must not break the existing carry-forward (missing contacts are
+    held up to max_age_s so icons don't blink out)."""
+    prev = _feat(lon=_LON, seen_at=time.time())
+    merged = _merge_with_previous({"features": []}, {"features": [prev]})
+    assert len(merged["features"]) == 1

--- a/apps/api/tests/test_data_no_pii.py
+++ b/apps/api/tests/test_data_no_pii.py
@@ -1,0 +1,94 @@
+"""Guard: bundled reference data carries no contact addresses.
+
+Upstream operator/owner free-text (WRI GPPD `owner`, SatNOGS station `name`)
+ships named individuals' work emails. We redistribute these files, so
+`scripts/build_places_data.py::_scrub_pii` strips addresses at build time.
+This asserts the committed artifacts stay scrubbed and that the helper the
+generator uses actually works.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+DATA_DIR = ROOT / "apps" / "api" / "app" / "data"
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def _load_builder():
+    path = ROOT / "scripts" / "build_places_data.py"
+    spec = importlib.util.spec_from_file_location("build_places_data", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("name", ["infrastructure.json"])
+def test_bundled_data_has_no_email_addresses(name: str) -> None:
+    path = DATA_DIR / name
+    if not path.exists():
+        pytest.skip(f"{name} not built in this checkout")
+    found = sorted(set(EMAIL_RE.findall(path.read_text(encoding="utf-8"))))
+    assert found == [], f"{name} exposes contact addresses: {found}"
+
+
+def test_infrastructure_rows_still_intact() -> None:
+    """The scrub must redact fields, not drop records."""
+    path = DATA_DIR / "infrastructure.json"
+    if not path.exists():
+        pytest.skip("infrastructure.json not built in this checkout")
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    assert len(rows) > 120_000, f"row count collapsed to {len(rows)}"
+
+
+def test_scrub_pii_strips_address_but_keeps_the_org() -> None:
+    scrub = _load_builder()._scrub_pii
+    assert (
+        scrub("GEUK Direct LTD - Daniel Corcoran - daniel@geukdirect.com")
+        == "GEUK Direct LTD - Daniel Corcoran"
+    )
+    assert scrub("Innogy (Wai-Kit Cheung <waikit.cheung@belectric.co.uk>)") == "Innogy (Wai-Kit Cheung)"
+    assert scrub("Smarter Energy Solutions -  info@smarterenergysolutions.co.uk") == "Smarter Energy Solutions"
+    # a field that is nothing but an address collapses, so callers can default it
+    assert scrub("shiggy@iprimus.com.au") is None
+    assert scrub("") is None
+    assert scrub(None) is None
+    # untouched when there is no address
+    assert scrub("Kajaki Hydroelectric Power Plant") == "Kajaki Hydroelectric Power Plant"
+
+
+def test_no_real_user_uuid_in_beta_sql_doc() -> None:
+    """The tier-grant runbook must use placeholders, not a live auth user id."""
+    doc = ROOT / "docs" / "beta-sql-commands.md"
+    if not doc.exists():
+        pytest.skip("beta-sql-commands.md absent")
+    text = doc.read_text(encoding="utf-8")
+    uuids = re.findall(r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", text)
+    assert uuids == [], f"live user uuid in a committed doc: {uuids}"
+    real = [e for e in EMAIL_RE.findall(text) if not e.endswith("@example.com")]
+    assert real == [], f"real address in a committed doc: {real}"
+
+
+# The maintainer's own account and the prod Supabase project id kept getting
+# pasted into dogfood/stress-test writeups. Docs are the leak site, not code.
+_OPERATOR_PII = re.compile(r"andrewyong\.dev|xryong|dagqceedkxxvvbhmewca", re.I)
+
+
+def test_docs_carry_no_operator_account_or_prod_project_id() -> None:
+    docs = ROOT / "docs"
+    if not docs.exists():
+        pytest.skip("docs/ absent")
+    hits = [
+        f"{p.relative_to(ROOT)}:{i}"
+        for p in docs.rglob("*.md")
+        for i, line in enumerate(p.read_text(encoding="utf-8", errors="ignore").splitlines(), 1)
+        if _OPERATOR_PII.search(line)
+    ]
+    assert hits == [], f"operator account / prod project id in committed docs: {hits}"

--- a/apps/web/src/globe/adapters/PollGeoJsonAdapter.ts
+++ b/apps/web/src/globe/adapters/PollGeoJsonAdapter.ts
@@ -33,6 +33,7 @@ import {
   vesselSilhouette,
 } from '../../entity-panel/silhouettes.js';
 import { PrimitiveEntityLayer } from './PrimitiveEntityLayer.js';
+import { ingestFix, projectAt, type DrFix, type DrState } from './deadReckon.js';
 import { frameBudgetRemaining, recordFrameSpend } from '../frameBudget.js';
 import { perfSetDrain } from '../perf.js';
 import { isCameraMoving, cameraMovingForMs } from '../cameraMotion.js';
@@ -121,45 +122,43 @@ const VESSEL_FREEZE_POS_EPSILON_M = 25;
 // ── FlightRadar24-style dead-reckoning (operator opt-in 2026-06-28) ──────────
 // OFF by default; gated entirely on `useSettings().aircraftDeadReckon`. The
 // default aircraft path TELEPORTS to each real fix and forbids extrapolation
-// (CLAUDE.md). When the operator opts in, we feed each REAL fix into ONE
-// persistent SampledPositionProperty per aircraft and let Cesium's linear
-// interpolator carry the icon between fixes AND continue PAST the newest fix
-// along the last real segment's velocity (`ExtrapolationType.EXTRAPOLATE`,
-// capped at DEAD_RECKON_MAX_S then HOLD). This is the FR24 effect.
+// (CLAUDE.md). When the operator opts in, each REAL fix becomes a motion ANCHOR
+// and the icon's position is a pure function of that anchor + the clock:
 //
-// The FIRST cut re-created a fresh 2-sample property anchored at a fake
-// 90s-projected point every poll. That lost the trajectory and re-anchored to
-// "now" each time, so a stale RE-SENT fix (the feed repeats the last position
-// until a fresh one lands) snapped the icon BACK and reversed it. The fix:
-// keep the samples, derive velocity from REAL consecutive fixes (so a resend =
-// no new sample = the glide simply continues), and only add a sample when the
-// reported position actually moved (`drLastReal` gate in drain()). Positions
-// while ON are ESTIMATED, not observed; a map badge says so.
-// Glide tuning. Two segments per fix: (1) EASE from the current rendered position
-// TO the new real fix over ~the last inter-fix gap (converges on truth, no snap),
-// then (2) FORWARD-PROJECT past it along the contact's OWN reported track_deg at
-// velocity_ms for DR_PROJECT_HORIZON_S, then HOLD — so the icon keeps moving
-// through a signal gap instead of freezing at the last fix. The FIRST cut
-// extrapolated a velocity DERIVED from consecutive noisy fixes and overshot, then
-// snapped back; projecting along the REPORTED heading/speed stays close to truth,
-// so the next fix only nudges it (segment 1 absorbs the small correction). A
-// later cut dropped projection entirely (HOLD only) — that fixed the snap but
-// froze contacts with no fresh fix, the "keep planes moving doesn't" report. See
-// deadReckonSample().
-const DR_MIN_GLIDE_S = 1.5;
-const DR_MAX_GLIDE_S = 30;
-const DR_MAX_SPEED_MS = 600; // clamp apparent glide speed so a big gap can't streak
-const DR_FUTURE_ISO = '2100-01-01T00:00:00Z';
-// Forward-projection horizon (s): past the newest REAL fix the icon keeps gliding
-// along the reported track_deg at velocity_ms for this long, THEN holds. This is
-// what makes "keep planes moving" actually keep a contact moving during a signal
-// gap (the previous HOLD-only glide converged on the last fix and froze). 120 s
-// comfortably spans the observed <=20 s inter-fix gaps, so a live contact is
-// always mid-projection when its next fix lands — continuous motion — while a
-// contact that TRULY lost signal coasts for ~2 min then holds instead of flying
-// off forever. Positions here are ESTIMATED (the PredictedMotionBadge says so).
-const DR_PROJECT_HORIZON_S = 120;
-const DR_MIN_PROJECT_SPEED_MS = 5; // below this a contact is parked → don't project
+//     position(t) = advance(anchor, track_deg, velocity_ms * max(0, t - t0))
+//
+// The model lives in deadReckon.ts (pure + unit-tested); this file only supplies
+// fixes and owns the Cesium property. Positions while ON are ESTIMATED, not
+// observed — the PredictedMotionBadge says so.
+//
+// REWRITTEN 2026-07-14 against two operator requirements: the icon must move at
+// the ACTUAL reported speed, and must NEVER go in reverse. Both are now
+// structural (see deadReckon.ts), and the sampled-glide history below is exactly
+// why — do not reintroduce any of it:
+//   - Cut 1 re-created a 2-sample property anchored at a fake 90 s-projected
+//     point every poll, so a resent fix snapped the icon BACK.
+//   - Cut 2 derived velocity from consecutive noisy fixes → overshoot + snap-back.
+//     (Measured 2026-07-14: only 13.5% of consecutive fix pairs give a speed
+//     within ±10% of the reported velocity_ms. Never fit velocity from fixes.)
+//   - Cut 3 dropped projection entirely (HOLD only) → contacts froze between
+//     fixes: the "keep planes moving doesn't" report.
+//   - Cut 4 (this rewrite's predecessor) EASED from the rendered position to the
+//     new fix over the inter-fix gap, then projected past it. That glide's
+//     apparent speed was dist/gap — arbitrary, NOT velocity_ms (requirement 1
+//     broken) — and when a stale fix landed behind the icon it GLIDED backwards
+//     over up to 30 s (requirement 2 broken). This is what the operator saw.
+//
+// The `drLastReal` gate in drain() stays load-bearing: only a fix whose reported
+// position actually MOVED becomes a new anchor. The feed repeats the last
+// position until a fresh one lands, and its seen_pos_s does not always grow with
+// it, so re-anchoring on a resend would restart the projection from the old
+// position — snapping the icon backwards.
+//
+// NOTE: the reverse the operator reported was ALSO being fed by the backend —
+// the snapshot tier merge served fixes that regressed along track (measured 9.2%
+// of airborne moves, median -3.8 km). Fixed in routes/adsb.py (_merge_raw_into
+// freshest-wins + the _regresses guard). No frontend model can fix a feed that
+// moves aircraft backwards; both halves are required.
 
 // Camera altitude (m) above which vessel glide is FROZEN. WHY: vessels glide via
 // SampledPositionProperty, which Cesium re-evaluates every frame the clock
@@ -416,104 +415,80 @@ export class PollGeoJsonAdapter implements LayerAdapter {
   // contacts every poll.
   private lastTrackPushMs = new Map<string, number>();
   // Dead-reckon only: last REAL fix position per id (Cartesian). Used to detect
-  // a resent/stale fix (same position) so we DON'T re-glide to a place the icon
-  // already reached.
+  // a resent/stale fix (same position) so we DON'T re-anchor on it. This gate is
+  // load-bearing: the feed repeats the last position until a fresh one lands, and
+  // its `seen_pos_s` does NOT always grow with it. Re-anchoring on a resend would
+  // restart the projection from the OLD position — i.e. snap the icon backwards.
   private drLastReal = new Map<string, Cesium.Cartesian3>();
-  // Dead-reckon only: sim-clock time of each id's last REAL fix, to size the
-  // glide duration (≈ the gap between fixes → continuous motion that arrives at
-  // truth just as the next fix lands).
-  private drLastT = new Map<string, Cesium.JulianDate>();
+  // Dead-reckon only: per-contact motion anchor (see deadReckon.ts). The icon's
+  // position is a pure function of this + the clock, so it always moves at the
+  // reported ground speed along the reported track, and never backwards.
+  private drState = new Map<string, DrState>();
+  // Dead-reckon only: the CallbackPositionProperty per id. Kept so a new fix
+  // mutates the anchor a live property already reads, rather than swapping the
+  // property (which would re-dirty the entity every poll).
+  private drProp = new Map<string, Cesium.CallbackPositionProperty>();
+  // Fixed origin for sim-clock→seconds. JulianDate.secondsDifference against a
+  // stable epoch keeps the motion model in plain seconds; the epoch cancels out.
+  private drEpoch: Cesium.JulianDate | null = null;
 
-  // FR24-style glide: ease the icon from where it currently renders TO the new
-  // REAL fix over ~the last inter-fix gap. Reuses the entity's SampledPosition-
-  // Property; drops any not-yet-reached future samples first so the new glide
-  // starts cleanly from the current position (no kink back toward the old
-  // target). HOLD past the newest fix — never extrapolate, so never overshoot.
-  private deadReckonSample(
-    existing: Cesium.Entity | undefined,
-    id: string,
-    t0: Cesium.JulianDate,
-    newPos: Cesium.Cartesian3,
-    trackDeg: number | null,
-    velocityMs: number | null,
-  ): Cesium.SampledPositionProperty {
-    let sampled =
-      existing && existing.position instanceof Cesium.SampledPositionProperty
-        ? existing.position
-        : undefined;
-    // Where the icon is RIGHT NOW (sim-clock time), to start the glide from.
-    let cur: Cesium.Cartesian3 | undefined;
-    if (existing && existing.position) {
-      try {
-        cur = existing.position.getValue(t0) as Cesium.Cartesian3 | undefined;
-      } catch {
-        cur = undefined;
-      }
-    }
-    if (!sampled) {
-      sampled = new Cesium.SampledPositionProperty();
-      sampled.setInterpolationOptions({
-        interpolationAlgorithm: Cesium.LinearApproximation,
-        interpolationDegree: 1,
-      });
-      sampled.forwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
-      sampled.backwardExtrapolationType = Cesium.ExtrapolationType.HOLD;
-    } else {
-      // Drop the prior glide's unreached future samples so we don't first head
-      // to the old target and then to the new one.
-      sampled.removeSamples(
-        new Cesium.TimeInterval({
-          start: t0,
-          stop: Cesium.JulianDate.fromIso8601(DR_FUTURE_ISO),
-          isStartIncluded: false,
-          isStopIncluded: true,
-        }),
-      );
-    }
-    const lastT = this.drLastT.get(id);
-    let glideS = lastT
-      ? Math.min(
-          Math.max(Math.abs(Cesium.JulianDate.secondsDifference(t0, lastT)), DR_MIN_GLIDE_S),
-          DR_MAX_GLIDE_S,
-        )
-      : DR_MIN_GLIDE_S;
-    if (cur) {
-      glideS = Math.max(glideS, Cesium.Cartesian3.distance(cur, newPos) / DR_MAX_SPEED_MS);
-      sampled.addSample(t0, cur); // bridge: start from where the icon is now
-    }
-    const arrive = Cesium.JulianDate.addSeconds(t0, glideS, new Cesium.JulianDate());
-    sampled.addSample(arrive, newPos);
-    // FR24 forward projection: continue PAST the real fix along the reported
-    // heading at the reported ground speed for DR_PROJECT_HORIZON_S, then HOLD
-    // (forwardExtrapolationType). This is what keeps a contact MOVING through a
-    // signal gap — without it the glide converged on the last fix and froze.
-    // Using the contact's OWN track+speed (not a fit) keeps the estimate close to
-    // truth, so the next real fix only nudges it (no overshoot/snap-back). A new
-    // fix clears this sample via removeSamples above and re-projects from truth.
-    if (trackDeg != null && velocityMs != null && velocityMs > DR_MIN_PROJECT_SPEED_MS) {
-      const dist = velocityMs * DR_PROJECT_HORIZON_S;
-      const brg = Cesium.Math.toRadians(trackDeg);
-      const enu = Cesium.Transforms.eastNorthUpToFixedFrame(newPos);
-      const local = new Cesium.Cartesian3(Math.sin(brg) * dist, Math.cos(brg) * dist, 0);
-      const projected = Cesium.Matrix4.multiplyByPoint(enu, local, new Cesium.Cartesian3());
-      sampled.addSample(
-        Cesium.JulianDate.addSeconds(arrive, DR_PROJECT_HORIZON_S, new Cesium.JulianDate()),
-        projected,
-      );
-    }
-    this.drLastT.set(id, t0.clone());
-    // Bound memory: keep only the last 5 min.
-    const cutoff = Cesium.JulianDate.addSeconds(t0, -300, new Cesium.JulianDate());
-    sampled.removeSamples(
-      new Cesium.TimeInterval({
-        start: Cesium.JulianDate.fromIso8601('1970-01-01T00:00:00Z'),
-        stop: cutoff,
-        isStartIncluded: true,
-        isStopIncluded: false,
-      }),
-    );
-    return sampled;
+  /** Sim-clock JulianDate → seconds since this adapter's epoch. */
+  private drSecs(t: Cesium.JulianDate): number {
+    if (!this.drEpoch) this.drEpoch = t.clone();
+    return Cesium.JulianDate.secondsDifference(t, this.drEpoch);
   }
+
+  // FR24-style dead-reckoning: hand the fix to the motion model (deadReckon.ts)
+  // and let the icon's position be a pure function of the anchor + the clock.
+  //
+  // The property is a CallbackPositionProperty rather than a SampledPosition-
+  // Property because the motion is ANALYTIC, not sampled: there is nothing to
+  // interpolate between. That is what makes the two operator requirements
+  // structural rather than tuned — the icon moves at exactly `velocity_ms` along
+  // exactly `track_deg`, and cannot move backwards. The old sampled glide eased
+  // from the current render position TO the new fix over the inter-fix gap, so its
+  // apparent speed was dist/gap (arbitrary, unrelated to velocity_ms) and a stale
+  // fix landing behind the icon was GLIDED to — the reported reverse.
+  private deadReckonPosition(
+    id: string,
+    t: Cesium.JulianDate,
+    fix: DrFix,
+  ): Cesium.CallbackPositionProperty {
+    this.drState.set(id, ingestFix(this.drState.get(id), fix, this.drSecs(t)));
+    let prop = this.drProp.get(id);
+    if (!prop) {
+      // isConstant=false: Cesium must re-evaluate every frame the clock advances.
+      prop = new Cesium.CallbackPositionProperty((time, result) => {
+        const s = this.drState.get(id);
+        if (!s || !time) return undefined;
+        const p = projectAt(s, this.drSecs(time));
+        return Cesium.Cartesian3.fromRadians(p.lonRad, p.latRad, s.altM, undefined, result);
+      }, false) as Cesium.CallbackPositionProperty;
+      this.drProp.set(id, prop);
+    }
+    return prop;
+  }
+
+  /** Build a motion-model fix from a feed feature's property bag. */
+  private drFixFrom(props: Record<string, unknown>, lon: number, lat: number, alt: number): DrFix {
+    // Position age = now - (seen_at - seen_pos_s). seen_at is when the BACKEND
+    // received the body; seen_pos_s is how old the position already was inside
+    // it. Same derivation the track-trail push uses.
+    const seenAt = props['seen_at'];
+    const seenPos = props['seen_pos_s'];
+    const obsSec =
+      typeof seenAt === 'number' ? seenAt - (typeof seenPos === 'number' ? seenPos : 0) : null;
+    return {
+      lonDeg: lon,
+      latDeg: lat,
+      altM: alt,
+      trackDeg: typeof props['track_deg'] === 'number' ? props['track_deg'] : null,
+      speedMs: typeof props['velocity_ms'] === 'number' ? props['velocity_ms'] : null,
+      ageS: obsSec != null ? Math.max(0, Date.now() / 1000 - obsSec) : 0,
+      onGround: props['on_ground'] === true,
+    };
+  }
+
   // Absolute wall-clock target (ms) for the next poll. The grid scheduler books
   // ticks against this fixed timeline so cadence stays steady regardless of how
   // long each poll's fetch + render took. 0 = uninitialised (set on first tick).
@@ -760,7 +735,8 @@ export class PollGeoJsonAdapter implements LayerAdapter {
     this.lastPos.clear();
     this.lastTrackPushMs.clear();
     this.drLastReal.clear();
-    this.drLastT.clear();
+    this.drState.clear();
+    this.drProp.clear();
     this.primRenderer?.destroy();
     this.primRenderer = null;
     this.vesselCluster?.destroy();
@@ -1215,13 +1191,10 @@ export class PollGeoJsonAdapter implements LayerAdapter {
               this.refreshBag(existing, props);
               continue;
             } else {
-              existing.position = this.deadReckonSample(
-                existing,
+              existing.position = this.deadReckonPosition(
                 id,
-                this.props.ctx.viewer.clock.currentTime.clone(),
-                newPos,
-                typeof props['track_deg'] === 'number' ? props['track_deg'] : null,
-                typeof props['velocity_ms'] === 'number' ? props['velocity_ms'] : null,
+                this.props.ctx.viewer.clock.currentTime,
+                this.drFixFrom(props, lon, lat, alt ?? 0),
               );
               this.drLastReal.set(id, newPos.clone());
             }
@@ -1348,13 +1321,10 @@ export class PollGeoJsonAdapter implements LayerAdapter {
         const opts: Cesium.Entity.ConstructorOptions = {
           id,
           position: deadReckon
-            ? this.deadReckonSample(
-                undefined,
+            ? this.deadReckonPosition(
                 id,
-                this.props.ctx.viewer.clock.currentTime.clone(),
-                newPos,
-                typeof props['track_deg'] === 'number' ? props['track_deg'] : null,
-                typeof props['velocity_ms'] === 'number' ? props['velocity_ms'] : null,
+                this.props.ctx.viewer.clock.currentTime,
+                this.drFixFrom(props, lon, lat, alt ?? 0),
               )
             : newPos,
           properties: props,
@@ -1410,7 +1380,8 @@ export class PollGeoJsonAdapter implements LayerAdapter {
         this.lastPos.delete(oldId);
         this.lastTrackPushMs.delete(oldId);
         this.drLastReal.delete(oldId);
-        this.drLastT.delete(oldId);
+        this.drState.delete(oldId);
+        this.drProp.delete(oldId);
         const icao = this.ownedIcao.get(oldId);
         if (icao) {
           aircraftDedup.release(icao, layerIdForPrune);

--- a/apps/web/src/globe/adapters/deadReckon.test.ts
+++ b/apps/web/src/globe/adapters/deadReckon.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DR_COAST_MAX_S,
+  DR_MAX_FIX_AGE_S,
+  DR_BACK_TOLERATE,
+  DR_PHASE_DEADBAND_S,
+  advance,
+  alongTrackM,
+  ingestFix,
+  projectAt,
+  type DrFix,
+} from './deadReckon';
+
+/**
+ * Vincenty INVERSE geodesic distance (metres) on WGS84 — the independent
+ * yardstick for these tests.
+ *
+ * Deliberately a different algorithm from the module's forward radii-of-curvature
+ * step, so it genuinely cross-checks it. (A spherical great-circle is NOT a valid
+ * check here: on a 6371 km sphere it disagrees with the WGS84 ground distance by
+ * ~0.16%, which at 250 m/s reads as a 0.8 m/s speed error that isn't real.)
+ */
+function gc(aLon: number, aLat: number, bLon: number, bLat: number): number {
+  const a = 6378137.0;
+  const f = 1 / 298.257223563;
+  const b = (1 - f) * a;
+  const L = bLon - aLon;
+  const U1 = Math.atan((1 - f) * Math.tan(aLat));
+  const U2 = Math.atan((1 - f) * Math.tan(bLat));
+  const sU1 = Math.sin(U1);
+  const cU1 = Math.cos(U1);
+  const sU2 = Math.sin(U2);
+  const cU2 = Math.cos(U2);
+  let lam = L;
+  let sSig = 0;
+  let cSig = 0;
+  let sig = 0;
+  let cSqA = 0;
+  let c2sm = 0;
+  for (let i = 0; i < 200; i++) {
+    const sLam = Math.sin(lam);
+    const cLam = Math.cos(lam);
+    sSig = Math.sqrt((cU2 * sLam) ** 2 + (cU1 * sU2 - sU1 * cU2 * cLam) ** 2);
+    if (sSig === 0) return 0; // coincident
+    cSig = sU1 * sU2 + cU1 * cU2 * cLam;
+    sig = Math.atan2(sSig, cSig);
+    const sA = (cU1 * cU2 * sLam) / sSig;
+    cSqA = 1 - sA * sA;
+    c2sm = cSqA === 0 ? 0 : cSig - (2 * sU1 * sU2) / cSqA; // equatorial line
+    const C = (f / 16) * cSqA * (4 + f * (4 - 3 * cSqA));
+    const prev = lam;
+    lam = L + (1 - C) * f * sA * (sig + C * sSig * (c2sm + C * cSig * (-1 + 2 * c2sm * c2sm)));
+    if (Math.abs(lam - prev) < 1e-12) break;
+  }
+  const uSq = (cSqA * (a * a - b * b)) / (b * b);
+  const A = 1 + (uSq / 16384) * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
+  const B = (uSq / 1024) * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
+  const dSig =
+    B *
+    sSig *
+    (c2sm +
+      (B / 4) *
+        (cSig * (-1 + 2 * c2sm * c2sm) -
+          (B / 6) * c2sm * (-3 + 4 * sSig * sSig) * (-3 + 4 * c2sm * c2sm)));
+  return b * A * (sig - dSig);
+}
+
+const fix = (o: Partial<DrFix> = {}): DrFix => ({
+  lonDeg: -0.45,
+  latDeg: 51.47,
+  altM: 10000,
+  trackDeg: 90,
+  speedMs: 250,
+  ageS: 0,
+  onGround: false,
+  ...o,
+});
+
+describe('deadReckon — requirement 1: speed is the ACTUAL reported speed', () => {
+  // The operator requirement is exact: "the predicted motion speed must be the
+  // actual speed, not faster or slower".
+  it.each([
+    ['due east', 90],
+    ['due north', 0],
+    ['due west', 270],
+    ['due south', 180],
+    ['diagonal', 37.5],
+  ])('renders exactly velocity_ms on a %s track', (_label, trackDeg) => {
+    const s = ingestFix(undefined, fix({ trackDeg, speedMs: 250 }), 1000);
+    const a = projectAt(s, 1000);
+    const b = projectAt(s, 1010); // 10 s → must be exactly 2500 m
+    const measured = gc(a.lonRad, a.latRad, b.lonRad, b.latRad) / 10;
+    expect(measured).toBeCloseTo(250, 1); // within 0.1 m/s
+  });
+
+  it('holds exact speed across a range of speeds and latitudes', () => {
+    for (const speedMs of [60, 120, 250, 300]) {
+      for (const latDeg of [-60, -20, 0, 35, 51.47, 70]) {
+        const s = ingestFix(undefined, fix({ speedMs, latDeg, trackDeg: 45 }), 0);
+        const a = projectAt(s, 0);
+        const b = projectAt(s, 30);
+        const measured = gc(a.lonRad, a.latRad, b.lonRad, b.latRad) / 30;
+        expect(Math.abs(measured - speedMs) / speedMs).toBeLessThan(0.001); // <0.1%
+      }
+    }
+  });
+
+  it('speed is constant over the whole coast — no accel/decel segments', () => {
+    // The OLD model glided cur→fix over the inter-fix gap, so apparent speed was
+    // dist/gap = arbitrary. Sample every second; every second must be identical.
+    const s = ingestFix(undefined, fix({ speedMs: 200, trackDeg: 120 }), 0);
+    const speeds: number[] = [];
+    for (let t = 0; t < 30; t++) {
+      const a = projectAt(s, t);
+      const b = projectAt(s, t + 1);
+      speeds.push(gc(a.lonRad, a.latRad, b.lonRad, b.latRad));
+    }
+    for (const v of speeds) expect(v).toBeCloseTo(200, 1);
+  });
+});
+
+describe('deadReckon — requirement 2: NEVER moves backwards', () => {
+  it('is monotonically forward along track across the whole coast', () => {
+    const s = ingestFix(undefined, fix({ trackDeg: 270, speedMs: 240 }), 0);
+    let prev = projectAt(s, 0);
+    for (let t = 0.25; t <= DR_COAST_MAX_S + 20; t += 0.25) {
+      const cur = projectAt(s, t);
+      const d = alongTrackM(prev.lonRad, prev.latRad, cur.lonRad, cur.latRad, s.trackRad);
+      expect(d).toBeGreaterThanOrEqual(-1e-6);
+      prev = cur;
+    }
+  });
+
+  it('a STALE fix landing BEHIND the projection does not reverse the icon', () => {
+    // The exact reported bug: the feed re-sends an older position while we have
+    // already projected past it. The old code glided backwards to it over up to
+    // 30 s. Here the icon must not retreat along track.
+    const s0 = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    const at30 = projectAt(s0, 30);
+    // A fix 20 km BEHIND where we now render, claiming to be fresh.
+    const behind = fix({ lonDeg: -0.45, latDeg: 51.47, trackDeg: 90, speedMs: 250, ageS: 0 });
+    const s1 = ingestFix(s0, behind, 30);
+    const after = projectAt(s1, 30);
+    const jump = alongTrackM(at30.lonRad, at30.latRad, after.lonRad, after.latRad, s1.trackRad);
+    // It may SNAP back once (a genuine re-anchor to truth), but from then on it
+    // must only ever go forward — never a sustained backwards glide.
+    let prev = after;
+    for (let t = 30.25; t <= 60; t += 0.25) {
+      const cur = projectAt(s1, t);
+      const d = alongTrackM(prev.lonRad, prev.latRad, cur.lonRad, cur.latRad, s1.trackRad);
+      expect(d).toBeGreaterThanOrEqual(-1e-6);
+      prev = cur;
+    }
+    expect(Number.isFinite(jump)).toBe(true);
+  });
+
+  it('cannot reverse even if the sim clock is scrubbed backwards', () => {
+    const s = ingestFix(undefined, fix({ trackDeg: 45, speedMs: 250 }), 1000);
+    const atAnchor = projectAt(s, 1000);
+    const before = projectAt(s, 900); // 100 s BEFORE the anchor
+    expect(before.lonRad).toBeCloseTo(atAnchor.lonRad, 12);
+    expect(before.latRad).toBeCloseTo(atAnchor.latRad, 12);
+  });
+
+  it('a stream of jittery real-ish fixes never produces a backwards step', () => {
+    // Deterministic pseudo-noise on position/track/age, 6 s cadence like the feed.
+    let s = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    let rendered = projectAt(s, 0);
+    let seed = 7;
+    const rnd = (): number => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff - 0.5);
+    for (let k = 1; k <= 40; k++) {
+      const now = k * 6;
+      // Truth: flying east at 250 m/s from the origin, plus noise.
+      const truthLon = -0.45 + ((250 * now) / (6378137 * Math.cos((51.47 * Math.PI) / 180))) * (180 / Math.PI);
+      const f = fix({
+        lonDeg: truthLon + rnd() * 0.004,
+        latDeg: 51.47 + rnd() * 0.0008,
+        trackDeg: 90 + rnd() * 4,
+        speedMs: 250 + rnd() * 8,
+        ageS: Math.abs(rnd()) * 5,
+      });
+      s = ingestFix(s, f, now);
+      for (let t = now; t < now + 6; t += 0.5) {
+        const cur = projectAt(s, t);
+        const d = alongTrackM(rendered.lonRad, rendered.latRad, cur.lonRad, cur.latRad, s.trackRad);
+        // Allow the one-frame re-anchor snap at the fix boundary (t === now),
+        // but never a backwards step DURING the coast.
+        if (t > now) expect(d).toBeGreaterThanOrEqual(-1e-6);
+        rendered = cur;
+      }
+    }
+  });
+});
+
+describe('deadReckon — anchoring, coasting, freezing', () => {
+  it('anchors at the fix OBSERVATION time, so an aged fix renders carried forward', () => {
+    const s = ingestFix(undefined, fix({ ageS: 8, speedMs: 250, trackDeg: 90 }), 1000);
+    // Anchored 8 s in the past → at nowSec it has already flown 8 × 250 = 2000 m.
+    const atNow = projectAt(s, 1000);
+    const d = gc((-0.45 * Math.PI) / 180, (51.47 * Math.PI) / 180, atNow.lonRad, atNow.latRad);
+    expect(d).toBeCloseTo(2000, 0);
+  });
+
+  it('HOLDs past the coast limit instead of flying off forever', () => {
+    const s = ingestFix(undefined, fix({ speedMs: 250, trackDeg: 90 }), 0);
+    const atLimit = projectAt(s, DR_COAST_MAX_S);
+    const wayPast = projectAt(s, DR_COAST_MAX_S + 600);
+    expect(wayPast.lonRad).toBeCloseTo(atLimit.lonRad, 12);
+    expect(wayPast.latRad).toBeCloseTo(atLimit.latRad, 12);
+  });
+
+  it.each([
+    ['on_ground', { onGround: true }],
+    ['parked (below min speed)', { speedMs: 3 }],
+    ['stale fix (OpenSky breadth tier)', { ageS: DR_MAX_FIX_AGE_S + 1 }],
+    ['no track', { trackDeg: null }],
+    ['no speed', { speedMs: null }],
+  ])('does NOT synthesise motion for %s — it holds at the reported fix', (_l, over) => {
+    const s = ingestFix(undefined, fix(over as Partial<DrFix>), 0);
+    expect(s.frozen).toBe(true);
+    const a = projectAt(s, 0);
+    const b = projectAt(s, 120);
+    expect(a.lonRad).toBe(b.lonRad);
+    expect(a.latRad).toBe(b.latRad);
+  });
+
+  it('a small correction is absorbed as a phase shift — no position jump', () => {
+    const s0 = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    const at12 = projectAt(s0, 12);
+    // Next fix ~1 s of flight behind the projection → inside the deadband.
+    const nudged = advance(s0.lonRad, s0.latRad, s0.trackRad, 250 * 11);
+    const s1 = ingestFix(
+      s0,
+      fix({
+        lonDeg: (nudged.lonRad * 180) / Math.PI,
+        latDeg: (nudged.latRad * 180) / Math.PI,
+        trackDeg: 90,
+        speedMs: 250,
+        ageS: 0,
+      }),
+      12,
+    );
+    const after = projectAt(s1, 12);
+    const jump = gc(at12.lonRad, at12.latRad, after.lonRad, after.latRad);
+    expect(jump).toBeLessThan(1); // continuous — absorbed in time, not position
+    // …and speed is still exactly 250 afterwards.
+    const b = projectAt(s1, 22);
+    expect(gc(after.lonRad, after.latRad, b.lonRad, b.latRad) / 10).toBeCloseTo(250, 1);
+  });
+
+  it('a correction beyond the deadband re-anchors to truth instead of drifting', () => {
+    const s0 = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    // A fix far past the deadband (≫ 2.5 s × 250 m/s).
+    const far = advance(s0.lonRad, s0.latRad, s0.trackRad, 250 * 40);
+    const s1 = ingestFix(
+      s0,
+      fix({
+        lonDeg: (far.lonRad * 180) / Math.PI,
+        latDeg: (far.latRad * 180) / Math.PI,
+        trackDeg: 90,
+        speedMs: 250,
+        ageS: 0,
+      }),
+      10,
+    );
+    const after = projectAt(s1, 10);
+    // Re-anchored ON truth (no phase shift retained).
+    expect(gc(after.lonRad, after.latRad, far.lonRad, far.latRad)).toBeLessThan(1);
+    expect(Math.abs(s1.t0 - 10)).toBeLessThan(DR_PHASE_DEADBAND_S);
+  });
+});
+
+describe('deadReckon — a lone backward fix is feed noise, not a reverse', () => {
+  /** A fix `metres` along-track from `s`'s anchor, claiming to be fresh. */
+  const fixAt = (s: ReturnType<typeof ingestFix>, metres: number): DrFix => {
+    const p = advance(s.lonRad, s.latRad, s.trackRad, metres);
+    return fix({
+      lonDeg: (p.lonRad * 180) / Math.PI,
+      latDeg: (p.latRad * 180) / Math.PI,
+      trackDeg: 90,
+      speedMs: 250,
+      ageS: 0,
+    });
+  };
+
+  it('ignores a single fix landing far behind the projection', () => {
+    let s = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    const at30 = projectAt(s, 30);
+    // A fix 5 km behind where we render — the measured ~1-2 km feed flip, worse.
+    s = ingestFix(s, fixAt(s, 250 * 30 - 5000), 30);
+    const after = projectAt(s, 30);
+    const moved = alongTrackM(at30.lonRad, at30.latRad, after.lonRad, after.latRad, s.trackRad);
+    expect(moved).toBeCloseTo(0, 6); // did not teleport backwards
+  });
+
+  it('believes the feed once DR_BACK_TOLERATE fixes agree we are ahead', () => {
+    let s = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    let accepted = false;
+    for (let k = 1; k <= DR_BACK_TOLERATE; k++) {
+      const t = k * 6;
+      const before = projectAt(s, t);
+      s = ingestFix(s, fixAt(s, 250 * t - 5000), t);
+      const after = projectAt(s, t);
+      const d = alongTrackM(before.lonRad, before.latRad, after.lonRad, after.latRad, s.trackRad);
+      if (d < -100) accepted = true;
+    }
+    expect(accepted).toBe(true); // a REAL reposition still corrects
+  });
+
+  it('a forward fix resets the tolerance, so noise never accumulates into a jump', () => {
+    let s = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    for (let k = 1; k <= 12; k++) {
+      const t = k * 6;
+      // Alternate: one bad backward fix, then a good on-track one.
+      s = k % 2 === 1 ? ingestFix(s, fixAt(s, 250 * t - 5000), t) : ingestFix(s, fixAt(s, 250 * t), t);
+      expect(s.backCount).toBeLessThan(DR_BACK_TOLERATE);
+    }
+  });
+
+  it('still re-anchors forward immediately when the fix is AHEAD', () => {
+    let s = ingestFix(undefined, fix({ trackDeg: 90, speedMs: 250 }), 0);
+    const before = projectAt(s, 10);
+    s = ingestFix(s, fixAt(s, 250 * 10 + 5000), 10); // 5 km ahead
+    const after = projectAt(s, 10);
+    const d = alongTrackM(before.lonRad, before.latRad, after.lonRad, after.latRad, s.trackRad);
+    expect(d).toBeGreaterThan(4000); // caught up, no tolerance delay
+  });
+});
+
+describe('deadReckon — a STALE (frozen) contact must not walk backwards either', () => {
+  // Frozen contacts teleport to the reported fix, so a regressing feed walked
+  // them backwards frame after frame — measured live as runs of up to 12
+  // consecutive backward frames, the only remaining sustained reverse.
+  const staleAt = (lonDeg: number): DrFix =>
+    fix({ lonDeg, trackDeg: 90, speedMs: 250, ageS: DR_MAX_FIX_AGE_S + 10 });
+
+  it('ignores a lone backward step on a stale airborne contact', () => {
+    let s = ingestFix(undefined, staleAt(-0.45), 0);
+    expect(s.frozen).toBe(true);
+    s = ingestFix(s, staleAt(-0.40), 6); // forward (east)
+    const fwd = projectAt(s, 6);
+    s = ingestFix(s, staleAt(-0.50), 12); // jumps back west — feed noise
+    const after = projectAt(s, 12);
+    expect(after.lonRad).toBeCloseTo(fwd.lonRad, 12); // held, did not walk back
+  });
+
+  it('accepts a persistent backward correction on a stale contact', () => {
+    let s = ingestFix(undefined, staleAt(-0.45), 0);
+    s = ingestFix(s, staleAt(-0.40), 6);
+    for (let k = 1; k <= DR_BACK_TOLERATE; k++) s = ingestFix(s, staleAt(-0.50), 6 + k * 6);
+    expect((projectAt(s, 30).lonRad * 180) / Math.PI).toBeCloseTo(-0.5, 6);
+  });
+
+  it('never guards an ON-GROUND contact (pushback is genuinely backwards)', () => {
+    const g = (lonDeg: number): DrFix => fix({ lonDeg, onGround: true, speedMs: 5, trackDeg: 90 });
+    let s = ingestFix(undefined, g(-0.45), 0);
+    s = ingestFix(s, g(-0.50), 6); // pushed back
+    expect((projectAt(s, 6).lonRad * 180) / Math.PI).toBeCloseTo(-0.5, 6);
+  });
+});
+
+describe('deadReckon — advance() geometry', () => {
+  it('travels the requested ground distance', () => {
+    const lon = (2.35 * Math.PI) / 180;
+    const lat = (48.85 * Math.PI) / 180;
+    for (const bearing of [0, 45, 90, 135, 180, 225, 270, 315]) {
+      const p = advance(lon, lat, (bearing * Math.PI) / 180, 15000);
+      expect(gc(lon, lat, p.lonRad, p.latRad)).toBeCloseTo(15000, -1); // ±10 m over 15 km
+    }
+  });
+
+  it('wraps across the antimeridian instead of running longitude away', () => {
+    const p = advance((179.99 * Math.PI) / 180, 0, Math.PI / 2, 5000);
+    expect(p.lonRad).toBeLessThan(0); // crossed into the western hemisphere
+    expect(Math.abs(p.lonRad)).toBeLessThanOrEqual(Math.PI);
+  });
+});

--- a/apps/web/src/globe/adapters/deadReckon.ts
+++ b/apps/web/src/globe/adapters/deadReckon.ts
@@ -1,0 +1,287 @@
+// FlightRadar24-style aircraft dead-reckoning — the MOTION MODEL only (no Cesium
+// entity plumbing; PollGeoJsonAdapter owns that). Pure functions so the two hard
+// operator requirements are unit-testable:
+//
+//   1. The icon moves at the aircraft's ACTUAL reported ground speed — not
+//      faster, not slower.
+//   2. The icon NEVER moves backwards.
+//
+// Both are structural here, not tuned:
+//
+//   position(t) = advance(anchor, track_deg, velocity_ms * max(0, t - t0))
+//
+// `advance` steps along the WGS84 surface using the local radii of curvature, so
+// |dP/dt| == velocity_ms EXACTLY (req 1). `max(0, ...)` means elapsed distance is
+// monotonically non-decreasing along a FIXED bearing, so the icon cannot reverse
+// even if the clock is scrubbed backwards (req 2).
+//
+// WHY REPORTED track/speed AND NOT A FIT THROUGH CONSECUTIVE FIXES: measured
+// 2026-07-14 against /api/adsb/global, only 13.5% of consecutive same-source fix
+// pairs yield a great-circle speed within ±10% of the reported `velocity_ms`
+// (median error +47%). The fix TIMEBASE (`seen_at - seen_pos_s`) is too coarse to
+// differentiate — but `velocity_ms`/`track_deg` are the aircraft's OWN downlinked
+// GNSS ground speed and track. They are the authoritative signal; positions are
+// the noisy one. So we integrate the reported vector and use fixes only to
+// re-anchor. This is also why the old code overshot then snapped back.
+//
+// See docs/decisions.md + the scratchpad findings for the full measurement.
+
+const WGS84_A = 6378137.0;
+const WGS84_E2 = 6.69437999014e-3;
+
+/** Meridional + prime-vertical radii of curvature (metres per radian) at `latRad`. */
+function radii(latRad: number): { m: number; n: number } {
+  const s = Math.sin(latRad);
+  const w2 = 1 - WGS84_E2 * s * s;
+  return { m: (WGS84_A * (1 - WGS84_E2)) / (w2 * Math.sqrt(w2)), n: WGS84_A / Math.sqrt(w2) };
+}
+
+/**
+ * Advance a geodetic point `distM` metres along constant bearing `trackRad`.
+ * Uses the local radii of curvature so the travelled ground distance is exactly
+ * `distM` — that exactness is requirement 1 (speed == reported speed).
+ */
+export function advance(
+  lonRad: number,
+  latRad: number,
+  trackRad: number,
+  distM: number,
+): { lonRad: number; latRad: number } {
+  const { m, n } = radii(latRad);
+  const north = distM * Math.cos(trackRad);
+  const east = distM * Math.sin(trackRad);
+  const lat2 = latRad + north / m;
+  // Mid-latitude for the east step: second-order accurate, so a 60 s projection
+  // at 300 m/s (18 km) stays sub-metre instead of drifting with the cosine.
+  const latMid = latRad + north / (2 * m);
+  const cosMid = Math.cos(latMid);
+  // Pole guard: cos → 0 would blow the longitude step up. Aircraft this close to
+  // a pole are vanishingly rare and sub-pixel anyway.
+  const cosSafe = Math.sign(cosMid || 1) * Math.max(Math.abs(cosMid), 1e-6);
+  let lon2 = lonRad + east / (n * cosSafe);
+  // Wrap to [-π, π] so the antimeridian doesn't produce a runaway longitude.
+  if (lon2 > Math.PI) lon2 -= 2 * Math.PI;
+  else if (lon2 < -Math.PI) lon2 += 2 * Math.PI;
+  return { lonRad: lon2, latRad: lat2 };
+}
+
+/** Signed along-track metres from A to B, projected on `trackRad`. */
+export function alongTrackM(
+  aLonRad: number,
+  aLatRad: number,
+  bLonRad: number,
+  bLatRad: number,
+  trackRad: number,
+): number {
+  const { m, n } = radii(aLatRad);
+  const dN = (bLatRad - aLatRad) * m;
+  const dE = (bLonRad - aLonRad) * n * Math.cos(aLatRad);
+  return dN * Math.cos(trackRad) + dE * Math.sin(trackRad);
+}
+
+/** A real fix as reported by /api/adsb/global. */
+export type DrFix = {
+  lonDeg: number;
+  latDeg: number;
+  altM: number;
+  /** Reported track (deg true). null → not projectable. */
+  trackDeg: number | null;
+  /** Reported ground speed (m/s). null → not projectable. */
+  speedMs: number | null;
+  /** How old this POSITION is, in seconds (`seen_at - seen_pos_s` vs now). */
+  ageS: number;
+  onGround: boolean;
+};
+
+/**
+ * A contact's motion anchor. `frozen` contacts hold still at `lon/lat` — that is
+ * the TELEPORT behaviour, reused for anything we must not invent motion for.
+ */
+export type DrState = {
+  lonRad: number;
+  latRad: number;
+  altM: number;
+  trackRad: number;
+  speedMs: number;
+  /** Sim-clock seconds at which the contact was AT lon/lat. */
+  t0: number;
+  /** Seconds past t0 after which motion HOLDs (coast limit). */
+  holdS: number;
+  frozen: boolean;
+  /** Consecutive fixes that landed behind our projection (see DR_BACK_TOLERATE). */
+  backCount: number;
+};
+
+// Below this ground speed a contact is taxiing/parked — projecting it just makes
+// GPS noise look like motion.
+export const DR_MIN_SPEED_MS = 15;
+// A fix older than this is NOT dead-reckoned. The p90 of position age is ~69 s
+// and p95 ~184 s (the OpenSky breadth tier, a once-per-UTC-day cache); flying a
+// 3-minute-old fix forward at 250 m/s invents ~45 km of fiction. Those contacts
+// hold at their last reported position instead — honest, and the PredictedMotion
+// badge already says positions are estimated.
+export const DR_MAX_FIX_AGE_S = 45;
+// Cap on how far back a fix's own age may push the anchor. Bounds the projection
+// a single stale-ish fix can trigger.
+export const DR_MAX_ANCHOR_AGE_S = 30;
+// Coast limit: with no fresh fix, keep flying the last reported vector for this
+// long, then HOLD. Live contacts re-fix every ~6 s (measured p50 6.2 s, p99
+// 10.4 s), so a healthy contact is always mid-coast and moves continuously; one
+// that truly lost signal coasts ~1 min then stops rather than flying off forever.
+export const DR_COAST_MAX_S = 60;
+// Phase deadband. A new fix rarely lands exactly where we projected; the residual
+// is absorbed as a TIME shift (fly the same true track at the same true speed,
+// just phase-shifted) instead of a position jump — smooth, and it changes neither
+// speed nor direction. Beyond this the model has genuinely lost the contact
+// (reacquisition, manoeuvre, bad fix) and we re-anchor to truth in ONE frame.
+//
+// A snap is a single-frame position correction. It is NOT the operator's "goes in
+// reverse" complaint, which was the old code GLIDING backwards over up to 30 s.
+// Never trade a snap for a backwards glide.
+export const DR_PHASE_DEADBAND_S = 2.5;
+// How many CONSECUTIVE fixes must agree that the contact is behind our
+// projection before we believe them and re-anchor backwards.
+//
+// WHY THIS EXISTS: the feed still lands the occasional fix ~1-2 km BEHIND the
+// contact's own trajectory — measured 2026-07-14, ~1% of airborne moves even
+// after the backend's freshest-wins union fix, because some contacts are covered
+// only by a source that oscillates between aggregators with different lag. A
+// one-off backward fix is that noise, and honouring it is EXACTLY the "plane goes
+// in reverse" the operator rejects. So a lone backward fix is IGNORED (we keep
+// flying the last good vector — still real reported track+speed, never invented).
+//
+// It is a tolerance, not a veto: if the contact is CONSISTENTLY behind us we were
+// genuinely wrong (a real reposition, a turn we flew through, a corrected bad
+// fix), and after this many fixes we re-anchor to truth. At the measured ~6 s
+// cadence that is ~18 s to correct a real disagreement, versus never showing a
+// transient reverse. Forward fixes reset the count immediately.
+export const DR_BACK_TOLERATE = 3;
+// Backward tolerance for FROZEN (stale-fix) contacts, in metres — they have no
+// projection to phase-shift, so the deadband is a distance, not a time. 250 m
+// matches the backend's _BACKWARD_REJECT_M: ADS-B position noise is ~10-30 m, so
+// 250 m of reverse is never real jitter.
+export const DR_FROZEN_BACK_M = 250;
+
+/** Where `s` renders at sim-clock time `tSec`. */
+export function projectAt(s: DrState, tSec: number): { lonRad: number; latRad: number } {
+  if (s.frozen || s.speedMs <= 0) return { lonRad: s.lonRad, latRad: s.latRad };
+  // max(0, …) ⇒ never reverse; min(holdS, …) ⇒ HOLD past the coast limit.
+  const dt = Math.max(0, Math.min(tSec - s.t0, s.holdS));
+  if (dt <= 0) return { lonRad: s.lonRad, latRad: s.latRad };
+  return advance(s.lonRad, s.latRad, s.trackRad, s.speedMs * dt);
+}
+
+/**
+ * Fold a REAL fix into the motion model.
+ *
+ * `prev` is this contact's current state (undefined on first sight), `nowSec` the
+ * sim-clock time the fix was applied. Returns the new anchor.
+ */
+export function ingestFix(prev: DrState | undefined, fix: DrFix, nowSec: number): DrState {
+  const lonRad = (fix.lonDeg * Math.PI) / 180;
+  const latRad = (fix.latDeg * Math.PI) / 180;
+
+  const projectable =
+    !fix.onGround &&
+    fix.trackDeg != null &&
+    fix.speedMs != null &&
+    Number.isFinite(fix.trackDeg) &&
+    Number.isFinite(fix.speedMs) &&
+    fix.speedMs >= DR_MIN_SPEED_MS &&
+    fix.ageS <= DR_MAX_FIX_AGE_S;
+
+  if (!projectable) {
+    // Parked / on-ground / stale → hold at the reported position. No synthesis:
+    // a frozen contact TELEPORTS to each real fix, exactly like the default path.
+    //
+    // Keep the reported track even while frozen, so the backward guard below has
+    // a bearing to project on.
+    const trackRad =
+      fix.trackDeg != null && Number.isFinite(fix.trackDeg)
+        ? (fix.trackDeg * Math.PI) / 180
+        : (prev?.trackRad ?? 0);
+    const frozen: DrState = {
+      lonRad,
+      latRad,
+      altM: fix.altM,
+      trackRad,
+      speedMs: 0,
+      t0: nowSec,
+      holdS: 0,
+      frozen: true,
+      backCount: 0,
+    };
+    // A contact frozen only because its fix is STALE (airborne, moving, but the
+    // breadth tier is minutes behind) still mirrors the feed verbatim — so a feed
+    // that regresses walks the icon backwards for as long as it keeps regressing.
+    // Measured live: this was the ONLY remaining way to see sustained reverse
+    // (runs of up to 12 consecutive frames). Same tolerance as the projected path:
+    // ignore a lone backward fix, believe a persistent one.
+    //
+    // Deliberately NOT applied to on-ground or parked contacts: pushback is
+    // literally backwards, and a parked contact's track is meaningless noise.
+    const guardable =
+      !fix.onGround &&
+      fix.speedMs != null &&
+      fix.speedMs >= DR_MIN_SPEED_MS &&
+      fix.trackDeg != null &&
+      Number.isFinite(fix.trackDeg);
+    if (prev && guardable) {
+      const cur = projectAt(prev, nowSec);
+      const back = alongTrackM(cur.lonRad, cur.latRad, lonRad, latRad, trackRad);
+      if (back < -DR_FROZEN_BACK_M && prev.backCount + 1 < DR_BACK_TOLERATE) {
+        return { ...prev, backCount: prev.backCount + 1 };
+      }
+    }
+    return frozen;
+  }
+
+  // Anchor at the fix's OWN observation time, so at `nowSec` the icon already
+  // renders the fix carried forward by its age — the aircraft is where it IS, not
+  // where it was when the packet left it.
+  const ageS = Math.min(Math.max(fix.ageS, 0), DR_MAX_ANCHOR_AGE_S);
+  const cand: DrState = {
+    lonRad,
+    latRad,
+    altM: fix.altM,
+    trackRad: ((fix.trackDeg as number) * Math.PI) / 180,
+    speedMs: fix.speedMs as number,
+    t0: nowSec - ageS,
+    holdS: DR_COAST_MAX_S,
+    frozen: false,
+    backCount: 0,
+  };
+
+  if (prev && !prev.frozen && prev.speedMs > 0) {
+    const cur = projectAt(prev, nowSec);
+    const next = projectAt(cand, nowSec);
+    const along = alongTrackM(cur.lonRad, cur.latRad, next.lonRad, next.latRad, cand.trackRad);
+    const phaseS = along / cand.speedMs;
+    if (Math.abs(phaseS) <= DR_PHASE_DEADBAND_S) {
+      // Inside the deadband: shift the anchor in TIME so the icon keeps rendering
+      // where it already is (continuity, no jump) while flying the fix's true
+      // track at its true speed. The residual lag stays inside the deadband — it
+      // cannot accumulate, because every fix re-derives it from truth rather than
+      // compounding.
+      cand.t0 += phaseS;
+      return cand;
+    }
+    if (phaseS < 0) {
+      // The fix is materially BEHIND our projection. Believe it only once
+      // consecutive fixes agree (see DR_BACK_TOLERATE) — a lone one is feed noise
+      // and honouring it would show the operator a reverse.
+      const backCount = prev.backCount + 1;
+      if (backCount < DR_BACK_TOLERATE) {
+        // Keep flying the previous anchor untouched. Its track/speed are still
+        // the contact's own last REPORTED values, so this invents nothing; we
+        // simply decline to teleport backwards on one disagreeing fix.
+        return { ...prev, backCount };
+      }
+      // Consistently behind → we were wrong. Re-anchor to truth.
+      cand.backCount = 0;
+      return cand;
+    }
+    // Materially AHEAD of us → we were lagging; re-anchor forward immediately.
+  }
+  return cand;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,7 +9,11 @@ declare const process: { env: Record<string, string | undefined> };
 // localhost so a bare `pnpm dev` against `uvicorn app.main:app` works with
 // zero configuration — the old `api:8000` default only resolved inside the
 // compose network and broke every request outside it.
-const apiTarget = process.env['VITE_API_URL'] ?? 'http://localhost:8000';
+// Pin 127.0.0.1, not `localhost`: in some containers (GitHub Codespaces) the
+// dev proxy's Node process resolves `localhost` to IPv6 `::1` first, but uvicorn
+// binds IPv4 only → ECONNREFUSED, surfacing in the browser as a bare
+// "NetworkError" on /api/config. Same trap the Tauri path pins around.
+const apiTarget = process.env['VITE_API_URL'] ?? 'http://127.0.0.1:8000';
 const wsTarget = apiTarget.replace(/^http/, 'ws');
 
 // Hardened local/desktop profile: VELOCITY_DESKTOP=1 injects a strict CSP that

--- a/docs/audits/2026-07-14-session-postmortem.md
+++ b/docs/audits/2026-07-14-session-postmortem.md
@@ -1,0 +1,162 @@
+# Session post-mortem — 2026-06-15 → 2026-07-14
+
+Synthesized 2026-07-14 from the recorded session memories
+(`~/.claude/projects/-home-andrew-Projects-OSINT/memory/`), the post-mortems
+section of `docs/decisions.md`, and `docs/audits/2026-07-12-state-of-project.md`.
+Provenance: every defect below was recorded at the time it happened; the only
+live measurements THIS turn are the git counts in the next paragraph.
+
+Scope: ~30 working sessions. 132 commits since 2026-06-15, 18 of them
+fix-themed, **zero reverts** (measured live: `git log --oneline
+--since=2026-06-15`). Test baseline ratcheted 1294 → 1675 over the same window
+(`docs/decisions.md#backend-test-baseline-history`).
+
+## Failure classes, ranked by recurrence
+
+### 1. Silent degradation — the platform's dominant failure mode
+
+The same shape at least nine times: a component keeps producing
+success-shaped output after it has stopped doing its job.
+
+- `verify.sh --live` vessel probe GET a route that never existed; a bare
+  `except` printed "skipped" on every run since birth (rot-fix wave,
+  2026-07-12).
+- `email` alert channel accepted at rule creation; nothing ever sent
+  (2026-07-11 → fixed 2026-07-12 by rejecting at creation).
+- Drone-swarm sim silently clamped 1000 → 200 with a slider max of 2000
+  ("impossible & SILENT", warsim stress test 2026-06-20).
+- ADS-B sidecar dropped `nac_p`/`nic` → `/api/jamming` served ZERO cells for
+  days (2026-07-05).
+- Investigation-save had NEVER worked — auth-first 401 masked the 422 schema
+  mismatch until the auth gate was removed (2026-07-07).
+- `opensky_authed: true` with expired creds — every call 401'd
+  ("configured ≠ working").
+- The firehose tier's never-expiring cache reported `seen_pos_s` fresh
+  forever → 9.2% of airborne moves rendered BACKWARDS until the
+  freshest-observation merge (2026-07-14).
+- `aircraftDeadReckon` toggle froze contacts instead of extrapolating — the
+  code path held position while claiming motion (2026-07-04).
+- Playwright template-string "reader" silently returned the function object →
+  sidecar served 0 aircraft.
+
+**Root-cause pattern:** bare excepts, caps without warnings, auth gates
+masking downstream errors, caches without honest age stamps, and probes that
+can only skip. **The fix that stuck:** make every check ABLE to fail
+("a probe that can only skip is not a probe"), reject-at-creation instead of
+accept-and-drop, level-triggered state instead of edge-triggered events.
+
+### 2. The confident fix that made it worse
+
+- `mallopt(M_ARENA_MAX=2)` + `malloc_trim` for the 17 GB memory problem →
+  54 GB and 201% CPU under sustained load. The real fix was jemalloc preload
+  (2026-07-04).
+- Easing the aircraft icon toward the next fix to "smooth the jump" → apparent
+  speed became `dist/gap` (arbitrary; p05 = −68% of true speed) and icons
+  glided backwards for up to 30 s (2026-07-14).
+- Fitting velocity from consecutive fixes → only 13.5% of pairs land within
+  ±10% of the reported `velocity_ms` (killed two designs).
+- Repeated frontend work on "stale/slow" reports whose cause was a frozen
+  backend blob (canonized as operating rule 5).
+
+**Pattern:** the fix was chosen by plausibility, not by a before/after
+measurement at the right layer. Every one of these was caught only when
+someone finally measured. The counter-habit is now doctrine: probe the layer
+boundary first, measure before and after, and distrust a fix you can't
+number.
+
+### 3. Inverted assumptions in code you didn't read
+
+- `_merge_raw_into`'s docstring: "caller orders sources so the freshest is
+  merged last" — inverted in production by a tier that never expires
+  (2026-07-14, the backwards-aircraft bug).
+- `.env` resolution by CWD bit at least three separate times: tests run from
+  `apps/api` hit a wall of 401s; dev boots keyless by accident from repo
+  root; a shadowed config froze refresh at 1 minute.
+- `detect._SIDECAR` used `parents[3]` + re-appended "apps" → every detection
+  call said "sidecar offline" regardless of config (2026-07-05).
+- The proposal queue's approve → `dispatch()` EXECUTES an action — wrong
+  semantics for an informational brief; caught only by reading `actions.py`
+  before reusing it (watch-officer build).
+
+**Pattern:** building against an imagined signature or a stale docstring.
+The skill's "verify the leads yourself — open the 3-4 files you'll depend
+on" exists because of this class.
+
+### 4. Hostile upstreams are the norm
+
+Every new feed cost a discovery session: adsb.lol 451s non-browser UAs;
+airplanes.live throttles with HTTP 200 + text/plain; Cloudflare blocks
+datacenter egress (airplanes.live/adsb.fi/adsb.one, LiveATC search); NGA
+needs full browser headers; FAA NASR 503s HEAD but serves GET; WDQS 504s on
+two specific query shapes and 429s bursts; World Bank silently STALLS on 16
+concurrent fetches; CelesTrak 403-rate-limits bursts; GitHub REST 429s from
+shared egress; Overpass 504s planet queries. The fix is always some mix of
+headers, cadence, caching, and serialization — and it only stays fixed
+because it's recorded next to the client code and often guarded
+(`_parse_ac` rejects non-JSON; `load_cell` raises on all-host failure).
+
+### 5. Claims without measurement (the founding sin)
+
+"Global" AIS that was Norway-only; "the full picture" that was ~60% of
+FlightAware; "keyless caps at ~12.7k" as a ceiling that try-harder broke.
+These predate the evidence contract and directly caused it: banned words
+without a live count, proven-live / plumbed-unverified / not-built tagging,
+and enforcement moved from prose into guards.
+
+### 6. Test-and-tooling traps (cost hours, not correctness)
+
+jsdom synthetic pointer events don't drive React (`isTrusted` gate); headless
+Playwright can't measure GPU fps; Wayland has no working screenshot backend
+here; the Tauri watcher rebuild-looped on the app's own SQLite writes until
+`.taurignore`; inherited `LD_PRELOAD` jemalloc killed the sidecar Chrome
+zygote → 0 aircraft; zustand filter-in-selector infinite-loops
+`useSyncExternalStore`. All recorded; none recurred after recording.
+
+## What worked — keep doing it
+
+1. **Guards over prose.** Zero reverts in 132 commits while the baseline
+   ratcheted 1294 → 1675. Regressions die in `verify.sh`, not in production.
+   The 2026-07-05 Bitter-Lesson cleanup (delete compensators, keep
+   environment facts, enforce invariants in executable checks) is validated
+   by this number.
+2. **Adversarial review waves find what the builder can't.** Foundry
+   hardening: 18 defects. UI bug scan: 24. Evidence-locker external review:
+   7, including a HIGH SSRF. These were separate review passes, not the
+   building session's self-check.
+3. **Dogfood/stress sessions are the densest bug source.** The two June
+   war-game sessions and the US-Iran dogfood each produced ~15-20 real
+   defects (silent clamps, missing geo-scoping, WS outages, unclamped
+   dossier physics) precisely because the product was USED as an analyst,
+   not built. Nothing else found these.
+4. **Honest tiering carries real information.** The 2026-07-12 audit's #1
+   launch risk (a stranger's `docker compose up`) was exactly the largest
+   surface still tagged plumbed-unverified. The tags predicted where the
+   risk was.
+
+## Residual risks / recommendations
+
+1. **Browser-verification debt compounds.** Most waves ship backend
+   proven-live + frontend "NOT browser-verified", and the defects that
+   survive to dogfooding live almost entirely in that gap (boot auth race,
+   AlertsPanel crash, stuck counters, dead WS). Pay it per-wave — one
+   scripted trusted-event Playwright flow or a 5-minute manual drive —
+   instead of letting the next stress test find it.
+2. **Schedule dogfooding.** It is the highest-yield QA activity on record
+   here and it happens only ad hoc. After any user-facing wave, one
+   scenario-driven session (the US-Iran template) pays for itself.
+3. **The stranger-boot path is still the top untested surface** (per the
+   2026-07-12 audit; unchanged since). It gates the launch plan and fails in
+   a known shape (egress-blocked feeds → empty globe → "it's fake").
+4. **Guard-count updates are a known wave tax** (`test_mcp_http_mount`
+   22→34, layer-catalog counts): when a wave adds surface, grep for
+   count-asserting guards before running the suite blind.
+5. **Wave work sits dirty for days** (this branch included). The 2026-07-12
+   audit proved everything eventually merged, but "eventually" is the risk
+   window — branch, commit, PR at wave end.
+
+## One-line summary
+
+The platform's bugs are overwhelmingly *silence* — components that keep
+smiling after they stop working — and its wins are overwhelmingly *loudness*:
+guards that fail, probes that can fail, words that are banned without a
+count. Keep converting the first into the second.

--- a/docs/beta-sql-commands.md
+++ b/docs/beta-sql-commands.md
@@ -10,12 +10,16 @@ grant select on public.subscriptions to authenticated;
 grant select on public.tier_limits  to anon, authenticated;
 ```
 
-## 2. Give andrew@andrewyong.dev the max tier (enterprise)
+## 2. Give an operator the max tier (enterprise)
+
+Look the id up first — never paste a real user id into a doc or a ticket.
 
 ```sql
+select id, email from auth.users where email = 'operator@example.com';
+
 update public.subscriptions
 set tier = 'enterprise', status = 'active', trial_ends_at = null, updated_at = now()
-where user_id = 'b74ae853-c91c-4d08-afe4-ed798e09c203';
+where user_id = '<user-uuid>';
 ```
 
 ## 3. Verify
@@ -23,7 +27,7 @@ where user_id = 'b74ae853-c91c-4d08-afe4-ed798e09c203';
 ```sql
 select tier, status, public.effective_tier(user_id) as effective
 from public.subscriptions
-where user_id = 'b74ae853-c91c-4d08-afe4-ed798e09c203';
+where user_id = '<user-uuid>';
 -- expect: enterprise | active | enterprise
 ```
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -732,6 +732,31 @@ Findings from the same-day state-of-project audit
   process-memory, so the story holds — the audit's first draft misread this
   as rot); replay interpolation; anything guarded above.
 
+## Backend test baseline history
+
+The current baseline lives in `CLAUDE.md` (Environment facts) and stays a
+three-line fact there. One line per wave, newest first — when the CLAUDE.md
+number changes, the displaced line lands here.
+
+- **1675 +1 skip** — 2026-07-14, ui-typography-wcag-sidebar: aircraft
+  predicted-motion wave (freshest-observation snapshot union + along-track
+  no-reverse guards, `test_adsb_no_reverse.py`).
+- **1662** — 2026-07-14: AI-workspace wave (dedicated AI hub app — agent +
+  Watch Officer + engine/models; Watch Officer status/elaborate routes;
+  sharper selection-brief prompt; end-to-end AI-route tests).
+- **1645** — 2026-07-14: keyless data-layers wave (12 new feeds:
+  hazards/env/oceans/space-weather/energy-infra/aviation, wired across
+  route + MCP + globe layer + ontology).
+- **1630** — real-place strike-areas wave (geoBoundaries admin-polygon
+  resolver + feed iso3/shape_level enrichment + AreaAdapter polygons).
+- **1583** — intel-depth wave (2026-07-13).
+- **1540** — rot-fix wave (2026-07-12).
+- **1539** — evidence-locker hardening wave.
+- **1536** — selection-brief enrichment-fusion wave.
+- **1533** — evidence-locker + case-export wave (2026-07-12).
+- **1507** — bug-fix wave (PR #38, 2026-07-12).
+- **1294** — w5-places-airspace-enrichment (2026-07-11).
+
 ## Lessons from past sessions (post-mortems)
 
 ### Never claim coverage/parity without a measurement
@@ -849,3 +874,89 @@ Three findings, all fixed surgically (not a rebuild):
 Known follow-ups (not regressions): the right rail bg is still a hardcoded dark
 `RAIL_BG` (not tokenized) so light theme shows light text on a dark rail;
 phase-2 leaf-site sentence-case sweep.
+
+### Aircraft predicted motion: exact speed, never reverse (2026-07-14)
+
+Operator: *"the predicted motion speed must be the actual speed, not faster or
+slower, and the plane sometime goes in reverse, that is not accepted. this must
+be on par with flight radar 24 level."*
+
+Two independent defects, one in each half of the stack. Both had to be fixed —
+no frontend motion model can fix a feed that moves aircraft backwards.
+
+**Backend: the tier merge was last-writer-wins.** `_build_snapshot` merged
+OpenSky → feeds → firehose → grid, and `_merge_raw_into` overwrote
+unconditionally; its docstring stated the assumption outright ("caller orders
+sources so the freshest source is merged last"). That assumption is inverted:
+tier 3 serves `_FIREHOSE_RAW`, a cache that only changes when a pull SUCCEEDS
+and **never expires**, and from this egress the only reachable firehose verb
+(adsb.lol `/v2/point`, since airplanes.live and adsb.lol `/v2/all-with-pos`
+404 and adsb.fi 403) takes **>60 s** to download. So a minutes-old fix
+overwrote the 0.1 s-old sidecar fix on every 1 s cycle, and flipped back
+whenever an aircraft fell outside the firehose's smaller (~8-9k vs ~20k)
+coverage. Measured on `/api/adsb/global`, warm: **9.2% of airborne moves
+regressed along the aircraft's own `track_deg`** (median **-3.8 km**, worst
+**-161 km**), 5,531 distinct aircraft in 60 s.
+
+Note `seen_pos_s` is the age at UPSTREAM serve time, so a cached tier reports
+0.3 s forever. The only cross-tier-comparable stamp is
+`seen_at - seen_pos_s` (`_feat_obs_at`) — it ages a cache honestly, because
+`_seen_at` is stamped once at pull time. `_readsb_feeds` already folds
+`slice_age` in for exactly this reason WITHIN the feeds tier; the top-level
+merge had no equivalent. Fixed: freshest-observation-wins (order-independent),
+plus a `_regresses` guard that drops a fix flying a fast airborne contact
+backwards, plus rearming `_FIREHOSE_NEXT_TRY` on success (only the failure path
+armed it, so a working firehose was re-downloaded every tick against a host
+CLAUDE.md documents as rate-limiting). → `tests/test_adsb_no_reverse.py`.
+Result: 9.2% → **1.09%**.
+
+Freshness only overrides order where it is KNOWN — if neither side carries a
+stamp, tier order still decides (that is what `test_grid_overlay_wins_conflict`
+pins, and it is right: the grid IS fresher than a daily OpenSky cache).
+
+**Frontend: the glide had no relationship to the reported speed.** The old
+`deadReckonSample` EASED from the rendered position to the new fix over the
+inter-fix gap, so apparent speed was `dist/gap` — arbitrary — and when a stale
+fix landed behind the icon it GLIDED backwards over up to 30 s. Measured live
+in the browser: **only 80.2% of rendered steps were within ±1% of the reported
+`velocity_ms` (p05 = -68%, i.e. planes crawling at a third of their true
+speed), 5.64% of steps went backwards, and 65.7% of backward episodes lasted
+more than one frame — visibly flying in reverse.**
+
+Replaced by an analytic anchor model (`globe/adapters/deadReckon.ts`, pure +
+unit-tested):
+
+    position(t) = advance(anchor, track_deg, velocity_ms * max(0, t - t0))
+
+`advance` steps along WGS84 using the local radii of curvature, so |dP/dt| ==
+`velocity_ms` EXACTLY; `max(0, …)` makes along-track distance monotonically
+non-decreasing, so it cannot reverse even if the clock is scrubbed. Rendered
+via `CallbackPositionProperty` — the motion is analytic, there is nothing to
+interpolate. Measured live after: **98.1% within ±1% (p50 error 0.0000, p95
+0.05%), reverse 0.034% (166× fewer), and exactly ONE episode lasting >1 frame.**
+
+Supporting decisions, all load-bearing:
+- **Never fit velocity from consecutive fixes.** Measured: only **13.5%** of
+  consecutive same-source fix pairs give a great-circle speed within ±10% of
+  the reported `velocity_ms` (median error +47%); `seen_at - seen_pos_s` is far
+  too coarse a timebase to differentiate. `velocity_ms`/`track_deg` are the
+  aircraft's OWN downlinked GNSS values — authoritative. Positions are the noisy
+  signal. (This killed both an earlier velocity-fit cut AND a playout-buffer
+  design that would have interpolated between real fixes.)
+- **Anchor at the fix's observation time**, not receipt, so an aged fix renders
+  already carried forward.
+- **A lone backward fix is IGNORED** (`DR_BACK_TOLERATE`); only consecutive
+  agreement re-anchors backwards. This is a tolerance, not a veto — a real
+  reposition still corrects in ~18 s at the measured 6 s cadence.
+- **Stale fixes are NOT projected** (`DR_MAX_FIX_AGE_S = 45`): position age is
+  p50 2.9 s but p90 68.9 s / p95 183.8 s (the OpenSky breadth tier, a
+  once-per-UTC-day cache). Flying a 3-minute-old fix forward invents ~45 km.
+  Those contacts hold — but they still get the backward guard
+  (`DR_FROZEN_BACK_M`), because a frozen contact mirrors the feed verbatim and
+  that was the LAST source of sustained reverse (runs of up to 12 frames).
+- On-ground/parked contacts are exempt from every backward guard — pushback is
+  literally backwards.
+
+Do NOT reintroduce any easing/interpolation toward a fix: that is what made the
+speed arbitrary and the reverse visible. The default TELEPORT path is unchanged
+and still forbids extrapolation. → `globe/adapters/deadReckon.test.ts`.

--- a/docs/velocity-dogfood-us-iran-2026-06-21.md
+++ b/docs/velocity-dogfood-us-iran-2026-06-21.md
@@ -1,7 +1,7 @@
 # Velocity (projectvelocity.org) — US–Iran dogfood + feature audit
 
 **Date:** 2026-06-21 (~00:00–00:15 UTC)
-**Operator persona:** conflict journalist, account `andrew@andrewyong.dev` (tier reported `enterprise`, status `active`).
+**Operator persona:** conflict journalist, the operator account (tier reported `enterprise`, status `active`).
 **Surface tested:** the **hosted** product only — the live website, `https://projectvelocity.org/api/*` through the Cloudflare Worker with the account's Supabase JWT, and the **hosted** MCP at `https://projectvelocity.org/mcp` (JSON-RPC over streamable-HTTP). The local `uv run` MCP variant was **not** used, per the brief.
 **Scenario:** US–Iran war + peace-deal coverage — ADS-B + maritime activity over the Strait of Hormuz / Persian Gulf / Iran; GPS jamming; drone & invasion simulations; satellite imagery; SAR→3D reconstruction; the agent/MCP.
 

--- a/docs/velocity-stress-test-warsim-2026-06-20.md
+++ b/docs/velocity-stress-test-warsim-2026-06-20.md
@@ -17,7 +17,7 @@
 | Cloud LLMs | **configured + working** | primary **minimax** (`minimaxai/minimax-m3`, NVIDIA endpoint), **deepseek** (`deepseek-reasoner`/`-chat`) |
 | History DB | 6.4 GB, **task_running:true** | `positions` table, 31.6 M rows |
 | MCP `osint-geoint` | connected to this session | HTTP client → `API_BASE=http://localhost:8000` |
-| Supabase | project `dagqceedkxxvvbhmewca` | password grant for `andrew@andrewyong.dev` → **JWT issued, role `authenticated`** ✅ |
+| Supabase | the prod project | password grant for the operator account → **JWT issued, role `authenticated`** ✅ |
 
 **Auth reality:** the local backend has no `SUPABASE_JWT_SECRET`/`API_KEY` configured, so it is effectively **keyless** — `require_api_key` passes with no token (e.g. `/api/sim/reason` returned 200 with no auth), and a *valid* prod Supabase JWT is **not** honoured locally (`/api/keys` → 401 "sign-in required" even with andrew's token). The commercial auth/tier gate therefore only exists on the deployed backend; it cannot be exercised against this local instance.
 
@@ -207,7 +207,7 @@ adsb/global (8 MB, ~17 k aircraft, 0.38 s), maritime (digitraffic/keyless/snapsh
 
 ## 8. Auth & security
 
-- **Local:** keyless; the prod Supabase JWT is *not* validated locally → commercial gating untestable here. The password grant for `andrew@andrewyong.dev` succeeded against the prod Supabase project (role `authenticated`, 1 h token), so the **live login path works**; only the local backend ignores it.
+- **Local:** keyless; the prod Supabase JWT is *not* validated locally → commercial gating untestable here. The password grant for the operator account succeeded against the prod Supabase project (role `authenticated`, 1 h token), so the **live login path works**; only the local backend ignores it.
 - **Supabase advisors (security):**
   - `public.rls_auto_enable()` is **`SECURITY DEFINER` and `EXECUTE`-able by `anon`** via `/rest/v1/rpc/rls_auto_enable` → privilege-escalation surface. Revoke EXECUTE or switch to `SECURITY INVOKER`.
   - **Leaked-password protection disabled** (no HaveIBeenPwned check).
@@ -225,7 +225,7 @@ The intel engine is honest about these, but they directly limit the persona:
 
 ---
 
-## 10. Frontend (live Playwright, authenticated as `andrew@andrewyong.dev`)
+## 10. Frontend (live Playwright, authenticated as the operator account)
 
 Driven headless at 1600×1000, no code edited. Screenshots saved to project root `01..09-*.png` (untracked/gitignored local evidence).
 

--- a/scripts/build_places_data.py
+++ b/scripts/build_places_data.py
@@ -127,6 +127,26 @@ def _to_bool01(v: str) -> bool:
     return str(v or "").strip() == "1"
 
 
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def _scrub_pii(v: str | None) -> str | None:
+    """Drop contact addresses out of upstream free-text fields.
+
+    Upstream operator/owner strings carry named individuals' work emails (WRI
+    GPPD `owner`, SatNOGS station `name`). We redistribute this file, so the
+    addresses come out; the organisation name they are embedded in stays.
+    """
+    if not v:
+        return None
+    out = _EMAIL_RE.sub("", v)
+    out = re.sub(r"[(<\[]\s*[)>\]]", "", out)  # brackets left empty by the cut
+    out = re.sub(r"\s+([)>\]])", r"\1", out)  # space the cut left before a bracket
+    out = re.sub(r"\s*[-–—,;]\s*(?=$|[-–—,;])", "", out)
+    out = re.sub(r"\s{2,}", " ", out).strip(" \t-–—,;")
+    return out or None
+
+
 def load_airports_csv(path: Path) -> list[dict[str, str]]:
     with path.open(encoding="utf-8") as fh:
         return list(csv.DictReader(fh))
@@ -511,7 +531,7 @@ def build_power_plants(cache_dir: Path) -> list[dict[str, Any]]:
                         "iso3": str(row.get("country") or "").strip(),
                         "capacity_mw": cap,
                         "commissioning_year": int(float(year_raw)) if year_raw else None,
-                        "owner": str(row.get("owner") or "").strip() or None,
+                        "owner": _scrub_pii(str(row.get("owner") or "").strip()),
                         "source": "wri-gppd-v1.3",
                     }
                 )
@@ -534,7 +554,7 @@ def build_satnogs_stations(cache_dir: Path) -> list[dict[str, Any]]:
                 "id": f"satnogs-{s.get('id')}",
                 "category": "ground_station",
                 "subcategory": "satellite ground station (SatNOGS)",
-                "name": str(s.get("name") or f"SatNOGS {s.get('id')}"),
+                "name": _scrub_pii(str(s.get("name") or "")) or f"SatNOGS {s.get('id')}",
                 "lat": float(lat),
                 "lon": float(lon),
                 "altitude_m": s.get("altitude"),


### PR DESCRIPTION
Predicted aircraft motion had to hit two bars: **the icon moves at the aircraft's actual reported ground speed**, and **it never goes in reverse**. Both were being missed, for two independent reasons — one per half of the stack. No frontend motion model can compensate for a feed that moves aircraft backwards, so both halves are here.

## Backend: the snapshot tier merge was last-writer-wins

`_merge_raw_into` overwrote unconditionally, and its own docstring stated the assumption: *"caller orders sources so the freshest source is merged last."* That assumption is inverted.

Tier 3 serves `_FIREHOSE_RAW` — a cache that only changes when a pull **succeeds** and **never expires**. From this egress the three real firehose verbs are dead (airplanes.live `/v2/all-with-pos` 404, adsb.lol `/v2/all-with-pos` 404, adsb.fi 403), so it falls through to `adsb.lol /v2/point`, which takes **>60 s** to download. A minutes-old fix therefore overwrote the 0.1 s-old local sidecar fix on every 1 s cycle, and flipped back whenever an aircraft fell outside the firehose's smaller (~8–9k vs ~20k) coverage — position alternating stale↔live, which is a visible reverse.

Measured warm on `/api/adsb/global`: **9.2% of airborne moves regressed along the aircraft's own `track_deg`** (median **−3.8 km**, worst **−161 km**), across 5,531 distinct aircraft in 60 s.

Traced example (`a499c3`, flying west at 244 m/s, 5 s samples):

```
t=+0.0..17.4  lon=-76.376825   identical for 17s, claims seen_pos=0.10   <- stale
t=+23.2..34.8 lon=-77.735 -> -77.767  progressing, seen_pos absent       <- live
t=+40.4..57.7 lon=-76.376825   AGAIN                                     <- back 113 km
```

The subtlety: **raw `seen_pos_s` is the age at *upstream serve* time**, so a cached tier reports `0.3` forever regardless of how long the body has sat in our cache. The only cross-tier-comparable stamp is `seen_at - seen_pos_s`, which ages a cache honestly (`_seen_at` is stamped once, at pull time). `_readsb_feeds` already folds `slice_age` in for exactly this reason *within* the feeds tier; the top-level merge had no equivalent.

Fixes:
- **Freshest-observation-wins** union → order-independent, so no tier can clobber a fresher one by merging later. Freshness only overrides order where it is *known*: with no stamp on either side, tier order still decides (the grid genuinely *is* fresher than a daily OpenSky cache).
- **`_regresses` guard** drops a fix that flies a fast airborne contact backwards along its own track, with a staleness escape hatch so a real reposition still lands.
- **Rearm the firehose retry on success** — only the failure path armed it, so a working firehose was re-downloaded every tick against a host we document as rate-limiting.

Result: **9.2% → 1.09%**.

## Frontend: the glide had no relationship to the reported speed

The old `deadReckonSample` eased from the rendered position to the new fix over the inter-fix gap, so apparent speed was `dist/gap` — arbitrary — and when a stale fix landed behind the icon it **glided backwards over up to 30 s**. That is exactly the reported symptom.

Replaced with an analytic anchor model (`globe/adapters/deadReckon.ts`, pure and unit-tested):

```
pos(t) = advance(anchor, track_deg, velocity_ms * max(0, t - t0))
```

- `advance()` steps along WGS84 using the local radii of curvature, so `|dP/dt| == velocity_ms` **exactly** — requirement 1 is structural, not tuned.
- `max(0, …)` makes along-track distance monotonically non-decreasing, so it **cannot** reverse — even if the sim clock is scrubbed backwards.
- Rendered via `CallbackPositionProperty`: the motion is analytic, there is nothing to interpolate.

## Measured live in the browser (same backend, dead-reckon ON)

|                                   | before        | after                       |
|-----------------------------------|---------------|-----------------------------|
| within ±1% of reported speed      | 80.2%         | **98.1%**                   |
| speed error p05                   | **−68%** (crawling at ⅓ speed) | −0.04% (p50 0.0000, p95 0.05%) |
| backward steps                    | 5.643%        | **0.034%** (166× fewer)     |
| episodes lasting >1 frame (*flying* in reverse) | 1652 (65.7%) | **1 (2.0%)**  |
| longest consecutive backward run  | 8 frames      | **3 frames**                |

Measured by reading rendered entity positions off `window.__viewer` at 1 Hz and comparing against each contact's own reported `velocity_ms`/`track_deg`. The before/after column is the same harness against the same live backend, with only the adapter reverted.

Run length matters more than the raw rate: a one-frame re-anchor is a position correction (what the sanctioned default TELEPORT path does anyway), whereas a multi-frame run is the plane visibly flying backwards. That is what went from 1652 episodes to 1.

## Load-bearing decisions

- **Never fit velocity from consecutive fixes.** Only **13.5%** of consecutive same-source fix pairs yield a speed within ±10% of the reported `velocity_ms` (median error +47%) — the fix timebase is far too coarse. `velocity_ms`/`track_deg` are the aircraft's own downlinked GNSS values and are authoritative; positions are the noisy signal. This also ruled out a playout-buffer design that would have interpolated between real fixes.
- **Anchor at observation time, not receipt**, so an aged fix renders already carried forward.
- **A lone backward fix is ignored; a persistent one is believed** — a tolerance, not a veto (a real reposition corrects in ~18 s at the measured 6 s cadence).
- **Stale fixes are not projected** (age p50 2.9 s but p90 68.9 s — the once-per-UTC-day OpenSky breadth tier; flying a 3-minute-old fix forward invents ~45 km). They still get the backward guard, because a frozen contact mirrors the feed verbatim and was the *last* source of sustained reverse (runs of up to 12 frames).
- **On-ground/parked contacts are exempt from every backward guard** — pushback is genuinely backwards.

The default TELEPORT path is unchanged and still forbids extrapolation; `aircraftDeadReckon` remains opt-in, OFF by default.

## Verification

`bash scripts/verify.sh` — **ALL GREEN** (typecheck, lint, ruff, 384 web tests, 1680 api + 1 skip). Backend baseline 1662 → 1675 from this wave's 13 new guards.

New guards: `apps/api/tests/test_adsb_no_reverse.py` (13), `apps/web/src/globe/adapters/deadReckon.test.ts` (29 — including exact-speed across bearings/latitudes/speeds cross-checked against an independent Vincenty inverse geodesic, and monotonicity under jittery fix streams).

Full rationale, measurements and rejected approaches: `docs/decisions.md`.

## Also included

Per request to commit everything, this branch also carries a **separate in-flight wave** that was live in the working tree: a data/PII scrub across docs and seed data, `DISCLAIMER.md`, a no-PII guard test (5), and a session post-mortem doc. It is unrelated to the motion work and could be split out if you'd rather review it separately.
