### PR TITLE
Stop the coverage scan pinning the WAL at 49.6 GB

### DIFF
--- a/apps/api/app/history.py
+++ b/apps/api/app/history.py
@@ -33,6 +33,14 @@ _RATE_LIMIT_SECS: float = 5.0        # minimum gap between writes for same id
 _RATE_LIMIT_DEG: float = 0.01        # OR ~1 km movement triggers immediate write
 _MAX_BUFFERED_IDS: int = 60_000      # FIFO-evict beyond this to keep RAM bounded
 _PRUNE_INTERVAL_S: float = 3600.0    # enforce retention at most once per hour
+_WAL_SIZE_LIMIT_BYTES: int = 512 * 1024**2  # truncate the WAL back to <=512 MB
+# Coverage aggregates the whole archive (83 M rows measured -> 73 s), so it
+# cannot be recomputed per poll: the replay bar asks every 5 s, and a query
+# that outlives its own poll interval means a read transaction is ALWAYS open.
+# That is what pinned the WAL. The numbers it feeds (recording-since, GB, fix
+# count, per-hour density) move slowly, so serve a cached answer and let the
+# scan run at most this often.
+_COVERAGE_TTL_S: float = 120.0
 
 # ── module-level state ─────────────────────────────────────────────────────────
 # _buffer: ordered list of rows pending flush
@@ -41,6 +49,10 @@ _buffer: list[tuple[str, str, float, float, float, float, str]] = []
 _last: collections.OrderedDict[str, tuple[float, float, float]] = collections.OrderedDict()
 _rows_written: int = 0
 _flush_task: asyncio.Task[None] | None = None
+# (window_hours, bucket_hours), computed_at, payload — see coverage() for why
+# this cache is a correctness control and not a speed optimisation.
+_coverage_cache: tuple[tuple[int, int], float, dict[str, Any]] | None = None
+_coverage_lock: asyncio.Lock = asyncio.Lock()
 _db_path: str | None = None          # resolved at start(); overridable in tests
 _db_path_override: str | None = None  # set by tests via override_db_path()
 # Phase 1: vessels we've already run through entity resolution this process, so
@@ -99,6 +111,14 @@ def _connect() -> sqlite3.Connection:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     con = sqlite3.connect(path, check_same_thread=False)
     con.execute("PRAGMA journal_mode=WAL")
+    # A WAL only checkpoints past its OLDEST live reader. The recorder writes
+    # continuously, so one long-running read holds every frame written during
+    # it, and without a size limit the file is never truncated back after the
+    # checkpoint that finally clears it. Measured on the dev box: a 15.2 GB
+    # archive carrying a 49.6 GB WAL, of which a TRUNCATE checkpoint reclaimed
+    # 48.6 GB — 98 % of it redundant page versions pinned by readers. The limit
+    # bounds the file whatever the read pattern does.
+    con.execute(f"PRAGMA journal_size_limit={_WAL_SIZE_LIMIT_BYTES}")
     con.execute(
         """
         CREATE TABLE IF NOT EXISTS positions (
@@ -461,8 +481,37 @@ def _coverage_sync(window_hours: int, bucket_hours: int) -> dict[str, Any]:
 
 
 async def coverage(window_hours: int, bucket_hours: int) -> dict[str, Any]:
-    loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _coverage_sync, window_hours, bucket_hours)
+    """Cached: at most one scan per _COVERAGE_TTL_S, and never two at once.
+
+    Both bounds matter, and neither is about latency. The scan holds a read
+    transaction for its whole duration, and a WAL cannot checkpoint past its
+    oldest reader — so an uncached 73 s scan re-armed every 5 s kept a reader
+    permanently open and the WAL grew without limit (49.6 GB against a 15.2 GB
+    archive). The lock additionally stops a burst of callers each opening their
+    own concurrent scan: an HTTP client that gives up does NOT cancel the
+    executor thread it started, so aborted polls used to pile up server-side.
+    """
+    global _coverage_cache
+    key = (window_hours, bucket_hours)
+    now = time.time()
+    cached = _coverage_cache
+    if cached is not None and cached[0] == key and now - cached[1] < _COVERAGE_TTL_S:
+        return cached[2]
+
+    async with _coverage_lock:
+        # Re-check: a caller queued behind the lock is served by the scan that
+        # just finished rather than starting an identical one.
+        cached = _coverage_cache
+        now = time.time()
+        if cached is not None and cached[0] == key and now - cached[1] < _COVERAGE_TTL_S:
+            return cached[2]
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(None, _coverage_sync, window_hours, bucket_hours)
+        # Don't cache a degraded answer: a transient error would otherwise stick
+        # for the whole TTL.
+        if not result.get("degraded"):
+            _coverage_cache = (key, time.time(), result)
+        return result
 
 
 # ── prune ─────────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_history.py
+++ b/apps/api/tests/test_history.py
@@ -111,6 +111,7 @@ def _reset_module(tmp_db: str) -> None:
     H._last.clear()
     H._rows_written = 0
     H._flush_task = None
+    H._coverage_cache = None
     H.override_db_path(tmp_db)
 
 
@@ -530,6 +531,76 @@ async def test_coverage_shape_and_totals(tmp_path: pytest.TempPathFactory) -> No
     assert result["total_bytes"] > 0
     assert result["row_count"] == 3
     assert sum(b["count"] for b in result["buckets"]) == result["row_count"]
+
+
+@pytest.mark.asyncio
+async def test_coverage_scan_is_cached_and_never_concurrent(
+    tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The archive scan runs at most once per TTL, and never twice at once.
+
+    Regression: coverage() scanned on every call. The scan takes far longer
+    than the replay bar's 5 s poll (73 s over 83 M rows, measured), so a read
+    transaction was always open — and a WAL cannot checkpoint past its oldest
+    reader. The dev box ended up with a 49.6 GB WAL on a 15.2 GB archive, 98 %
+    of it reclaimable. Aborting the HTTP request does not cancel the executor
+    thread, so bursts piled up concurrently too. Both bounds are load-bearing.
+    """
+    db = str(tmp_path / "coverage_cache.db")
+    _reset_module(db)
+
+    now = time.time()
+    H._buffer.append(("aircraft", "aircraft:cache1", now - 60, 5.0, 50.0, 0.0, "{}"))
+    rows, H._buffer = H._buffer, []
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, H._flush_sync, rows)
+
+    calls = 0
+    real = H._coverage_sync
+    in_flight = 0
+    max_in_flight = 0
+
+    def counting(window_hours: int, bucket_hours: int) -> dict:
+        nonlocal calls, in_flight, max_in_flight
+        calls += 1
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            time.sleep(0.05)  # stand in for the real multi-second scan
+            return real(window_hours, bucket_hours)
+        finally:
+            in_flight -= 1
+
+    monkeypatch.setattr(H, "_coverage_sync", counting)
+
+    # A burst of concurrent callers, as the replay bar produced.
+    results = await asyncio.gather(*(H.coverage(24, 1) for _ in range(8)))
+    assert calls == 1, f"expected one scan for a concurrent burst, got {calls}"
+    assert max_in_flight == 1, "scans must never overlap: an overlapping read pins the WAL"
+    assert all(r["row_count"] == 1 for r in results)
+
+    # Inside the TTL: still no new scan.
+    await H.coverage(24, 1)
+    assert calls == 1
+
+    # Past the TTL: the data is allowed to refresh.
+    monkeypatch.setattr(H, "_COVERAGE_TTL_S", 0.0)
+    await H.coverage(24, 1)
+    assert calls == 2
+
+
+def test_connect_bounds_the_wal_file(tmp_path: pytest.TempPathFactory) -> None:
+    """Every connection caps the WAL, so no read pattern can grow it unbounded."""
+    db = str(tmp_path / "wal_limit.db")
+    _reset_module(db)
+    try:
+        con = H._connect()
+        limit = con.execute("PRAGMA journal_size_limit").fetchone()[0]
+        con.close()
+        assert limit == H._WAL_SIZE_LIMIT_BYTES
+        assert 0 < limit <= 1024**3, "an unbounded/huge WAL limit defeats the point"
+    finally:
+        H.override_db_path(None)
 
 
 def test_coverage_route_returns_expected_keys(

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1159,6 +1159,53 @@ Rule that falls out: **trace a string to a render before rewriting it.** Also
 kept intact: the evidence locker's forensic warnings (`hash MISMATCH: blob
 altered or missing`) and every `'—'` null placeholder.
 
+### The coverage scan pinned the WAL: 49.6 GB of it (2026-07-16)
+
+Found while shooting the v1.0.0 screenshots: the dev API sat at **37 GB RSS**,
+holding :8000 without answering. It had been up 90 minutes.
+
+**The archive was 71 GB for 15 GB of data.** `data/history.db` 15.23 GB,
+`data/history.db-wal` **49.63 GB**. With the API stopped,
+`PRAGMA wal_checkpoint(TRUNCATE)` took 37.7 s and left db 16.27 GB, wal 0.00 GB
+— the database grew 1.04 GB, so **98 % of that WAL was redundant page versions
+that could never be checkpointed.**
+
+**Mechanism, and it is a feedback loop.** A WAL only checkpoints past its
+OLDEST live reader. `CoverageStrip` polls `/api/history/coverage` every 5 s;
+`coverage()` scanned the whole archive on every call and the scan outlived its
+own poll interval, so a read transaction was permanently open. The recorder
+writes continuously, so the WAL grew without bound. Then the loop closes: every
+page read must search the wal-index to find the newest version of that page, so
+a bigger WAL makes the scan *slower*, which holds the reader *longer*, which
+grows the WAL *faster*. That is why it ran away instead of settling — the same
+scan measured **73 s against the 49.6 GB WAL and 14.8 s once it was gone.**
+The "slow query" was a symptom, not the cause.
+
+Aborting the HTTP request never helped: it does not cancel the executor thread,
+so `run_in_executor` bursts piled up as concurrent scans, each its own reader.
+
+**Fix, both halves load-bearing.** `coverage()` caches per
+`(window_hours, bucket_hours)` for `_COVERAGE_TTL_S` (120 s) behind an
+`asyncio.Lock`, so the scan runs at most once per TTL and never twice at once;
+degraded results are not cached. `_connect()` sets
+`PRAGMA journal_size_limit=512 MB` so the file is truncated back after
+checkpoint whatever the read pattern does. The cache is a **correctness
+control, not a speed optimisation** — do not "optimise" it away.
+
+Proven live, replaying the workload that caused it (coverage every 5 s for
+2 min against the real 16 GB archive): WAL flat at **0 MB** (was 49.6 GB), RSS
+flat at **~660 MB** (was climbing 4-5 GB/min to a peak of 83 GB), first call
+14.8 s then ~0 ms cached.
+→ `tests/test_history.py::test_coverage_scan_is_cached_and_never_concurrent`,
+`::test_connect_bounds_the_wal_file`
+
+Ruled out on the way, so nobody re-walks it: the coverage query itself holds
+only ~73 MB (measured in isolation over 83.6 M rows); the tile cache is capped
+at 1 GB; jemalloc was correctly loaded with `background_thread:true`. The 37 GB
+was anonymous heap (`Pss_File` 108 MB), and it tracked the WAL — it has not
+recurred since, but the precise allocation path was never isolated, so treat
+"RSS is fixed" as empirical, not explained.
+
 ### v1.0.0, and the repo is now `velocity` (2026-07-16)
 
 Operator: *"execute first item first"* — the first item being the launch, which


### PR DESCRIPTION
Found while shooting the v1.0.0 screenshots: the dev API was wedged at 37 GB RSS, holding :8000 without answering, 90 minutes after boot. The cause is worse than the memory number, and it hits exactly the people the launch is aimed at — self-hosters running this for days.

## The archive was 71 GB for 15 GB of data

```
data/history.db      15.23 GB
data/history.db-wal  49.63 GB   <-- the write-ahead log
```

With the API stopped, `PRAGMA wal_checkpoint(TRUNCATE)` took 37.7 s:

```
before: db=15.23 GB  wal=49.63 GB
after:  db=16.27 GB  wal=0.00 GB
```

The database grew **1.04 GB**. So ~98% of that WAL was redundant page versions that could never be checkpointed.

## Mechanism: a feedback loop, not a leak

A WAL only checkpoints past its **oldest live reader**. `CoverageStrip` polls `/api/history/coverage` every 5 s, and `coverage()` scanned the whole archive on every call. The scan outlives its own poll interval, so a read transaction was permanently open while the recorder wrote continuously.

Then the loop closes: every page read must search the wal-index for the newest version of that page, so a **bigger WAL makes the scan slower**, which **holds the reader longer**, which **grows the WAL faster**. The same scan measured **73 s against the 49.6 GB WAL, and 14.8 s once it was gone.** The slow query was a symptom, not the cause.

Aborting the HTTP request never helped — it doesn't cancel the executor thread, so `run_in_executor` bursts piled up as concurrent scans, each its own reader.

## Fix — both halves load-bearing

- `coverage()` caches per `(window_hours, bucket_hours)` for 120 s behind an `asyncio.Lock`: the scan runs at most once per TTL and **never twice at once**. Degraded results aren't cached. This is a **correctness control, not a speed optimisation** — please don't optimise it away.
- `_connect()` sets `PRAGMA journal_size_limit=512 MB`, so the file is truncated back after checkpoint whatever the read pattern does.

## Proven live

Replaying the exact workload that caused it (coverage every 5 s for 2 min, real 16 GB archive, recorder writing):

| | before | after |
|---|---|---|
| WAL | grew to 49.63 GB | **0 MB, flat** |
| RSS | +4-5 GB/min, peak 83 GB | **flat ~660 MB** |
| coverage | 73 s every call | 14.8 s once, then ~0 ms |

`bash scripts/verify.sh` green: **1721 passed, 1 skipped** (baseline 1719 + the two guards here). Both guards verified to fail against the pre-fix code.

## Ruled out, so nobody re-walks it

The scan itself holds only ~73 MB (measured in isolation over 83,641,008 rows). The tile cache is capped at 1 GB. jemalloc was loaded correctly with `background_thread:true`. The 37 GB was anonymous heap (`Pss_File` was only 108 MB) and it tracked the WAL; it hasn't recurred, but the precise allocation path was never isolated — so **treat the RSS result as empirical, not explained.** That's the one loose thread here.

## Note

This is the second half of the `CoverageStrip` bug fixed in #48. That fix stopped the client aborting its own request every 5 s; this one stops the server-side consequence. The client fix alone was **not** sufficient — a single 73 s scan re-armed every 5 s still keeps a reader open ~93% of the time.