### PR TITLE
v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ labelled as automated output, not sold as "AI insight."
 **[Live demo](https://projectvelocity.org)** · [Quick start](#quick-start) · [The apps](#the-apps) · [Take the tour](#take-the-tour) · [Query it from an AI agent](#mcp-server-query-the-live-console-from-an-ai-agent)
 
 [![License](https://img.shields.io/badge/license-AGPL--3.0-orange.svg)](./LICENSE)
-[![Version](https://img.shields.io/badge/release-v1.0.0-blue.svg)](https://github.com/AndrewCTF/velocity/releases/latest)
+[![Version](https://img.shields.io/badge/release-v1.0.1-blue.svg)](https://github.com/AndrewCTF/velocity/releases/latest)
 [![Tests](https://img.shields.io/badge/tests-1719%20passing-brightgreen.svg)](#tests)
 [![No keys required](https://img.shields.io/badge/API%20keys-optional-success.svg)](#what-it-pulls-in)
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osint-api"
-version = "1.0.0"
+version = "1.0.1"
 description = "OSINT geospatial console — FastAPI backend"
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osint/web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "AGPL-3.0-or-later",
   "private": true,
   "type": "module",

--- a/apps/web/src/command-bar/CommandBar.tsx
+++ b/apps/web/src/command-bar/CommandBar.tsx
@@ -58,7 +58,7 @@ export function CommandBar({
     <div className="flex h-full items-stretch">
       {/* brand mark */}
       <div className={CELL}>
-        <Brand name="VELOCITY" version="v1.0.0" />
+        <Brand name="VELOCITY" version="v1.0.1" />
       </div>
 
       {/* unified search */}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osint",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "AGPL-3.0-or-later",
   "private": true,
   "packageManager": "pnpm@10.33.2",


### PR DESCRIPTION
Patch release for the WAL fix in #49.

v1.0.0 was tagged before that landed, so anyone cloning at the tag and leaving it recording gets an archive that grows without bound — a 49.6 GB write-ahead log against 15.2 GB of data on the dev box, 98% of it redundant pages that could never be checkpointed. That's the one failure mode a self-hosted tool can't ship with, and the launch posts aren't out yet, so the tag should be correct before they are.

Version only. Bumped in `package.json`, `apps/web/package.json`, `apps/api/pyproject.toml`, the brand mark and the README badge. `apps/desktop`, `tools/*` and `packages/shared` stay at 0.1.0, same as v1.0.0.

`bash scripts/verify.sh` green: **1721 passed, 1 skipped**.