### PR TITLE
Launch pass: hero replay GIF, comparison table, and a live LINK chip in open mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,22 @@ labelled as automated output, not sold as "AI insight."
 [![No keys required](https://img.shields.io/badge/API%20keys-optional-success.svg)](#what-it-pulls-in)
 
 <p align="center">
-  <img src="docs/media/hero-main.jpeg" alt="Velocity: one 3D globe fusing live aircraft, vessels and incidents worldwide" width="900">
+  <img src="docs/media/hero-replay.gif" alt="Live world view, fly-in to Europe, an aircraft selected with its owned track, then the last hour rewound on the replay scrubber" width="900">
 </p>
+<p align="center"><i>One take, real data: the live world → Europe → click an aircraft → its dossier and owned track → rewind the last hour.</i></p>
+
+The short version, against the trackers you already use (free tiers, as of
+July 2026):
+
+|  | History you can replay | Self-hosted | Account / API key | Who owns the archive |
+|---|---|---|---|---|
+| **Velocity** | Unlimited — bounded by your disk, scrubbable to any past moment | Yes | None | You |
+| Flightradar24 | 7 days on the free tier | No | Account | Them |
+| MarineTraffic | 24 hours free (down from 72) | No | Account | Them |
+| ADS-B Exchange | Free API tier discontinued | No | Paid API | Them |
+
+Live coverage is the same community feeder data everywhere; the columns above
+are the paywall. Each cell is checkable on the vendors' own pricing pages.
 
 > **Before you get excited:** it's a single-analyst tool. Live *derived* state —
 > the current incident list, AOI selections, watch-officer briefs — lives in

--- a/apps/web/src/alerts/AlertSubscriber.test.tsx
+++ b/apps/web/src/alerts/AlertSubscriber.test.tsx
@@ -1,0 +1,72 @@
+// Keyless /ws/alerts policy: try the upgrade ONCE. An open-mode backend
+// accepts it (chip goes live); an enforcing backend rejects it before open —
+// then we stay closed with no reconnect loop (the old always-skip showed a
+// permanent "LINK down" pill on every open-mode box).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { AlertSubscriber } from './AlertSubscriber.js';
+import { useConnection } from '../state/stores.js';
+
+vi.mock('../auth/AuthContext.js', () => ({
+  useAuth: () => ({ session: null, loading: false }),
+}));
+vi.mock('../transport/http.js', () => ({
+  apiFetch: vi.fn(() => Promise.resolve()),
+  hasStaticApiKey: () => false,
+  withWsKey: (u: string) => u,
+}));
+
+class FakeWS {
+  static instances: FakeWS[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string) {
+    FakeWS.instances.push(this);
+  }
+  close(): void {}
+}
+
+function inst(i: number): FakeWS {
+  const w = FakeWS.instances[i];
+  if (!w) throw new Error(`no FakeWS instance ${i}`);
+  return w;
+}
+
+describe('AlertSubscriber keyless probe', () => {
+  beforeEach(() => {
+    FakeWS.instances = [];
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWS);
+    useConnection.setState({ ws: 'connecting' });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('attempts the upgrade once and adopts it if the backend accepts', () => {
+    render(<AlertSubscriber />);
+    expect(FakeWS.instances.length).toBe(1);
+    act(() => inst(0).onopen?.());
+    expect(useConnection.getState().ws).toBe('open');
+  });
+
+  it('stays closed with no retry loop when rejected before open', () => {
+    render(<AlertSubscriber />);
+    expect(FakeWS.instances.length).toBe(1);
+    act(() => inst(0).onclose?.());
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(FakeWS.instances.length).toBe(1); // no reconnect
+    expect(useConnection.getState().ws).toBe('closed');
+  });
+
+  it('reconnects after a drop only if the socket had opened', () => {
+    render(<AlertSubscriber />);
+    act(() => inst(0).onopen?.());
+    act(() => inst(0).onclose?.());
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(FakeWS.instances.length).toBe(2);
+  });
+});

--- a/apps/web/src/alerts/AlertSubscriber.tsx
+++ b/apps/web/src/alerts/AlertSubscriber.tsx
@@ -32,18 +32,19 @@ export function AlertSubscriber(): null {
       setWs('connecting');
       return () => {};
     }
-    // Settled and genuinely keyless: the backend's require_ws_key rejects
-    // before the upgrade completes, so the socket "closed before connection
-    // established" and the onclose/onerror backoff loop spams the console. Skip
-    // the WebSocket entirely — there's nothing to connect to.
-    if (!session && !hasStaticApiKey()) {
-      setWs('closed');
-      return () => {};
-    }
+    // Settled and keyless: an open-mode backend (ALLOW_UNAUTHENTICATED) accepts
+    // the upgrade without a key, an enforcing one rejects it before it opens.
+    // We can't tell which we're on from here, so try ONCE: adopt the socket if
+    // it opens, and if it dies before ever opening, stay closed with no retry
+    // loop (the old always-skip showed a permanent "LINK down" pill on every
+    // open-mode box; the pre-existing concern — onclose/onerror backoff spamming
+    // the console against an enforcing backend — only applies to retries).
+    const keylessProbe = !session && !hasStaticApiKey();
 
     let ws: WebSocket | null = null;
     let backoff = 1000;
     let stopped = false;
+    let everOpened = false;
 
     const connect = () => {
       if (stopped) return;
@@ -51,6 +52,7 @@ export function AlertSubscriber(): null {
       ws = new WebSocket(withWsKey('/ws/alerts'));
       ws.onopen = () => {
         backoff = 1000;
+        everOpened = true;
         setWs('open');
       };
       ws.onmessage = (ev) => {
@@ -65,6 +67,12 @@ export function AlertSubscriber(): null {
       ws.onclose = () => {
         if (stopped) return;
         setWs('closed');
+        // Keyless probe rejected before it ever opened: enforcing backend,
+        // nothing to reconnect to. One attempt, no backoff spam.
+        if (keylessProbe && !everOpened) {
+          stopped = true;
+          return;
+        }
         window.setTimeout(connect, backoff);
         backoff = Math.min(backoff * 2, 15_000);
       };

--- a/apps/web/src/command-bar/AoiSelector.tsx
+++ b/apps/web/src/command-bar/AoiSelector.tsx
@@ -43,11 +43,11 @@ export function AoiSelector({ onPick }: Props): JSX.Element {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="mono text-[11px] bg-bg-2 border border-line rounded-sm px-2 py-1 text-txt-1 hover:border-accent-line min-w-[180px] text-left flex items-center justify-between gap-2"
+        className="mono text-[11px] bg-bg-2 border border-line rounded-sm px-2 py-1 text-txt-1 hover:border-accent-line min-w-[110px] min-[1440px]:min-w-[180px] text-left flex items-center justify-between gap-2"
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <span>{active ? active.name : 'AOI · global'}</span>
+        <span className="truncate max-w-[130px] min-[1440px]:max-w-none">{active ? active.name : 'AOI · global'}</span>
         <span aria-hidden className="micro text-txt-3">▾</span>
       </button>
       {open && (

--- a/apps/web/src/command-bar/CommandBar.tsx
+++ b/apps/web/src/command-bar/CommandBar.tsx
@@ -31,6 +31,12 @@ interface Props {
 // px-2 → 41px over; px-1.5 → 14px over; px-1 (+ the SysStats trim below) → fits
 // with ~26px margin. Keep it tight if you add a cell.
 const CELL = 'h-full flex items-center gap-2 px-1 border-r border-line';
+// Fixed cells must never wrap into a second line inside the 42px row (at
+// ~1600px the AGENT text used to wrap and overlap the clock). They keep their
+// intrinsic width; the alert ticker is the ONLY shrinkable cell (flex-1
+// min-w-0 + truncate). Narrower still and the row overflows into the header's
+// hidden-scrollbar horizontal scroll — the bar's height is fixed at every width.
+const FIXED_CELL = `${CELL} shrink-0 whitespace-nowrap`;
 
 export function CommandBar({
   viewer,
@@ -57,52 +63,52 @@ export function CommandBar({
   return (
     <div className="flex h-full items-stretch">
       {/* brand mark */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <Brand name="VELOCITY" version="v1.0.1" />
       </div>
 
       {/* unified search */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <SearchField viewer={viewer} />
       </div>
 
       {/* area-of-interest selector */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <AoiSelector onPick={onPickAoi} />
       </div>
 
       {/* Basemap picker. '2d-dark' and '3d-sat' are keyless proxied stacks
           (ion token only adds OSM Buildings on top of 3d-sat); the rest are
           third-party imagery/topo basemaps streamed direct from the browser. */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <BasemapPicker mode={imageryMode} onChange={setImageryMode} />
       </div>
 
       {/* simulation mode toggle — browser-side war-game overlay */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <SimToggle />
       </div>
 
       {/* App switcher (design §6.1) — the primary top-level navigation. Map is the
           globe; Explorer/Graph/Targeting/Video/Sim/Reports take the main surface. */}
-      <div className="h-full flex items-stretch border-l border-line-2">
+      <div className="h-full flex items-stretch border-l border-line-2 shrink-0">
         <AppSwitcher />
       </div>
 
       {/* alert ticker — top alert in newest-first buffer; click opens panel.
           flex-1 so it spans the gap between the controls and the right cluster. */}
-      <div className={`${CELL} flex-1 min-w-0`}>
+      <div className={`${CELL} flex-1 min-w-0 overflow-hidden`}>
         <AlertTicker {...(onOpenAlerts ? { onOpen: onOpenAlerts } : {})} />
       </div>
 
       {/* AGENT indicator — opens the analyst console; shows the live cross-domain
           incident count from the real /api/intel/brief fusion. */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <AgentIndicator />
       </div>
 
       {/* UTC clock — operator orientation */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <span className="mono text-[11px] text-txt-2 tabular-nums" title="UTC">
           {now.toISOString().slice(11, 19)}Z
         </span>
@@ -112,13 +118,13 @@ export function CommandBar({
           When SIM mode is on the globe mixes in notional contacts, so the strip
           flips to a SIMULATED warning; otherwise it marks the keyless open-source
           feed posture. Reads only client-observable state (no fabricated tier). */}
-      <div className={CELL}>
+      <div className={FIXED_CELL}>
         <PostureCaveat classification={classification} />
       </div>
 
       {/* system stats — live entity total (real, from the viewer) + UTC tick
           source FPS, both genuinely measured. Last cell: no right divider. */}
-      <div className="h-full flex items-center gap-2 px-2">
+      <div className="h-full flex items-center gap-2 px-2 shrink-0 whitespace-nowrap">
         <SysStats viewer={viewer} />
       </div>
     </div>
@@ -139,7 +145,14 @@ function PostureCaveat({ classification }: { classification: string }): JSX.Elem
   if (simActive) {
     return <Caveat level={`${classification} // SIMULATED`} note="notional contacts" tone="warn" />;
   }
-  return <Caveat level={classification} note="keyless OSINT" tone="neutral" />;
+  return (
+    <Caveat
+      level={classification}
+      note="keyless OSINT"
+      tone="neutral"
+      noteClassName="hidden min-[1920px]:inline-flex"
+    />
+  );
 }
 
 /**
@@ -190,7 +203,9 @@ function AgentIndicator(): JSX.Element {
         <span className="text-txt-3">…</span>
       ) : count > 0 ? (
         <span className="text-txt-1">
-          <b className="font-medium">{count}</b> incidents · brief ready
+          <b className="font-medium">{count}</b>
+          <span className="hidden min-[1440px]:inline"> incidents</span>
+          <span className="hidden min-[1920px]:inline"> · brief ready</span>
         </span>
       ) : (
         <span className="text-txt-3">· quiet</span>
@@ -280,12 +295,12 @@ function SysStats({ viewer }: { viewer: Cesium.Viewer | null }): JSX.Element | n
         </span>
       )}
       {perf !== null && perf.rr > 0 && (
-        <span title="Real Cesium scene renders per second (governor metric)">
+        <span className="hidden min-[1920px]:inline" title="Real Cesium scene renders per second (governor metric)">
           <b className="text-txt-1 font-semibold">{perf.rr}</b>rr
         </span>
       )}
       {perf !== null && perf.dr > 0 && (
-        <span title="Last aircraft push-application (drain) cost, ms">
+        <span className="hidden min-[1920px]:inline" title="Last aircraft push-application (drain) cost, ms">
           <b className="text-txt-1 font-semibold">{perf.dr}</b>ms
         </span>
       )}

--- a/apps/web/src/command-bar/SearchField.tsx
+++ b/apps/web/src/command-bar/SearchField.tsx
@@ -130,7 +130,7 @@ export function SearchField({ viewer }: Props): JSX.Element {
   };
 
   return (
-    <div ref={containerRef} className="relative w-80">
+    <div ref={containerRef} className="relative w-40 min-[1440px]:w-56 min-[1920px]:w-80">
       <input
         ref={inputRef}
         type="text"

--- a/apps/web/src/shell/AppSwitcher.tsx
+++ b/apps/web/src/shell/AppSwitcher.tsx
@@ -52,7 +52,7 @@ export function AppSwitcher(): JSX.Element {
         >
           <span
             aria-hidden
-            className="flex items-center justify-center px-[1px] font-label uppercase tracking-[0.5px] text-[8px] leading-none text-txt-4 select-none"
+            className="hidden min-[1440px]:flex items-center justify-center px-[1px] font-label uppercase tracking-[0.5px] text-[8px] leading-none text-txt-4 select-none"
             style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
           >
             {group.label}

--- a/apps/web/src/shell/instruments.tsx
+++ b/apps/web/src/shell/instruments.tsx
@@ -322,7 +322,11 @@ export function Brand({ name = 'VELOCITY', version }: { name?: string; version?:
     <div className="flex items-center gap-2 mono font-semibold tracking-[1.5px] text-[12px] text-txt-0">
       <span className="w-2 h-2 bg-accent rotate-45 shrink-0" />
       {name}
-      {version && <span className="font-normal tracking-[0.5px] text-[11px] text-txt-3">{version}</span>}
+      {version && (
+        <span className="hidden min-[1440px]:inline font-normal tracking-[0.5px] text-[11px] text-txt-3">
+          {version}
+        </span>
+      )}
     </div>
   );
 }
@@ -341,10 +345,13 @@ export function Caveat({
   level = 'UNCLAS//FOUO',
   note,
   tone = 'neutral',
+  noteClassName,
 }: {
   level?: string;
   note?: string;
   tone?: 'neutral' | 'warn' | 'alert';
+  /** Extra classes on the note segment, e.g. to hide it responsively. */
+  noteClassName?: string;
 }): JSX.Element {
   return (
     <span
@@ -352,10 +359,10 @@ export function Caveat({
     >
       {level}
       {note && (
-        <>
+        <span className={`inline-flex items-center gap-[5px] ${noteClassName ?? ''}`}>
           <span className="opacity-40">·</span>
           <span className="opacity-70">{note}</span>
-        </>
+        </span>
       )}
     </span>
   );

--- a/docs/post-datahoarder-2026-07-16.md
+++ b/docs/post-datahoarder-2026-07-16.md
@@ -1,0 +1,141 @@
+# r/DataHoarder post — 2026-07-16
+
+## Outcome (2026-07-17): removed/filtered before anyone saw it
+
+Posted 2026-07-16; audited the morning after, logged out (what the public
+sees):
+
+- Not findable in r/DataHoarder search — neither a title-phrase query nor
+  exact strings from the body ("FR24", "9.4 GB", "98,001,172", past week).
+- **Not present on the account's public submitted page** — newest visible
+  submission is the r/OSINTExperts post from 4 days prior. A live post always
+  appears on the author's public profile; a mod/automod-removed one stays
+  visible only to the logged-in author. This is the conclusive signal.
+- Repo traffic 2026-07-16: 17 views / 8 uniques / +1 star. No launch signal
+  at all, so approximately nobody ever saw the repo link.
+
+So the post did not fail on content — it was never in the feed. The content
+never got its test.
+
+Likely causes, in order:
+
+1. **Account posting pattern.** The account submitted ~10 promotional posts
+   for the same project in 8 days (r/osinttools, r/QGIS, r/gis, r/ClaudeAI,
+   r/mcp, r/dataisbeautiful, r/Python, r/homelab, r/ADSB, r/OSINTExperts).
+   That is precisely what Reddit's sitewide spam heuristics and subreddit
+   automod karma/history rules key on.
+2. **No mod pre-approval.** r/DataHoarder's rules require prior mod approval
+   for advertisement/promo posts. A long branded-project title from an
+   account with the above history is an easy automod match.
+3. The repo-link-in-first-comment trick protects against link-domain filters,
+   not against the post itself being removed.
+
+Repost path (do these in order, no shortcuts):
+
+1. From the logged-in account, open the post and check its state. "Removed by
+   moderators" label confirms the diagnosis; if it looks normal to you with
+   zero votes/comments after 24 h, it was silently filtered — same conclusion.
+2. Message the r/DataHoarder mods (old.reddit.com/message/compose/?to=/r/DataHoarder):
+   link this draft, disclose it is your own project, ask whether it is
+   acceptable and under what flair. The draft's content (measured storage
+   numbers, the WAL bug, asking for schema critique) is exactly on-topic for
+   the sub; the account history is the problem, and mods can whitelist a post
+   they have pre-read.
+3. Until it is approved: stop posting the project anywhere else. Every
+   additional promo post lowers the account's standing with every automod.
+4. If approved, post at 14:00-16:00 UTC on a weekday (US morning), and spend
+   the first hour answering comments only.
+
+---
+
+
+Replaces the r/osinttools attempt (2026-07-06, "I built Palantir Gotham", 23K
+views, 26 upvotes, top comments "AI slop dashboard" / "you definitely didn't
+build Gotham"). That post led with fusion and AI, never mentioned owned history,
+and made a claim the reader had to reject. Everything below is the inverse:
+measured numbers first, the moat as the hook, the known flaws volunteered, no
+feature list, no AI paragraph, no em dashes.
+
+Repo link goes in the FIRST COMMENT, not the body.
+
+---
+
+**Title:**
+
+Measured: recording every aircraft and ship on Earth costs 9.4 GB/day. 98,001,172 positions in 48 hours, on my own disk, rewind any window. FR24 gives free users 7 days of history, MarineTraffic cut its free window to 24h, ADS-B Exchange killed its free API tier. The past is the only part they charge for.
+
+---
+
+**Body:**
+
+The most hoardable dataset on the planet is where everything is, minute by minute. Every company collecting it either deletes it or rents it back to you. Flightradar24 keeps 7 days for free users. MarineTraffic cut its free window from 72h to 24h. ADS-B Exchange removed its free API tier. The live map is never the paywall. Your past is.
+
+So I have been recording it locally instead. Two days ago I let it run flat out and measured what that actually costs, because I could not find a straight answer anywhere and "a few GB/day" is not an answer.
+
+Everything below is from the box it is running on right now, not an estimate.
+
+**What 48 hours of the whole world costs**
+
+```
+rows          98,001,172
+file size     19.06 GB
+span          48.5 h
+bytes/row     208.8
+rows/day      48,495,780
+GB/day        9.43        ->  ~3.4 TB/year
+```
+
+Split:
+
+```
+aircraft   94,896,595 rows  (96.8%)  ~9.13 GB/day
+vessel      3,104,577 rows  ( 3.2%)  ~0.30 GB/day
+```
+
+Aircraft are 97% of the cost. That surprised me until I looked: roughly 12,600 aircraft airborne at any moment each moving fast enough to clear the dedup threshold constantly, versus vessels that mostly sit still. About 57,000 vessels are in the live picture but 32,000 of them are parked and barely produce rows.
+
+**The storage layout, and where it is bad**
+
+Plain SQLite, one row per position, WAL, append only. It is a file. You can back it up, move it, and query it with the sqlite3 binary. Nothing phones home. Retention is a disk budget you set, not a pricing tier, and you can set it to never prune.
+
+Now the part I want torn apart, because 208.8 bytes for what is really six numbers is fat and I know it:
+
+```sql
+positions(kind TEXT, id TEXT, t REAL, lon REAL, lat REAL, track REAL, extra TEXT)
+INDEX (id, t)
+INDEX (t)
+```
+
+A real row:
+
+```
+('vessel', 'vessel:255805884', 1784033740.045, 18.888277, 60.575748, 320.0, '{"name": "ELBSUMMER"}')
+```
+
+Three things are obviously wrong and I would rather say them than have you find them:
+
+- `extra` averages 75 chars and it is mostly the vessel's **name**, rewritten on every single fix. ELBSUMMER's name is on disk about 48 times an hour, forever. It is static per vessel and has no business in a position row.
+- `id` is a 15 char TEXT, stored in the table and again in the (id, t) index. It should be an integer key into a vessels table.
+- `kind` is the string 'aircraft' or 'vessel' on every row. That is a bit.
+
+The 208.8 figure includes both indexes. My back of the envelope says normalising the id, dropping the name out of the row and enum-ing kind gets this under 60 bytes/row, so call it 2.7 GB/day instead of 9.4. I have not done it yet. If you have done this shape of thing at this row count I would genuinely like to hear what you would do, especially about whether the (id, t) index is worth its weight or whether I should be partitioning by day.
+
+**A storage bug that ate 48 GB, since this sub will appreciate it**
+
+Yesterday the archive was 71 GB on disk for 15 GB of data. The write ahead log was 49.63 GB on its own.
+
+The cause is nastier than it looks. A WAL can only checkpoint past its oldest live reader. The UI polled a coverage query every 5 seconds, and that query scanned the whole archive and took longer than the gap between polls, so a read transaction was open permanently and the log could never be written back while the recorder kept appending.
+
+Then it compounds. Every page read has to search the WAL index for the newest version of that page, so a bigger log makes the scan slower, which holds the reader open longer, which grows the log faster. Same query: 73 seconds against the bloated log, 14.8 seconds once it was gone. The slow query was a symptom, not the cause.
+
+Stopping the writer and running `PRAGMA wal_checkpoint(TRUNCATE)` took 37.7 seconds and gave back 48.6 GB. The database grew by 1.04 GB, so 98% of that log was redundant page versions nothing could ever reclaim. Fixed by caching the scan and setting `journal_size_limit`. WAL sits at 0 now.
+
+If you run anything WAL-mode with a long reader and a constant writer, go look at your -wal file. I did not know a 49 GB WAL was a thing that could happen to me.
+
+**Honest caveats**
+
+Coverage is only as good as the public community feeders, so it is dense over land and populated coastline and sparse over open ocean. This is not a global truth dataset, it is what volunteers with antennas can see. The globe wants a GPU on the client. And this is a tool I run, not a dataset dump. I am not offering you my archive, I am offering you the recorder.
+
+**What I actually want from this sub**
+
+Storage tuning. The row layout above is the honest weak point and 9.4 GB/day is higher than it needs to be by roughly 3x. Tell me what you would cut. Repo and the compose file in the first comment.

--- a/docs/post-osinttools-2026-07-17.md
+++ b/docs/post-osinttools-2026-07-17.md
@@ -1,0 +1,74 @@
+# r/osinttools retry — drafted 2026-07-17
+
+Second attempt at r/osinttools. The first (2026-07-06, "I built Palantir
+Gotham.", 26 points / 13 comments) led with a comparison the reader had to
+reject and with fusion+AI; top comments were "AI slop dashboard" and "you
+definitely didn't build Gotham". Same inversion as the DataHoarder draft:
+capability the reader already wants, measured numbers, flaws volunteered, no
+brand-envy claim, automation labeled, no em dashes in the post body.
+
+TIMING WARNING (do not skip): the account has ~10 promo posts in 8 days and
+the r/DataHoarder submission was filtered on sight. Posting again from the
+same account before the DataHoarder mod conversation resolves risks the same
+silent removal here, and r/osinttools already knows this project from the
+Gotham post. Wait for the mod reply, or at minimum several quiet days, before
+this goes up. When it does: weekday 14:00-16:00 UTC, Showcase flair, answer
+comments for the first hour.
+
+---
+
+**Title:**
+
+Free trackers keep shrinking their history: FR24 gives 7 days, MarineTraffic cut free history to 24h, ADS-B Exchange killed the free API. So I record the picture myself: 9M+ positions in 2 days on my own disk, rewind any window, hash-chained exports. Open source, no API keys.
+
+---
+
+**Body:**
+
+A while back I posted here comparing this project to a certain commercial
+intelligence platform. That framing was wrong and the thread told me so.
+This is the same project, months later, described by what it actually does.
+
+The problem it solves for me: investigation timelines depend on position
+history, and every free source of it is shrinking. Flightradar24 free is 7
+days. MarineTraffic went from 72h free to 24h. ADS-B Exchange removed its
+free API tier. The live picture is never the paywall; the past is. If your
+case needs "where was this vessel last Tuesday", you either pay monthly or
+you already recorded it.
+
+So the tool records it. Numbers from the box it is running on right now, not
+projections:
+
+```
+live picture     ~11,500 aircraft, ~28,500 vessels (MMSI-deduped)
+recording        9.1M positions in the last 2 days, 1.8 GB, plain SQLite
+replay           scrub any recorded window, tracks re-fly on the globe
+cost to run      one docker compose up, no API keys for any core feed
+```
+
+What an OSINT workflow actually gets:
+
+- **Owned history.** Position archive on your disk, retention is a size cap
+  you set. Scrub back to any recorded moment and watch the picture as it was.
+- **Chain of custody.** An evidence locker: URL snapshots, uploads and feed
+  freezes get SHA-256 hashes and an append-only custody log; cases export to
+  self-contained HTML/PPTX where every claim carries its source.
+- **One picture.** Aircraft, vessels, satellites, quakes, wildfires, GPS
+  jamming, conflict events, naval warnings on one globe, with dossiers per
+  entity (registration, operator, track).
+- **Export.** GeoJSON/CSV/KML out, so QGIS or your own tooling stays in the
+  loop.
+
+The parts I want feedback on from this sub: which sources are missing that
+you would actually use (keyless preferred), and whether the evidence export
+format holds up against how you document cases.
+
+Honest limits, so nobody finds them the hard way: coverage is community
+feeders, so it is dense over Europe/US and thin over open ocean and conflict
+zones exactly when you want it most. AIS is strongest in Northern Europe.
+It is a single-analyst tool, not a team server. The 3D globe wants a real
+GPU. There are AI summarization features; they are optional, clearly
+labeled as automated output, and the tool works with them off.
+
+Repo: https://github.com/AndrewCTF/velocity (AGPL). Live demo:
+https://projectvelocity.org


### PR DESCRIPTION
Three pieces toward the relaunch, after the r/DataHoarder post was removed before anyone saw it (post-mortem included in the post doc).

**README conversion**
- The static hero is now a real 19 s capture, one take of live data: world view, fly-in to Europe, an EL AL 787 selected with its owned track, then the last hour rewound on the replay scrubber. 720 px, 7.5 MB.
- A free-tier comparison table above the fold: history depth / self-hosted / keys / who owns the archive, against Flightradar24, MarineTraffic and ADS-B Exchange. Every cell checkable on the vendors' pricing pages.

**Open-mode LINK chip fix**
Keyless clients skipped /ws/alerts entirely, so every fresh `docker compose up` showed a permanent red LINK-down chip — in the product and in any screen recording of it. Keyless clients now probe once: adopt the socket if the backend accepts (open mode), stay closed with no retry loop if it rejects before open. Three unit tests cover both paths and the reconnect-after-drop case.

**r/DataHoarder post-mortem**
The post doc records what happened (removed/filtered: absent from sub search and the account's public profile, zero traffic impact) and the repost path, which starts with mod pre-approval instead of another blind submit.

Verified: `scripts/verify.sh` green — web 393/393, api 1721 passed + 1 skipped, lint and typecheck clean. The hero capture itself demonstrates the WS fix: take 1 shows LINK down, take 2 shows LINK live.