### PR TITLE
Overnight hardening: SSRF, availability, and data-integrity fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,10 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1719 passed + 1 skipped** (skip = opt-in live probe; measured
-  2026-07-15, branch platform-hardening-and-copy-pass, sidecar
-  freshness+supervision wave). Never commit below the baseline you inherited. When you raise it,
+  Baseline: **1741 passed + 1 skipped** (skip = opt-in live probe; measured
+  2026-07-18, branch overnight-hardening-2026-07-18, overnight bug-hunt wave
+  (SSRF/replay/history-cap/entity-panel/feed-guards + foundry/collab/recon/
+  ontology hardening)). Never commit below the baseline you inherited. When you raise it,
   update the number/date/wave here and move the displaced line to
   `docs/decisions.md#backend-test-baseline-history` — this bullet stays a
   three-line fact, not a changelog.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,10 +155,10 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1741 passed + 1 skipped** (skip = opt-in live probe; measured
+  Baseline: **1745 passed + 1 skipped** (skip = opt-in live probe; measured
   2026-07-18, branch overnight-hardening-2026-07-18, overnight bug-hunt wave
   (SSRF/replay/history-cap/entity-panel/feed-guards + foundry/collab/recon/
-  ontology hardening)). Never commit below the baseline you inherited. When you raise it,
+  ontology + correlation-loop/weather/detector hardening)). Never commit below the baseline you inherited. When you raise it,
   update the number/date/wave here and move the displaced line to
   `docs/decisions.md#backend-test-baseline-history` — this bullet stays a
   three-line fact, not a changelog.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1745 passed + 1 skipped** (skip = opt-in live probe; measured
+  Baseline: **1747 passed + 1 skipped** (skip = opt-in live probe; measured
   2026-07-18, branch overnight-hardening-2026-07-18, overnight bug-hunt wave
   (SSRF/replay/history-cap/entity-panel/feed-guards + foundry/collab/recon/
   ontology + correlation-loop/weather/detector hardening)). Never commit below the baseline you inherited. When you raise it,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Ontology (2026-07-07, docs/decisions.md#ontology-local-first-store-2026-07-07):
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **1747 passed + 1 skipped** (skip = opt-in live probe; measured
+  Baseline: **1750 passed + 1 skipped** (skip = opt-in live probe; measured
   2026-07-18, branch overnight-hardening-2026-07-18, overnight bug-hunt wave
   (SSRF/replay/history-cap/entity-panel/feed-guards + foundry/collab/recon/
   ontology + correlation-loop/weather/detector hardening)). Never commit below the baseline you inherited. When you raise it,

--- a/apps/api/app/correlate/runner.py
+++ b/apps/api/app/correlate/runner.py
@@ -108,7 +108,7 @@ async def _opensky_loop(stop: asyncio.Event) -> None:
             if e.response is not None and e.response.status_code == 429:
                 backoff = min(backoff * 2 + 30.0, 900.0)
             log.debug("opensky loop status: %s", e)
-        except httpx.HTTPError as e:
+        except Exception as e:  # noqa: BLE001 — never let one bad poll kill the loop
             log.debug("opensky loop transient: %s", e)
         await asyncio.sleep(30 + backoff)
 
@@ -173,7 +173,7 @@ async def _mil_loop(stop: asyncio.Event) -> None:
                 }
                 obs = _aircraft_obs_from_geojson(fc, "adsb_mil")
                 store.add_many(obs)
-        except httpx.HTTPError as e:
+        except Exception as e:  # noqa: BLE001 — never let one bad poll kill the loop
             log.debug("mil_loop transient: %s", e)
         await asyncio.sleep(30)
 
@@ -244,7 +244,7 @@ async def _quake_loop(stop: asyncio.Event) -> None:
                         )
                     if batch:
                         store.add_many(batch)
-        except httpx.HTTPError as e:
+        except Exception as e:  # noqa: BLE001 — never let one bad poll kill the loop
             log.debug("quake_loop transient: %s", e)
         await asyncio.sleep(120)
 
@@ -284,7 +284,7 @@ async def _emerg_loop(stop: asyncio.Event) -> None:
                 }
                 obs = _aircraft_obs_from_geojson(fc, "airplanes_live")
                 store.add_many(obs)
-        except httpx.HTTPError as e:
+        except Exception as e:  # noqa: BLE001 — never let one bad poll kill the loop
             log.debug("emerg loop transient: %s", e)
         await asyncio.sleep(30)
 

--- a/apps/api/app/foundry/binding.py
+++ b/apps/api/app/foundry/binding.py
@@ -116,8 +116,19 @@ async def sync_binding(
                 if len(candidates) == 1:
                     target_id = candidates[0]
             existing = await reg.get(target_id)
+            if existing is not None and target_id != object_id:
+                # Resolved onto a pre-existing object minted by another source:
+                # overlay our mapped props onto its blob so the wholesale-replace
+                # upsert (removals included, by contract) doesn't wipe the props
+                # this binding never owned — including the natural key when the
+                # author didn't map key_column. For a foundry-minted object
+                # (target_id == object_id) the binding IS the sole writer, so the
+                # sparse blob is authoritative and no merge is wanted.
+                merged = {**(existing.props or {}), **props}
+            else:
+                merged = props
             await reg.upsert(
-                Object(id=target_id, kind=binding["object_kind"], props=props),
+                Object(id=target_id, kind=binding["object_kind"], props=merged),
                 source=source,
             )
             if existing is None:

--- a/apps/api/app/foundry/sqlrun.py
+++ b/apps/api/app/foundry/sqlrun.py
@@ -63,10 +63,14 @@ def _guard_query(query: str) -> str:
 
 
 def _cell(value: Any) -> Any:
+    if isinstance(value, bool):  # bool is an int subclass — store as 0/1
+        return int(value)
+    if isinstance(value, int) and not (-(2**63) <= value < 2**63):
+        # SQLite INTEGER is signed 64-bit; a larger Python int (a 20-digit id)
+        # overflows executemany. Store the oversize value as text, don't crash.
+        return str(value)
     if value is None or isinstance(value, (int, float, str)):
         return value
-    if isinstance(value, bool):  # pragma: no cover - bool is int subclass
-        return int(value)
     try:
         return json.dumps(value, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
@@ -83,7 +87,9 @@ def _load_table(conn: sqlite3.Connection, name: str, rows: list[dict[str, Any]])
                 cols.append(key)
     if not cols:
         cols = ["value"]
-    col_sql = ", ".join(f'"{c}"' for c in cols)
+    # Double any embedded quote so a column literally named a"b is a valid SQL
+    # identifier ("a""b") instead of malformed DDL that raises out of the load.
+    col_sql = ", ".join('"' + c.replace('"', '""') + '"' for c in cols)
     conn.execute(f'CREATE TABLE "{name}" ({col_sql})')
     placeholders = ", ".join("?" for _ in cols)
     conn.executemany(
@@ -109,8 +115,14 @@ def run_sql(
     conn = sqlite3.connect(":memory:")
     timer: threading.Timer | None = None
     try:
-        for name, rows in tables.items():
-            _load_table(conn, slug_ident(name), rows)
+        try:
+            for name, rows in tables.items():
+                _load_table(conn, slug_ident(name), rows)
+        except (sqlite3.Error, ValueError, OverflowError) as exc:
+            # Loading runs before the inner try below, so without this a malformed
+            # identifier or an out-of-range value would escape run_sql unwrapped
+            # and 500 the SQL route instead of returning a clean SqlError (4xx).
+            raise SqlError(f"could not load input table: {exc}") from exc
         conn.execute("PRAGMA query_only=ON")
         timer = threading.Timer(max(0.1, timeout_s), conn.interrupt)
         timer.start()

--- a/apps/api/app/foundry/transforms.py
+++ b/apps/api/app/foundry/transforms.py
@@ -12,15 +12,26 @@ from __future__ import annotations
 import ast
 import calendar
 import functools
+import json
 import re
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
-from app.foundry.store import FoundryError
+from app.foundry.store import MAX_ROWS_PER_DATASET, FoundryError
 
 Row = dict[str, Any]
+
+
+def _hashable(v: Any) -> Any:
+    """A stable, hashable form of a possibly-nested cell value. group_by / join /
+    pivot keys can carry a JSON list or dict (NDJSON columns), which cannot be a
+    dict key — canonicalize those to a string so one nested value does not raise
+    TypeError and abort the whole build (these steps aren't row-quarantined)."""
+    if isinstance(v, (list, dict)):
+        return json.dumps(v, sort_keys=True, default=str)
+    return v
 
 # ── safe expression evaluator ─────────────────────────────────────────────────
 
@@ -565,11 +576,11 @@ def _step_join(rows: list[Row], step: dict[str, Any], provider: DatasetProvider)
     how = step.get("how", "left")
     index: dict[Any, list[Row]] = {}
     for rr in right_rows:
-        index.setdefault(rr.get(right_on), []).append(rr)
+        index.setdefault(_hashable(rr.get(right_on)), []).append(rr)
     right_cols = list(right_rows[0].keys()) if right_rows else []
     out: list[Row] = []
     for r in rows:
-        matches = index.get(r.get(on))
+        matches = index.get(_hashable(r.get(on)))
         if not matches:
             if how == "inner":
                 continue
@@ -579,6 +590,16 @@ def _step_join(rows: list[Row], step: dict[str, Any], provider: DatasetProvider)
             continue
         for match in matches:
             out.append({**match, **r})
+        # A low-cardinality join key fans out to len(left) * len(matches) rows and
+        # the dataset row cap is only checked AFTER run_steps returns — so bound
+        # the materialized product here, or a join OOMs the whole API before the
+        # cap ever runs. Checked per left-row (worst case one extra key's matches).
+        if len(out) > MAX_ROWS_PER_DATASET:
+            raise FoundryError(
+                422,
+                f"join fan-out exceeded the {MAX_ROWS_PER_DATASET} row cap "
+                "(low-cardinality join key?)",
+            )
     return out
 
 
@@ -587,7 +608,7 @@ def _step_aggregate(rows: list[Row], step: dict[str, Any]) -> list[Row]:
     aggs: dict[str, str] = step["aggs"]
     groups: dict[tuple[Any, ...], list[Row]] = {}
     for r in rows:
-        key = tuple(r.get(g) for g in group_by)
+        key = tuple(_hashable(r.get(g)) for g in group_by)
         groups.setdefault(key, []).append(r)
     out: list[Row] = []
     for key, members in groups.items():
@@ -767,7 +788,7 @@ def _step_pivot(rows: list[Row], step: dict[str, Any]) -> list[Row]:
     seen: set[str] = set()
     groups: dict[tuple[Any, ...], dict[str, list[Any]]] = {}
     for r in rows:
-        key = tuple(r.get(i) for i in index)
+        key = tuple(_hashable(r.get(i)) for i in index)
         pv = r.get(column)
         pvs = "" if pv is None else str(pv)
         if pvs not in seen:

--- a/apps/api/app/history.py
+++ b/apps/api/app/history.py
@@ -532,30 +532,36 @@ def prune(retention_hours: int) -> int:
 
 
 def enforce_size_cap(max_bytes: int) -> int:
-    """Drop the oldest rows until the DB file is under *max_bytes*.
+    """Drop the oldest rows until the DB's IN-USE size is under *max_bytes*.
 
-    The on-disk file size only shrinks after a VACUUM, so we cannot delete-and-
-    measure in a loop. Instead we estimate the fraction of rows to drop from the
-    byte overage (with a 10 % margin) and delete that oldest slice in one pass;
-    the caller VACUUMs afterwards and the next hourly pass corrects any residue.
-    Returns the deleted row count. A max_bytes of 0 disables the cap.
+    Sizing off ``os.path.getsize`` would over-delete: a bare DELETE (this pass
+    runs right after ``prune``) leaves reclaimable free pages that the on-disk
+    file still counts because auto_vacuum is off, and the caller VACUUMs
+    immediately afterwards. We would then drop an extra oldest slice that the
+    VACUUM was about to hand back for free — chronically shortening the replay
+    window. So measure in-use bytes (page_count - freelist_count) * page_size,
+    which is what the file becomes after the VACUUM.
+
+    The size only shrinks on VACUUM, so we cannot delete-and-measure in a loop.
+    Instead we estimate the fraction of rows to drop from the byte overage (with
+    a 10 % margin) and delete that oldest slice in one pass; the next hourly pass
+    corrects any residue. Returns the deleted row count. max_bytes 0 disables it.
     """
     if max_bytes <= 0:
-        return 0
-    path = _resolved_db_path()
-    try:
-        size = os.path.getsize(path)
-    except OSError:
-        return 0
-    if size <= max_bytes:
         return 0
     try:
         con = _connect()
         try:
+            page_size = con.execute("PRAGMA page_size").fetchone()[0]
+            page_count = con.execute("PRAGMA page_count").fetchone()[0]
+            freelist = con.execute("PRAGMA freelist_count").fetchone()[0]
+            in_use = (page_count - freelist) * page_size
+            if in_use <= max_bytes:
+                return 0
             total = con.execute("SELECT COUNT(*) FROM positions").fetchone()[0]
             if total <= 0:
                 return 0
-            over_frac = 1.0 - (max_bytes / size)
+            over_frac = 1.0 - (max_bytes / in_use)
             to_drop = min(total - 1, int(total * over_frac * 1.1) + 1)
             if to_drop <= 0:
                 return 0

--- a/apps/api/app/intel/country_profile.py
+++ b/apps/api/app/intel/country_profile.py
@@ -29,6 +29,7 @@ client would hang.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any
 
@@ -42,6 +43,9 @@ _SPARQL = "https://query.wikidata.org/sparql"
 _PROFILE_TTL = 86400.0  # 24h — leadership/structure changes are rare
 _SECURITY_TTL = 900.0  # 15 min — matches the GDELT/UCDP layer cadence
 _BRIEF_TTL = 600.0  # 10 min
+# Total wall-clock cap on the brief ladder, under Cloudflare's 100 s edge limit —
+# the per-backend timeout_s below bounds each rung, this bounds their sum.
+_BRIEF_LLM_BUDGET_S = 90.0
 
 _MAX_BRANCHES = 12
 _MAX_EVENTS = 25
@@ -449,20 +453,26 @@ async def country_brief(
         }
         import json as _json
 
-        res = await llm.chat(
-            [
-                {"role": "system", "content": llm.with_prose_style(_BRIEF_SYS)},
-                {"role": "user", "content": _json.dumps(payload, ensure_ascii=False)},
-            ],
-            tier="fast",
-            max_tokens=900,
-            timeout_s=60.0,
-            label="country.brief",
-        )
+        try:
+            res = await asyncio.wait_for(
+                llm.chat(
+                    [
+                        {"role": "system", "content": llm.with_prose_style(_BRIEF_SYS)},
+                        {"role": "user", "content": _json.dumps(payload, ensure_ascii=False)},
+                    ],
+                    tier="fast",
+                    max_tokens=900,
+                    timeout_s=60.0,
+                    label="country.brief",
+                ),
+                timeout=_BRIEF_LLM_BUDGET_S,
+            )
+        except TimeoutError:
+            return {"ok": False, "reason": "no LLM backend configured", "iso3": iso3u, "name": name}
         if not res.ok:
             return {
                 "ok": False,
-                "reason": res.error or "no LLM backend configured",
+                "reason": "no LLM backend configured",
                 "iso3": iso3u,
                 "name": name,
             }

--- a/apps/api/app/intel/detectors.py
+++ b/apps/api/app/intel/detectors.py
@@ -27,7 +27,10 @@ def haversine_nm(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
     dphi = math.radians(lat2 - lat1)
     dlmb = math.radians(lon2 - lon1)
     a = math.sin(dphi / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlmb / 2) ** 2
-    return (2 * r_m * math.asin(math.sqrt(a))) * _NM_PER_M
+    # Clamp before asin: floating-point error can push sqrt(a) just past 1.0 for a
+    # near-antipodal pair, and math.asin(>1) raises a domain ValueError (same guard
+    # as correlate/rules.py:273). Uncaught here it drops the whole behavioral sweep.
+    return (2 * r_m * math.asin(min(1.0, math.sqrt(a)))) * _NM_PER_M
 
 
 def _in_bbox(lon: float, lat: float, bbox: Bbox | None) -> bool:

--- a/apps/api/app/intel/ontology_local.py
+++ b/apps/api/app/intel/ontology_local.py
@@ -33,8 +33,6 @@ from pathlib import Path
 from typing import Any
 
 from app.config import Settings, get_settings
-
-log = logging.getLogger(__name__)
 from app.intel.ontology import (
     Assertion,
     Link,
@@ -43,6 +41,8 @@ from app.intel.ontology import (
     kind_of,
 )
 from app.keys import UserCtx
+
+log = logging.getLogger(__name__)
 
 # ── DB path injection (for tests) ─────────────────────────────────────────────
 

--- a/apps/api/app/intel/ontology_local.py
+++ b/apps/api/app/intel/ontology_local.py
@@ -26,12 +26,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sqlite3
 import time
 from pathlib import Path
 from typing import Any
 
 from app.config import Settings, get_settings
+
+log = logging.getLogger(__name__)
 from app.intel.ontology import (
     Assertion,
     Link,
@@ -606,18 +609,25 @@ class SqliteRegistry(_GraphWalk):
         # If the DB is over-cap on custody rows alone, nothing is trimmed here
         # (the operator must raise ontology_db_max_bytes or archive) — the
         # legal record wins over the soft byte cap by design.
-        (total,) = con.execute(
-            "SELECT COUNT(*) FROM assertions WHERE prop!='custody'"
-        ).fetchone()
-        drop = max(1, total // 10)
-        con.execute(
-            "DELETE FROM assertions WHERE id IN ("
-            " SELECT id FROM assertions WHERE prop!='custody'"
-            " ORDER BY observed_at ASC, id ASC LIMIT ?)",
-            (drop,),
-        )
-        con.commit()
-        con.execute("VACUUM")
+        # Best-effort: this runs AFTER the caller's write already committed, so a
+        # lock contention here (a concurrent writer holds the DB during VACUUM,
+        # which needs an exclusive lock) must NOT surface as a 500 for a write that
+        # already persisted. Skip this cycle; the next gated attempt retries.
+        try:
+            (total,) = con.execute(
+                "SELECT COUNT(*) FROM assertions WHERE prop!='custody'"
+            ).fetchone()
+            drop = max(1, total // 10)
+            con.execute(
+                "DELETE FROM assertions WHERE id IN ("
+                " SELECT id FROM assertions WHERE prop!='custody'"
+                " ORDER BY observed_at ASC, id ASC LIMIT ?)",
+                (drop,),
+            )
+            con.commit()
+            con.execute("VACUUM")
+        except sqlite3.Error:
+            log.warning("ontology soft byte-cap enforcement skipped (db busy)", exc_info=True)
 
 
 # ── row → model ───────────────────────────────────────────────────────────────

--- a/apps/api/app/intel/ontology_local.py
+++ b/apps/api/app/intel/ontology_local.py
@@ -529,14 +529,23 @@ class SqliteRegistry(_GraphWalk):
         and is kept — the roadmap guard requires two sources to coexist.
         """
         encoded = _canon(value)
+        is_removal = bool(isinstance(derivation, dict) and derivation.get("op") == "remove")
         last = con.execute(
-            "SELECT value, source FROM assertions"
+            "SELECT value, source, derivation FROM assertions"
             " WHERE user_id=? AND object_id=? AND prop=?"
             " ORDER BY observed_at DESC, id DESC LIMIT 1",
             (self.ctx.user_id, object_id, prop),
         ).fetchone()
         if last is not None and last[0] == encoded and last[1] == source:
-            return
+            # A removal tombstone encodes value=None as "null", the same as an
+            # explicit note=null write — but they are different facts, so the
+            # tombstone must not be deduped away against a prior null value (else
+            # the removal never lands in the append-only provenance trail). Only a
+            # true duplicate (same value, source, AND removal-ness) is dropped.
+            last_deriv = json.loads(last[2]) if last[2] else None
+            last_removal = bool(isinstance(last_deriv, dict) and last_deriv.get("op") == "remove")
+            if last_removal == is_removal:
+                return
         con.execute(
             "INSERT INTO assertions (user_id, object_id, prop, value, source,"
             " confidence, observed_at, valid_until, derivation)"

--- a/apps/api/app/intel/watch.py
+++ b/apps/api/app/intel/watch.py
@@ -430,7 +430,11 @@ def evaluate_rules(
                 if _meets_severity(r, cand.severity_rank):
                     firings.append((r, cand, "enter"))
             elif was_inside and not now_inside:
-                _STATE.inside[key] = False
+                # Drop the key rather than store False: get(key, False) already
+                # treats an absent key as "outside", so this is equivalent state but
+                # bounds _STATE.inside to entities CURRENTLY inside a geofence — a
+                # False entry per distinct entity that ever transited grows forever.
+                _STATE.inside.pop(key, None)
                 firings.append((r, cand, "exit"))
     return firings
 

--- a/apps/api/app/llamacpp_sidecar.py
+++ b/apps/api/app/llamacpp_sidecar.py
@@ -165,8 +165,14 @@ async def ensure_hot(key: str) -> None:
 
 
 async def _load_hot_models() -> None:
+    # Runs in the background (see start): a slow or failed warm for one model must
+    # not abort the rest or leave an unretrieved exception on the fire-and-forget
+    # task. Each model also loads on demand via ensure_hot, so this is best-effort.
     for key in manager.get_hot():
-        await ensure_hot(key)
+        try:
+            await ensure_hot(key)
+        except Exception:  # noqa: BLE001 — warm is best-effort; on-demand load covers it
+            log.warning("hot-model warm failed for %s", key, exc_info=True)
 
 
 async def _hot_poll_loop() -> None:
@@ -297,8 +303,13 @@ async def start() -> None:
                 "llama-server healthy on %s (router mode, models-max=%s)",
                 _host(), settings.llamacpp_models_max,
             )
-            await _load_hot_models()
             _known_hot = set(manager.get_hot())
+            # Warm the pinned models in the BACKGROUND. Awaiting here blocked the
+            # lifespan-awaited start() until every hot model loaded (up to 300s
+            # each, sequential), freezing everything sequenced after it at boot
+            # (adsb start_snapshot, the AIS feeders, the watch loops). They load on
+            # demand via ensure_hot anyway, so the warm is a best-effort optimisation.
+            asyncio.create_task(_load_hot_models())
             _hot_poll_task = asyncio.create_task(_hot_poll_loop())
             return
         await asyncio.sleep(1.0)

--- a/apps/api/app/llamacpp_sidecar.py
+++ b/apps/api/app/llamacpp_sidecar.py
@@ -68,6 +68,7 @@ _proc: asyncio.subprocess.Process | None = None
 # browser never sees it — app.llm's _llamacpp_chat rung reads it via api_key().
 _api_key: str | None = None
 _hot_poll_task: asyncio.Task[None] | None = None
+_warm_task: asyncio.Task[None] | None = None  # background hot-model warm (best-effort)
 _known_hot: set[str] = set()
 
 
@@ -229,7 +230,7 @@ async def start() -> None:
     per-boot key, because a foreign process's key is unknown and unauthenticated
     chats would otherwise fail.
     """
-    global _proc, _api_key, _hot_poll_task, _known_hot
+    global _proc, _api_key, _hot_poll_task, _warm_task, _known_hot
     if not is_enabled():
         return
     settings = get_settings()
@@ -309,7 +310,7 @@ async def start() -> None:
             # each, sequential), freezing everything sequenced after it at boot
             # (adsb start_snapshot, the AIS feeders, the watch loops). They load on
             # demand via ensure_hot anyway, so the warm is a best-effort optimisation.
-            asyncio.create_task(_load_hot_models())
+            _warm_task = asyncio.create_task(_load_hot_models())
             _hot_poll_task = asyncio.create_task(_hot_poll_loop())
             return
         await asyncio.sleep(1.0)
@@ -321,10 +322,13 @@ async def start() -> None:
 async def stop() -> None:
     """Terminate llama-server (graceful SIGTERM, then SIGKILL). No-op if not
     ours / already gone."""
-    global _proc, _api_key, _hot_poll_task, _known_hot
+    global _proc, _api_key, _hot_poll_task, _warm_task, _known_hot
     if _hot_poll_task is not None:
         _hot_poll_task.cancel()
         _hot_poll_task = None
+    if _warm_task is not None:
+        _warm_task.cancel()
+        _warm_task = None
     _known_hot = set()
 
     proc, _proc = _proc, None

--- a/apps/api/app/localllm/manager.py
+++ b/apps/api/app/localllm/manager.py
@@ -494,7 +494,15 @@ async def _progress_monitor(job: Job, target_dir: Path) -> None:
 async def _run_job(job: Job, sha256_by_file: dict[str, str]) -> None:
     root = models_root()
     target_dir = root / job.key
-    target_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        # This ran before the try below, so a mkdir failure (disk full / not
+        # writable between the preflight and here) killed the fire-and-forget task
+        # with an unretrieved exception and left the job stuck in "queued" forever.
+        job.status = "error"
+        job.error = f"could not create model directory: {exc}"
+        return
     job.status = "downloading"
     monitor = asyncio.create_task(_progress_monitor(job, target_dir))
     try:

--- a/apps/api/app/news/images.py
+++ b/apps/api/app/news/images.py
@@ -49,37 +49,63 @@ def parse_og_image(html: str) -> str:
     return c.group(1).strip() if c else ""
 
 
-async def _is_public_url(url: str) -> bool:
-    """True only for an http(s) URL whose host resolves to public unicast IPs.
+async def _getaddrinfo(host: str, port: int | None) -> list:
+    """Thin wrapper over the loop resolver — a monkeypatch seam for tests."""
+    return await asyncio.get_event_loop().getaddrinfo(host, port)
 
-    Resolves the host (async, no blocking the loop) and rejects the request if
-    ANY resolved address is loopback/private/link-local/reserved/multicast —
-    the SSRF gate. A literal-IP host is parsed directly (no DNS, offline-safe).
+
+def _is_non_public(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return bool(
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+async def _resolve_public(url: str) -> tuple[bool, str | None]:
+    """``(is_public, ip_to_pin)``. Resolve the host (async, no blocking the loop)
+    and reject the request if ANY resolved address is loopback / private /
+    link-local / reserved / multicast — the SSRF gate. The returned IP lets the
+    caller pin the http connection to the just-validated address, closing the
+    DNS-rebinding gap between this check and the fetch. It is None for a literal-IP
+    host (nothing to rebind, offline-safe).
     """
     p = urlparse(url)
     if p.scheme not in ("http", "https") or not p.hostname:
-        return False
+        return False, None
     try:
-        infos = await asyncio.get_event_loop().getaddrinfo(p.hostname, p.port or None)
+        ipaddress.ip_address(p.hostname)
+        literal = True
+    except ValueError:
+        literal = False
+    try:
+        infos = await _getaddrinfo(p.hostname, p.port or None)
     except Exception:  # noqa: BLE001 — unresolvable host → treat as unsafe
-        return False
+        return False, None
     if not infos:
-        return False
+        return False, None
+    resolved: list[str] = []
     for info in infos:
         try:
             addr = ipaddress.ip_address(info[4][0])
         except ValueError:
-            return False
-        if (
-            addr.is_private
-            or addr.is_loopback
-            or addr.is_link_local
-            or addr.is_reserved
-            or addr.is_multicast
-            or addr.is_unspecified
-        ):
-            return False
-    return True
+            return False, None
+        if _is_non_public(addr):
+            return False, None
+        resolved.append(info[4][0])
+    if literal:
+        return True, None  # a literal-IP host cannot be rebound — nothing to pin
+    pin = next((a for a in resolved if ":" not in a), resolved[0] if resolved else None)
+    return True, pin
+
+
+async def _is_public_url(url: str) -> bool:
+    """True only for an http(s) URL whose host resolves to public unicast IPs."""
+    ok, _ = await _resolve_public(url)
+    return ok
 
 
 async def fetch_og_image(url: str, timeout_s: float = 6.0) -> str:
@@ -99,11 +125,22 @@ async def fetch_og_image(url: str, timeout_s: float = 6.0) -> str:
         client = get_client()
         cur = url
         for _ in range(_MAX_REDIRECTS + 1):
-            if not await _is_public_url(cur):
+            ok, pin = await _resolve_public(cur)
+            if not ok:
                 break
+            p = urlparse(cur)
+            req_url = cur
+            headers = {"User-Agent": _UA}
+            # Pin the http connection to the IP we just validated so httpx cannot
+            # re-resolve to a rebound (metadata / internal) address between the
+            # check and the fetch. https keeps its hostname for cert validation —
+            # the same documented residual risk as workflows/control.py.
+            if pin is not None and p.scheme == "http":
+                host = f"[{pin}]" if ":" in pin else pin
+                req_url = p._replace(netloc=f"{host}:{p.port}" if p.port else host).geturl()
+                headers["Host"] = p.netloc
             r = await client.get(
-                cur, timeout=timeout_s, follow_redirects=False,
-                headers={"User-Agent": _UA},
+                req_url, timeout=timeout_s, follow_redirects=False, headers=headers,
             )
             loc = r.headers.get("location")
             if r.status_code in (301, 302, 303, 307, 308) and loc:

--- a/apps/api/app/ratelimit.py
+++ b/apps/api/app/ratelimit.py
@@ -34,6 +34,7 @@ _COMPUTE_PREFIXES: tuple[str, ...] = (
     "/api/osint/recon",              # GPL deep-recon sidecar
     "/api/osint/investigate",        # LLM-backed OSINT orchestrator
     "/api/imagery/detect",           # YOLO detection subprocess
+    "/api/imagery/splat",            # AOI chip → 3DGS reconstruction (GPU job)
     "/api/extract",                  # LLM entity extraction
     "/api/intel/agent",              # LLM analysis agent
     "/api/intel/investigate",        # LLM investigation

--- a/apps/api/app/routes/adsb.py
+++ b/apps/api/app/routes/adsb.py
@@ -308,7 +308,10 @@ async def adsb_lol_point(
     async def load() -> dict[str, Any]:
         url = f"https://api.adsb.lol/v2/point/{lat}/{lon}/{radius_nm}"
         r = await get_client().get(url)
-        if r.status_code != 200:
+        # 200 + text/plain is how adsb.lol answers a rate limit; a bare r.json()
+        # there raises ValueError and 500s the route (cache.get_or_fetch does not
+        # wrap the loader). Treat a non-JSON body like a bad status → 502.
+        if r.status_code != 200 or "json" not in r.headers.get("content-type", "").lower():
             raise HTTPException(502, f"adsb.lol upstream {r.status_code}")
         j = r.json()
         return _aircraft_geojson(j.get("ac") or [])
@@ -2001,7 +2004,9 @@ async def adsb_fi_global() -> dict[str, Any]:
 
     async def load() -> dict[str, Any]:
         r = await get_client().get("https://opendata.adsb.fi/api/v2/snapshot")
-        if r.status_code != 200:
+        # 200 + text/plain rate-limit body would 500 the route on r.json(); treat
+        # a non-JSON body like a bad status → 502 (same guard as _parse_ac).
+        if r.status_code != 200 or "json" not in r.headers.get("content-type", "").lower():
             raise HTTPException(502, f"adsb.fi /snapshot {r.status_code}")
         j = r.json()
         return _aircraft_geojson(j.get("aircraft") or j.get("ac") or [])

--- a/apps/api/app/routes/ai_selection.py
+++ b/apps/api/app/routes/ai_selection.py
@@ -58,6 +58,9 @@ _MAX_CONTEXT_STRING = 320
 # to survive that preamble and still answer; 768 leaves room for both the
 # preamble and the longer structured markdown brief.
 _MAX_TOKENS = 768
+# Total wall-clock cap on the selection ladder so a stalled backend can't pin the
+# worker past the 100 s edge limit (the LLM call itself is otherwise unbounded).
+_SELECTION_LLM_BUDGET_S = 60.0
 
 
 class BriefIn(BaseModel):
@@ -360,15 +363,22 @@ async def post_selection_brief(
             context_json = json.dumps(context, default=str, separators=(",", ":"))
             user += f"\n\nENRICHMENT:\n{context_json}"
         started = time.monotonic()
-        res = await llm.chat(
-            [{"role": "system", "content": system}, {"role": "user", "content": user}],
-            tier="selection",
-            max_tokens=_MAX_TOKENS,
-            label="ai.selection_brief",
-        )
+        try:
+            res = await asyncio.wait_for(
+                llm.chat(
+                    [{"role": "system", "content": system}, {"role": "user", "content": user}],
+                    tier="selection",
+                    max_tokens=_MAX_TOKENS,
+                    label="ai.selection_brief",
+                ),
+                timeout=_SELECTION_LLM_BUDGET_S,
+            )
+        except TimeoutError as e:
+            raise HTTPException(status_code=502, detail="AI assessment unavailable") from e
         latency_ms = round((time.monotonic() - started) * 1000)
         if not res.ok:
-            raise HTTPException(status_code=502, detail=res.error or "selection brief failed")
+            # Never surface the raw backend error string to a client (copy rule).
+            raise HTTPException(status_code=502, detail="AI assessment unavailable")
         return {
             "ok": True,
             "text": res.text,

--- a/apps/api/app/routes/ais.py
+++ b/apps/api/app/routes/ais.py
@@ -121,6 +121,12 @@ def _normalize(text: str) -> str | None:
     lon = meta.get("longitude")
     if mmsi is None or lat is None or lon is None:
         return None
+    try:
+        mmsi = int(mmsi)
+    except (TypeError, ValueError):
+        # A malformed MMSI must skip this one message, not raise out of the
+        # async-for and tear down the shared upstream socket for every client.
+        return None
     ship_name = (meta.get("ShipName") or "").strip() or None
 
     # Extract / cache the ITU ship type. ShipStaticData carries it; some
@@ -134,8 +140,8 @@ def _normalize(text: str) -> str | None:
         or meta.get("ShipType")
     )
     if candidate_type is not None:
-        _remember_ship_type(int(mmsi), candidate_type)
-    ship_type = _ship_type_by_mmsi.get(int(mmsi))
+        _remember_ship_type(mmsi, candidate_type)
+    ship_type = _ship_type_by_mmsi.get(mmsi)
 
     out: dict[str, Any] = {
         "kind": "vessel",

--- a/apps/api/app/routes/cams.py
+++ b/apps/api/app/routes/cams.py
@@ -81,13 +81,17 @@ async def _load_digitraffic() -> list[Cam]:
         preset_id = (presets[0] or {}).get("id")
         if not preset_id:
             continue
+        try:
+            lat, lon = float(coords[1]), float(coords[0])
+        except (TypeError, ValueError):
+            continue  # a station pending geolocation (null coords) must not 500 /api/cams
         station_id = str(props.get("id") or f.get("id") or preset_id)
         out.append(
             Cam(
                 id=f"digitraffic:{station_id}",
                 name=str(props.get("name") or station_id).replace("_", " "),
-                lat=float(coords[1]),
-                lon=float(coords[0]),
+                lat=lat,
+                lon=lon,
                 snapshot_url=_DIGITRAFFIC_IMG.format(preset=preset_id),
                 source="digitraffic",
                 attribution="Fintraffic / digitraffic.fi (CC BY 4.0)",

--- a/apps/api/app/routes/collab.py
+++ b/apps/api/app/routes/collab.py
@@ -90,9 +90,18 @@ def _ws_token(ws: WebSocket) -> str:
     )
 
 
+class _AclUnavailable(Exception):
+    """A configured doc-ACL store could not be reached or parsed. The live
+    clearance gate must fail CLOSED here — an under-cleared user must not join a
+    classified doc's channel just because the store hiccuped."""
+
+
 async def _doc_acl(token: str, doc: str) -> tuple[int, list[str]] | None:
-    """A doc's (classification, compartments) via the definer RPC, or None if the
-    doc does not exist yet (new doc) / the store is unreachable."""
+    """A doc's (classification, compartments) via the definer RPC, or None when
+    there is no ACL to consult: no Supabase store configured (single-tenant
+    API-key auth), or the doc has no ACL row yet (a new doc being created).
+    Raises _AclUnavailable when a configured store cannot be reached or parsed —
+    that is distinct from "new doc" and must fail closed, not open."""
     s = get_settings()
     if not s.supabase_url:
         return None
@@ -106,13 +115,15 @@ async def _doc_acl(token: str, doc: str) -> tuple[int, list[str]] | None:
     try:
         async with _client() as c:
             r = await c.post(url, json={"p_doc": doc}, headers=headers)
-    except Exception:  # noqa: BLE001 — store down → fail closed below
-        return None
-    if r.status_code != 200:
-        return None
-    rows = r.json()
+        if r.status_code != 200:
+            raise _AclUnavailable(f"acl rpc {r.status_code}")
+        rows = r.json()
+    except _AclUnavailable:
+        raise
+    except Exception as e:  # noqa: BLE001 — transport error or non-JSON body
+        raise _AclUnavailable() from e
     if not rows:
-        return None
+        return None  # doc has no ACL row yet → a new doc being created
     row = rows[0]
     return int(row.get("classification") or 0), list(row.get("compartments") or [])
 
@@ -127,9 +138,12 @@ async def _collab_join_allowed(ws: WebSocket, doc: str) -> bool:
     p = await principal_for_token(_ws_token(ws))
     if p is None:
         return False
-    acl = await _doc_acl(p.token, doc)
+    try:
+        acl = await _doc_acl(p.token, doc)
+    except _AclUnavailable:
+        return False  # store hiccup: fail CLOSED, don't leak a classified doc
     if acl is None:
-        return True  # new doc (or store unreachable) — creating, allow
+        return True  # no ACL to consult (single-tenant / new doc) — allow
     level, comps = acl
     return clf.can_read(p.clearance, list(p.compartments), level, comps)
 

--- a/apps/api/app/routes/eq.py
+++ b/apps/api/app/routes/eq.py
@@ -24,7 +24,10 @@ async def quakes(range: Range = Query("day")) -> dict[str, Any]:
     async def fetch() -> dict[str, Any]:
         url = UPSTREAM.format(range=range)
         r = await get_client().get(url)
-        if r.status_code != 200:
+        # A non-JSON 200 (CDN error page / rate-limit body) would raise out of the
+        # cache.get_or_fetch loader and 500 this sacred keyless layer; treat it
+        # like a bad status → 502 so the quakes layer degrades, never crashes.
+        if r.status_code != 200 or "json" not in r.headers.get("content-type", "").lower():
             raise HTTPException(status_code=502, detail=f"upstream {r.status_code}")
         data = r.json()
         # USGS returns FeatureCollection — pass-through.

--- a/apps/api/app/routes/extract.py
+++ b/apps/api/app/routes/extract.py
@@ -11,6 +11,7 @@ audit row. ``commit=false`` returns a preview without writing.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import uuid
 from typing import Any
@@ -29,6 +30,8 @@ from app.security import Principal, current_principal_or_local
 router = APIRouter(tags=["extract"])
 
 _MAX_TEXT = 40_000
+# Total wall-clock cap on the extraction ladder, under the 100 s edge limit.
+_EXTRACT_LLM_BUDGET_S = 90.0
 _ENTITY_TYPES = {
     "Person", "Organization", "Location", "Vessel", "Aircraft", "Event", "Document", "Other",
 }
@@ -92,15 +95,20 @@ _PROMPT = (
 async def _run_llm(text: str, token: str, uid: str) -> dict[str, Any]:
     bound = llm.bind_user(uid, token)
     try:
-        parsed, res = await llm.chat_json(
-            [
-                {"role": "system", "content": _PROMPT},
-                {"role": "user", "content": text},
-            ],
-            tier="fast",
-            max_tokens=2048,
-            label="doc-extract",
+        parsed, res = await asyncio.wait_for(
+            llm.chat_json(
+                [
+                    {"role": "system", "content": _PROMPT},
+                    {"role": "user", "content": text},
+                ],
+                tier="fast",
+                max_tokens=2048,
+                label="doc-extract",
+            ),
+            timeout=_EXTRACT_LLM_BUDGET_S,
         )
+    except TimeoutError:
+        parsed, res = None, None  # → the 502 below; never pin the worker past the edge
     finally:
         llm.reset_user(bound)
     if parsed is None:

--- a/apps/api/app/routes/intel.py
+++ b/apps/api/app/routes/intel.py
@@ -15,6 +15,7 @@ intel bundle for it in a single round trip.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import Any
@@ -619,6 +620,10 @@ _NARRATIVE_SYSTEM = llm.with_prose_style(
 _NARRATIVE_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _NARRATIVE_TTL_S = 600.0
 _NARRATIVE_CACHE_MAX = 512
+# Total wall-clock bound on the reason-tier ladder — kept under Cloudflare's 100 s
+# edge limit so a stalled backend can't pin a worker into a 524 (llm.py notes the
+# calling route must cap this; the backends run sequentially, ~180 s each).
+_NARRATIVE_LLM_BUDGET_S = 85.0
 
 
 def _narrative_cache_put(entity_id: str, expires: float, payload: dict[str, Any]) -> None:
@@ -662,15 +667,21 @@ async def intel_dossier_narrative(entity_id: str = Query(...)) -> dict[str, Any]
     facts["track_points"] = len(doss.get("track") or [])
     user = "Dossier:\n" + json.dumps(facts, default=str)[:6000]
 
-    parsed, res = await llm.chat_json(
-        [
-            {"role": "system", "content": _NARRATIVE_SYSTEM},
-            {"role": "user", "content": user},
-        ],
-        tier="reason",
-        temperature=0.2,
-        max_tokens=900,
-    )
+    try:
+        parsed, res = await asyncio.wait_for(
+            llm.chat_json(
+                [
+                    {"role": "system", "content": _NARRATIVE_SYSTEM},
+                    {"role": "user", "content": user},
+                ],
+                tier="reason",
+                temperature=0.2,
+                max_tokens=900,
+            ),
+            timeout=_NARRATIVE_LLM_BUDGET_S,
+        )
+    except TimeoutError:
+        return {"ok": False, "error": "model unavailable", "model": None}
     if not res.ok or not isinstance(parsed, dict):
         # DossierNarrativeCard renders a non-"model unavailable" error string
         # verbatim, so passing res.error through leaks raw internals (e.g.

--- a/apps/api/app/routes/intel.py
+++ b/apps/api/app/routes/intel.py
@@ -618,6 +618,20 @@ _NARRATIVE_SYSTEM = llm.with_prose_style(
 # keeps the reason-tier cost off repeat selections without staleness mattering.
 _NARRATIVE_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _NARRATIVE_TTL_S = 600.0
+_NARRATIVE_CACHE_MAX = 512
+
+
+def _narrative_cache_put(entity_id: str, expires: float, payload: dict[str, Any]) -> None:
+    # Bound the cache: a stream of distinct entity ids (any MMSI/ICAO24) would
+    # otherwise grow this plain dict without limit. Drop expired entries first,
+    # then the soonest-expiring until under the cap, before inserting.
+    if len(_NARRATIVE_CACHE) >= _NARRATIVE_CACHE_MAX:
+        now = time.time()
+        for k in [k for k, (exp, _) in _NARRATIVE_CACHE.items() if exp <= now]:
+            del _NARRATIVE_CACHE[k]
+        while len(_NARRATIVE_CACHE) >= _NARRATIVE_CACHE_MAX:
+            del _NARRATIVE_CACHE[min(_NARRATIVE_CACHE, key=lambda k: _NARRATIVE_CACHE[k][0])]
+    _NARRATIVE_CACHE[entity_id] = (expires, payload)
 
 
 @router.post("/api/intel/dossier/narrative")
@@ -658,13 +672,17 @@ async def intel_dossier_narrative(entity_id: str = Query(...)) -> dict[str, Any]
         max_tokens=900,
     )
     if not res.ok or not isinstance(parsed, dict):
+        # DossierNarrativeCard renders a non-"model unavailable" error string
+        # verbatim, so passing res.error through leaks raw internals (e.g.
+        # "llamacpp call failed: ConnectError [Errno 111]") into the dashboard —
+        # against the copy rule. Return the clean sentinel; the detail is logged.
         return {
             "ok": False,
-            "error": res.error or "model unavailable",
+            "error": "model unavailable",
             "model": res.model,
         }
     payload = {"ok": True, "model": res.model, "backend": res.backend, **parsed}
-    _NARRATIVE_CACHE[entity_id] = (now + _NARRATIVE_TTL_S, payload)
+    _narrative_cache_put(entity_id, now + _NARRATIVE_TTL_S, payload)
     return payload
 
 

--- a/apps/api/app/routes/maps.py
+++ b/apps/api/app/routes/maps.py
@@ -162,11 +162,15 @@ def _from_object(obj: Object) -> SavedMap | None:
         state = CopState.model_validate(props.get("state") or {})
     except Exception:  # noqa: BLE001 — a malformed blob loads as an empty picture
         state = CopState()
+    # updated_at is typed str | None; pydantic v2 raises on a non-string value, and
+    # props is a user-writable blob (POST /api/ontology/object is keyless), so a
+    # crafted int/dict here would 500 the whole list. Coerce anything non-str to None.
+    _upd = props.get("updated_at")
     return SavedMap(
         id=obj.id,
         name=str(props.get("name") or obj.id),
         state=state,
-        updated_at=props.get("updated_at"),
+        updated_at=_upd if isinstance(_upd, str) else None,
         created_at=obj.created_at,
     )
 

--- a/apps/api/app/routes/maritime.py
+++ b/apps/api/app/routes/maritime.py
@@ -121,8 +121,11 @@ async def digitraffic_snapshot() -> dict[str, Any]:
             coords = geom.get("coordinates") or []
             if len(coords) < 2:
                 continue
-            lon = float(coords[0])
-            lat = float(coords[1])
+            try:
+                lon = float(coords[0])
+                lat = float(coords[1])
+            except (TypeError, ValueError):
+                continue  # a null / non-numeric coordinate must not 500 the route
             p = f.get("properties") or {}
             # Digitraffic `sog` is already KNOTS; mask the AIS 102.3-kn "not
             # available" sentinel so it doesn't paint as a 102-knot ghost and

--- a/apps/api/app/routes/recon.py
+++ b/apps/api/app/routes/recon.py
@@ -670,29 +670,44 @@ def _job_dir(job_id: str) -> Path:
     return _JOBS_ROOT / job_id
 
 
+def _owned_job_dir(job_id: str, request: Request) -> Path:
+    """Job dir for a result download, enforcing ownership like get_job/job_events
+    do. While a job is tracked in _JOBS (the live multi-user case), a non-owner is
+    rejected so a leaked/guessed job id can't be used to pull another analyst's
+    reconstruction. A job evicted from memory has its on-disk dir removed too
+    (_drop_job), so "not in _JOBS" means a bad id or a restart-surviving artifact
+    whose owner record is gone — fall through to disk, the same best-effort the
+    metadata routes already degrade to post-restart."""
+    d = _job_dir(job_id)  # validates the hex token first
+    job = _JOBS.get(job_id)
+    if job is not None and job.get("owner", "local") != _owner_key(request):
+        raise HTTPException(404, "no such job")
+    return d
+
+
 @router.get("/jobs/{job_id}/result.ply")
-async def job_result(job_id: str) -> FileResponse:
-    ply = _job_dir(job_id) / "out" / "point_cloud.ply"
+async def job_result(job_id: str, request: Request) -> FileResponse:
+    ply = _owned_job_dir(job_id, request) / "out" / "point_cloud.ply"
     if not ply.exists():
         raise HTTPException(404, "result not ready")
     return FileResponse(str(ply), media_type="application/octet-stream", filename="point_cloud.ply")
 
 
 @router.get("/jobs/{job_id}/result.spz")
-async def job_result_spz(job_id: str) -> FileResponse:
+async def job_result_spz(job_id: str, request: Request) -> FileResponse:
     """Full-SH .spz (Niantic, ~10x smaller than .ply) — the streamed artifact for
     the in-app Spark viewer, so the WHOLE splat loads with no opacity cap."""
-    spz = _job_dir(job_id) / "out" / "point_cloud.spz"
+    spz = _owned_job_dir(job_id, request) / "out" / "point_cloud.spz"
     if not spz.exists():
         raise HTTPException(404, "spz not ready")
     return FileResponse(str(spz), media_type="application/octet-stream", filename="point_cloud.spz")
 
 
 @router.get("/jobs/{job_id}/camera.json")
-async def job_camera(job_id: str) -> dict[str, Any]:
+async def job_camera(job_id: str, request: Request) -> dict[str, Any]:
     """A good initial viewer camera (a real training viewpoint, in the splat's
     median-centered space) so the in-app viewer opens framed on the scene."""
-    cam = _initial_camera(_job_dir(job_id) / "sparse" / "0")
+    cam = _initial_camera(_owned_job_dir(job_id, request) / "sparse" / "0")
     if cam is None:
         raise HTTPException(404, "camera not ready")
     return cam

--- a/apps/api/app/routes/recon.py
+++ b/apps/api/app/routes/recon.py
@@ -314,16 +314,23 @@ def register_sat_job(
     job_id = uuid.uuid4().hex[:12]
     work = _JOBS_ROOT / job_id
     scene = work / "aoi"  # rpc_stereo reads *.tif + rpc_*.txt from ONE dir
-    scene.mkdir(parents=True, exist_ok=True)
-    for tif in tifs:
-        shutil.copy(tif, scene / tif.name)
-        rpc = aoi / ("rpc_" + tif.stem + ".txt")
-        if not rpc.exists():
-            hits = list(aoi.glob("*" + tif.stem + "*.txt"))
-            rpc = hits[0] if hits else None
-        if rpc is None:
-            raise HTTPException(502, f"missing RPC sidecar for {tif.name}")
-        shutil.copy(rpc, scene / ("rpc_" + tif.stem + ".txt"))
+    try:
+        scene.mkdir(parents=True, exist_ok=True)
+        for tif in tifs:
+            shutil.copy(tif, scene / tif.name)
+            rpc = aoi / ("rpc_" + tif.stem + ".txt")
+            if not rpc.exists():
+                hits = list(aoi.glob("*" + tif.stem + "*.txt"))
+                rpc = hits[0] if hits else None
+            if rpc is None:
+                raise HTTPException(502, f"missing RPC sidecar for {tif.name}")
+            shutil.copy(rpc, scene / ("rpc_" + tif.stem + ".txt"))
+    except Exception:
+        # The job isn't in _JOBS yet, so _evict_jobs can never reclaim this dir —
+        # remove the partial chips before surfacing the error, or every failed
+        # setup leaks disk that no TTL/LRU eviction touches.
+        shutil.rmtree(work, ignore_errors=True)
+        raise
     _JOBS[job_id] = _new_job_record(job_id, owner)
     asyncio.create_task(_pipeline_sat(job_id, gsd))
     return job_id, len(tifs)

--- a/apps/api/app/routes/seismic.py
+++ b/apps/api/app/routes/seismic.py
@@ -40,7 +40,12 @@ async def emsc(
             return {"type": "FeatureCollection", "features": []}
         if r.status_code != 200:
             raise HTTPException(502, f"emsc upstream {r.status_code}")
-        j = r.json()
+        try:
+            j = r.json()
+        except ValueError as e:
+            # A 200 + non-JSON body (maintenance/rate-limit HTML) must degrade to a
+            # 502, not raise out of the loader and 500 this keyless route.
+            raise HTTPException(502, "emsc non-JSON body") from e
         feats: list[dict[str, Any]] = []
         for ev in j.get("features", []):
             props = ev.get("properties", {})

--- a/apps/api/app/routes/situations.py
+++ b/apps/api/app/routes/situations.py
@@ -128,6 +128,17 @@ def _to_object(sit_id: str, body: SituationIn, ts: str) -> Object:
     )
 
 
+def _safe_float(v: Any, default: float) -> float:
+    """Coerce an unconstrained prop value to a positive float, defaulting on junk.
+    props is a user-writable blob (POST /api/ontology/object is keyless), so a
+    non-numeric radius_km must degrade to the default, not 500 the whole list."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return default
+    return f if (f == f and f > 0) else default  # reject NaN / non-positive
+
+
 def _from_object(obj: Object) -> Situation | None:
     """Adapt an ontology Object back to a Situation, or ``None`` if it isn't one."""
     props = obj.props or {}
@@ -141,16 +152,17 @@ def _from_object(obj: Object) -> Situation | None:
     _sv, _stt = props.get("severity"), props.get("status")
     _sev = _sv if _sv in ("critical", "high", "med", "low") else "med"
     _st = _stt if _stt in ("active", "monitoring", "resolved", "archived") else "active"
+    _upd = props.get("updated_at")  # str | None field; a non-string value raises
     return Situation(
         id=obj.id,
         name=str(props.get("name") or obj.id),
         severity=_sev,  # type: ignore[arg-type]
         status=_st,  # type: ignore[arg-type]
         centroid=centroid,
-        radius_km=float(props.get("radius_km") or 50.0),
+        radius_km=_safe_float(props.get("radius_km"), 50.0),
         summary=str(props.get("summary") or ""),
         report=str(props.get("report") or ""),
-        updated_at=props.get("updated_at"),
+        updated_at=_upd if isinstance(_upd, str) else None,
         created_at=obj.created_at,
     )
 

--- a/apps/api/app/routes/weather.py
+++ b/apps/api/app/routes/weather.py
@@ -18,15 +18,25 @@ from app.upstream import cache, get_client
 router = APIRouter(tags=["weather"])
 
 
+def _json_or_502(r: Any, name: str) -> Any:
+    """A 200 with a non-JSON body (a CDN maintenance / rate-limit HTML page) would
+    raise out of the cache.get_or_fetch loader and 500 this keyless route. Parse
+    defensively and degrade to a 502 like a bad status instead."""
+    if r.status_code != 200:
+        raise HTTPException(502, f"{name} upstream {r.status_code}")
+    try:
+        return r.json()
+    except ValueError as e:
+        raise HTTPException(502, f"{name} non-JSON body") from e
+
+
 @router.get("/api/weather/swpc/kp")
 async def swpc_kp() -> dict[str, Any]:
     async def load() -> dict[str, Any]:
         r = await get_client().get(
             "https://services.swpc.noaa.gov/json/planetary_k_index_1m.json"
         )
-        if r.status_code != 200:
-            raise HTTPException(502, f"swpc upstream {r.status_code}")
-        return {"series": r.json()}
+        return {"series": _json_or_502(r, "swpc")}
 
     return await cache.get_or_fetch("swpc:kp", 60.0, load)
 
@@ -59,9 +69,7 @@ async def openmeteo(
         r = await get_client().get(
             "https://api.open-meteo.com/v1/forecast", params=params
         )
-        if r.status_code != 200:
-            raise HTTPException(502, f"open-meteo upstream {r.status_code}")
-        return r.json()  # type: ignore[no-any-return]
+        return _json_or_502(r, "open-meteo")  # type: ignore[no-any-return]
 
     return await cache.get_or_fetch(key, 600.0, load)
 
@@ -95,9 +103,7 @@ async def metar(
             "https://aviationweather.gov/api/data/metar",
             params={"ids": ",".join(normalized), "format": "json"},
         )
-        if r.status_code != 200:
-            raise HTTPException(502, f"aviationweather upstream {r.status_code}")
-        return {"data": r.json()}
+        return {"data": _json_or_502(r, "aviationweather")}
 
     return await cache.get_or_fetch(key, 300.0, load)
 
@@ -110,9 +116,7 @@ async def nws_alerts() -> dict[str, Any]:
             "https://api.weather.gov/alerts/active",
             headers={"Accept": "application/geo+json"},
         )
-        if r.status_code != 200:
-            raise HTTPException(502, f"nws upstream {r.status_code}")
-        j = r.json()
+        j = _json_or_502(r, "nws")
         feats: list[dict[str, Any]] = []
         for f in j.get("features", []) or []:
             geom = f.get("geometry")

--- a/apps/api/app/workflows/control.py
+++ b/apps/api/app/workflows/control.py
@@ -124,6 +124,37 @@ def _block_private() -> bool:
     )
 
 
+# AWS exposes IMDSv2 over IPv6 at this fixed unique-local address. It is a
+# credential-leaking metadata endpoint, not a generic LAN host, so it is blocked
+# even though general ULA (fc00::/7, the IPv6 equivalent of a private 192.168.x
+# LAN) stays reachable under the BYO posture.
+_AWS_IMDS_V6 = ipaddress.ip_address("fd00:ec2::254")
+
+
+def _unwrap_mapped(addr: Any) -> Any:
+    """Unwrap an IPv4-mapped / 6to4 / Teredo IPv6 literal to its embedded IPv4
+    (older CPython does not delegate a mapped literal to the is_* flags), so
+    ``::ffff:169.254.169.254`` classifies as the IPv4 it really is."""
+    if isinstance(addr, ipaddress.IPv6Address):
+        embedded = addr.ipv4_mapped or addr.sixtofour
+        if embedded is None and addr.teredo is not None:
+            embedded = addr.teredo[1]
+        if embedded is not None:
+            return embedded
+    return addr
+
+
+def _is_metadata_ip(addr: Any) -> bool:
+    """True for a cloud-metadata / link-local address in EITHER family: IPv4
+    169.254.0.0/16 (``is_link_local`` — covers 169.254.169.254 and the ECS
+    169.254.170.2 endpoint), IPv6 link-local fe80::/10, and the AWS IPv6 IMDS
+    host fd00:ec2::254. IPv4-mapped IPv6 forms are unwrapped first so
+    ``[::ffff:169.254.169.254]`` is caught. General private LAN / loopback stay
+    open (the BYO posture) — only the credential-leaking surface is blocked."""
+    addr = _unwrap_mapped(addr)
+    return bool(addr.is_link_local or addr == _AWS_IMDS_V6)
+
+
 def _ip_is_private(ip: str) -> bool:
     """True for any non-public address. IPv4-in-IPv6 encodings are unwrapped
     before classifying (older CPython does not delegate a mapped literal to the
@@ -132,12 +163,7 @@ def _ip_is_private(ip: str) -> bool:
         addr: Any = ipaddress.ip_address(ip)
     except ValueError:
         return True  # unparseable → treat as unsafe
-    if isinstance(addr, ipaddress.IPv6Address):
-        embedded = addr.ipv4_mapped or addr.sixtofour
-        if embedded is None and addr.teredo is not None:
-            embedded = addr.teredo[1]
-        if embedded is not None:
-            addr = embedded
+    addr = _unwrap_mapped(addr)
     return (
         addr.is_private
         or addr.is_loopback
@@ -163,12 +189,13 @@ def _resolves_private(host: str) -> bool:
 
 
 def _is_link_local(host: str) -> bool:
-    """True if *host* is, or resolves to, an IPv4 link-local address
-    (169.254.0.0/16 — the cloud-metadata range, incl. 169.254.169.254). Kept
-    deliberately narrow: this is the one range a benign single-operator tool
-    never legitimately targets, and the one that leaks instance credentials.
-    Localhost/private LAN are intentionally NOT blocked (the operator's control
-    server is routinely on 127.0.0.1 or the LAN — see the module docstring)."""
+    """True if *host* is, or resolves to, a cloud-metadata / link-local address
+    in either family (see ``_is_metadata_ip``: IPv4 169.254.0.0/16, IPv6
+    fe80::/10, and the AWS IPv6 IMDS host fd00:ec2::254). Kept deliberately
+    narrow: these are the ranges a benign single-operator tool never legitimately
+    targets, and the ones that leak instance credentials. Localhost/private LAN
+    are intentionally NOT blocked (the operator's control server is routinely on
+    127.0.0.1 or the LAN — see the module docstring)."""
     candidates: list[str] = []
     try:
         ipaddress.ip_address(host)
@@ -183,7 +210,7 @@ def _is_link_local(host: str) -> bool:
             ip = ipaddress.ip_address(addr)
         except ValueError:
             continue
-        if isinstance(ip, ipaddress.IPv4Address) and ip in ipaddress.ip_network("169.254.0.0/16"):
+        if _is_metadata_ip(ip):
             return True
     return False
 
@@ -282,7 +309,7 @@ def _pin_http_url(url: str, headers: dict[str, str]) -> tuple[str, dict[str, str
             ip = ipaddress.ip_address(addr)
         except ValueError:
             continue
-        if isinstance(ip, ipaddress.IPv4Address) and ip in ipaddress.ip_network("169.254.0.0/16"):
+        if _is_metadata_ip(ip):
             return (
                 url,
                 headers,

--- a/apps/api/tests/test_ai_routes_e2e.py
+++ b/apps/api/tests/test_ai_routes_e2e.py
@@ -116,6 +116,29 @@ def test_selection_brief_access_path(client: TestClient, monkeypatch: pytest.Mon
     assert "ENRICHMENT" in seen["system"]
 
 
+def test_selection_brief_bounds_a_stalled_model(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A stalled backend must not pin the worker: the route wraps the LLM call in
+    # asyncio.wait_for and degrades to a 502, not a 524-after-the-client-left.
+    import asyncio
+
+    from app.routes import ai_selection
+
+    monkeypatch.setattr(ai_selection, "_SELECTION_LLM_BUDGET_S", 0.05)
+
+    async def _hang(*_a, **_k):  # noqa: ANN002, ANN003
+        await asyncio.sleep(5)  # longer than the budget → wait_for fires
+        return llm.LlmResult(text="x", model="m", backend="stub")
+
+    monkeypatch.setattr(llm, "chat", _hang)
+    r = client.post(
+        "/api/ai/selection/brief",
+        json={"kind": "aircraft", "id": "AC-hang", "props": {"callsign": "T"}},
+    )
+    assert r.status_code == 502
+
+
 # ── AI alerts: watch-officer briefs ──────────────────────────────────────────
 
 def test_watch_officer_briefs_access_path(client: TestClient) -> None:

--- a/apps/api/tests/test_ais_normalize.py
+++ b/apps/api/tests/test_ais_normalize.py
@@ -1,0 +1,40 @@
+"""AISStream message normalization (app.routes.ais._normalize).
+
+Guards the trust boundary: a malformed MMSI must skip the single message, not
+raise out of the websocket async-for and tear down the shared upstream socket
+for every connected client.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.routes import ais
+
+
+def _msg(mmsi: object) -> str:
+    return json.dumps(
+        {
+            "MessageType": "PositionReport",
+            "MetaData": {
+                "MMSI": mmsi,
+                "latitude": 50.0,
+                "longitude": 10.0,
+                "ShipName": "TESTBOAT",
+            },
+            "Message": {"PositionReport": {"Sog": 10, "Cog": 90, "TrueHeading": 88}},
+        }
+    )
+
+
+def test_normalize_valid_mmsi_yields_vessel() -> None:
+    out = ais._normalize(_msg(123456789))
+    assert out is not None
+    assert json.loads(out)["id"] == "vessel:123456789"
+
+
+def test_normalize_malformed_mmsi_skips_message_not_raises() -> None:
+    # Non-numeric MMSI: skip this one message (return None), never raise.
+    assert ais._normalize(_msg("NOT-A-NUMBER")) is None
+    # A None MMSI is already dropped by the presence check.
+    assert ais._normalize(_msg(None)) is None

--- a/apps/api/tests/test_collab.py
+++ b/apps/api/tests/test_collab.py
@@ -48,6 +48,21 @@ async def test_join_gate_new_doc_allowed(monkeypatch) -> None:
     assert await collab_mod._collab_join_allowed(_FakeWS(), "doc") is True  # type: ignore[arg-type]
 
 
+async def test_join_gate_fails_closed_when_acl_store_unavailable(monkeypatch) -> None:
+    # A store hiccup (RPC down / non-200 / non-JSON) must DENY the join — an
+    # under-cleared user must not slip into a classified doc during an outage.
+    # Previously _doc_acl returned None for a store error, indistinguishable from
+    # a brand-new doc, so the gate failed OPEN.
+    monkeypatch.setattr(collab_mod, "_auth_enabled", lambda s: True)
+    monkeypatch.setattr(collab_mod, "principal_for_token", _async(Principal("u", "tok", clearance=0)))
+
+    async def _raise(*a: object, **k: object) -> object:
+        raise collab_mod._AclUnavailable()
+
+    monkeypatch.setattr(collab_mod, "_doc_acl", _raise)
+    assert await collab_mod._collab_join_allowed(_FakeWS(), "doc") is False  # type: ignore[arg-type]
+
+
 async def test_join_gate_denies_no_principal(monkeypatch) -> None:
     monkeypatch.setattr(collab_mod, "_auth_enabled", lambda s: True)
     monkeypatch.setattr(collab_mod, "principal_for_token", _async(None))

--- a/apps/api/tests/test_correlate.py
+++ b/apps/api/tests/test_correlate.py
@@ -255,3 +255,37 @@ def test_store_high_cardinality_add_is_not_quadratic() -> None:
     elapsed = time.time() - t0
     assert len(store._latest) >= 50_000  # we really are past the old threshold
     assert elapsed < 5.0, f"60k distinct adds took {elapsed:.1f}s — O(n)-per-add regression"
+
+
+def test_mil_loop_survives_non_json_body(monkeypatch) -> None:
+    # airplanes.live throttles with HTTP 200 + text/plain (CLAUDE.md). r.json()
+    # then raises ValueError, which used to escape the httpx-only except and kill
+    # the (unrespawned) ingest loop — the platform goes blind to mil/emergency
+    # squawks until restart. The loop must catch it and keep polling.
+    from app.correlate import runner
+
+    async def run() -> None:
+        class _Resp:
+            status_code = 200
+
+            def json(self) -> object:
+                raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+        class _Client:
+            async def get(self, *_a: object, **_k: object) -> object:
+                return _Resp()
+
+        monkeypatch.setattr(runner, "get_client", lambda: _Client())
+
+        stop = asyncio.Event()
+        real_sleep = asyncio.sleep
+
+        async def _fake_sleep(_s: float) -> None:
+            stop.set()  # end the loop after its first error-surviving cycle
+            await real_sleep(0)
+
+        monkeypatch.setattr(runner.asyncio, "sleep", _fake_sleep)
+        # Must return cleanly; an uncaught ValueError would propagate and fail here.
+        await runner._mil_loop(stop)
+
+    asyncio.run(run())

--- a/apps/api/tests/test_detectors.py
+++ b/apps/api/tests/test_detectors.py
@@ -68,3 +68,15 @@ def test_haversine_known_distance():
     # 1 degree of latitude ≈ 60 nm
     nm = detectors.haversine_nm(0.0, 0.0, 0.0, 1.0)
     assert 59.0 < nm < 61.0
+
+
+def test_haversine_nm_handles_antipodal_without_domain_error() -> None:
+    import math
+
+    from app.intel.detectors import haversine_nm
+
+    # Antipodal points sit at the asin(1.0) boundary; float error can push the
+    # argument just past 1.0, which the min(1.0, ...) clamp absorbs. Must return a
+    # finite ~half-circumference distance (~10,800 nm), never a domain ValueError.
+    d = haversine_nm(0.0, 0.0, 180.0, 0.0)
+    assert math.isfinite(d) and 10_000 < d < 11_000

--- a/apps/api/tests/test_foundry.py
+++ b/apps/api/tests/test_foundry.py
@@ -352,6 +352,51 @@ def test_binding_direct_registry_roundtrip() -> None:
     asyncio.run(run())
 
 
+def test_binding_resolve_preserves_foreign_object_props() -> None:
+    """Resolving onto a pre-existing object MERGES the binding's mapped props
+    instead of wholesale-replacing them. The upsert-wholesale contract makes the
+    binding authoritative only for foundry-MINTED objects; a sparse prop_map
+    synced onto a vessel another source minted must not wipe its name/flag/key."""
+    import asyncio
+
+    from app.foundry import binding as binding_mod
+    from app.foundry.store import FoundryStore
+    from app.intel.ontology import Object
+
+    async def run() -> None:
+        ctx = UserCtx("local", "")
+        reg = get_registry(ctx)
+        await reg.upsert(
+            Object(
+                id="vessel:w2res001",
+                kind="vessel",
+                props={"mmsi": "999000111", "name": "OLD_NAME", "flag": "NO"},
+            ),
+            source="ais",
+        )
+        store = FoundryStore()
+        ds = await store.create_dataset("resolve_merge_ds", "")
+        await store.add_version(
+            ds["id"],
+            [{"mmsi": "999000111", "cargo": "OIL"}],
+            [{"name": "mmsi", "type": "str"}, {"name": "cargo", "type": "str"}],
+            source="upload",
+        )
+        # prop_map maps only cargo (NOT the key column) — the sparse-blob case.
+        b = await store.create_binding(ds["id"], "vessel", "mmsi", {"cargo": "cargo"})
+        result = await binding_mod.sync_binding(store, b, ctx, resolve=True)
+        assert result["updated"] == 1  # resolved onto the pre-existing vessel
+
+        obj = await reg.get("vessel:w2res001")
+        assert obj is not None
+        assert obj.props["cargo"] == "OIL"  # binding's prop added
+        assert obj.props["name"] == "OLD_NAME"  # foreign props survived
+        assert obj.props["flag"] == "NO"
+        assert obj.props["mmsi"] == "999000111"  # the natural key survived
+
+    asyncio.run(run())
+
+
 def test_bindings_crud(client: TestClient) -> None:
     ds = client.post("/api/foundry/datasets", json={"name": "bind_crud_ds"}).json()
     r = client.post(

--- a/apps/api/tests/test_foundry_sql.py
+++ b/apps/api/tests/test_foundry_sql.py
@@ -108,3 +108,33 @@ def test_sql_max_rows_clamped(client: TestClient) -> None:
     )
     assert r.status_code == 200, r.text
     assert r.json()["ok"] is True
+
+
+def test_run_sql_tolerates_quoted_column_and_oversize_int() -> None:
+    # A column literally named a"b (valid JSON key) and an int > 2^63 (a 20-digit
+    # id) previously escaped run_sql as an unwrapped OperationalError / OverflowError
+    # and 500'd the route. Both must now load cleanly.
+    from app.foundry.sqlrun import run_sql
+
+    rows = [{'a"b': 1, "big": 10**25}]
+    out, _cols = run_sql("SELECT * FROM t", {"t": rows})
+    assert len(out) == 1
+    assert out[0]['a"b'] == 1
+    assert out[0]["big"] == str(10**25)  # oversize int stored as text, no overflow
+
+
+def test_run_sql_wraps_load_failure_as_sqlerror(monkeypatch) -> None:
+    # Any residual load-time sqlite failure must surface as SqlError (→ clean 4xx),
+    # never escape run_sql unwrapped (→ 500).
+    import sqlite3
+
+    import pytest
+
+    from app.foundry import sqlrun
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise sqlite3.OperationalError("boom")
+
+    monkeypatch.setattr(sqlrun, "_load_table", _boom)
+    with pytest.raises(sqlrun.SqlError):
+        sqlrun.run_sql("SELECT 1", {"t": [{"x": 1}]})

--- a/apps/api/tests/test_foundry_transforms.py
+++ b/apps/api/tests/test_foundry_transforms.py
@@ -320,6 +320,47 @@ def test_step_join_multi_match_fans_out_rows() -> None:
     assert out_left_unmatched == [{"port": None, "id": 2, "country": "US"}]
 
 
+def test_step_join_fanout_is_capped(monkeypatch) -> None:
+    # A low-cardinality key fans out len(left) * len(matches) rows, and the
+    # dataset row cap is only checked AFTER run_steps — so the join itself must
+    # bound the product or it OOMs the API. Shrink the cap to make the test cheap.
+    from app.foundry import transforms as tf
+
+    monkeypatch.setattr(tf, "MAX_ROWS_PER_DATASET", 10)
+    right = [{"k": "x", "v": i} for i in range(8)]  # 8 matches for key "x"
+    left = [{"id": i, "k": "x"} for i in range(5)]  # 5 * 8 = 40 rows > 10
+    with pytest.raises(FoundryError) as exc:
+        run_steps(
+            [{"type": "join", "right": "r", "on": "k", "how": "left"}], left, lambda _: right
+        )
+    assert exc.value.status_code == 422
+    assert "fan-out" in exc.value.detail
+
+
+def test_step_aggregate_and_join_tolerate_nested_key_value() -> None:
+    # A group_by / join column carrying a JSON list is unhashable as a dict key;
+    # it must be canonicalized, not raise TypeError and abort the whole build.
+    rows = [
+        {"tags": ["a", "b"], "speed": 10},
+        {"tags": ["a", "b"], "speed": 20},
+        {"tags": ["c"], "speed": 5},
+    ]
+    out = run_steps(
+        [{"type": "aggregate", "group_by": ["tags"], "aggs": {"n": "count", "total": "sum:speed"}}],
+        rows,
+        _provider_empty,
+    )
+    assert len(out) == 2  # two distinct tag-lists → two groups, no crash
+    assert sorted(r["n"] for r in out) == [1, 2]
+    # The same nested value on both sides of a join still matches.
+    joined = run_steps(
+        [{"type": "join", "right": "r", "on": "tags", "how": "inner"}],
+        [{"id": 1, "tags": ["a", "b"]}],
+        lambda _: [{"tags": ["a", "b"], "region": "EU"}],
+    )
+    assert len(joined) == 1 and joined[0]["region"] == "EU"
+
+
 def test_step_union() -> None:
     def provider(dataset_id: str) -> list[dict]:
         return [{"id": 99, "name": "extra"}]

--- a/apps/api/tests/test_history.py
+++ b/apps/api/tests/test_history.py
@@ -288,6 +288,50 @@ async def test_size_cap_drops_oldest_keeps_newest(tmp_path: pytest.TempPathFacto
 
 
 @pytest.mark.asyncio
+async def test_size_cap_ignores_reclaimable_free_pages(tmp_path: pytest.TempPathFactory) -> None:
+    """enforce_size_cap sizes off in-use bytes, not the un-vacuumed file. A prune
+    frees pages but (auto_vacuum is off) leaves the file at its high-water mark
+    until the caller VACUUMs. Sizing off the raw file would drop an extra oldest
+    slice the VACUUM was about to reclaim for free — chronically shortening the
+    replay window. Those reclaimable pages must NOT trigger a delete."""
+    db = str(tmp_path / "freelist.db")
+    _reset_module(db)
+    now = time.time()
+    # 5000 rows spaced 60 s apart span ~83 h — plenty of pages to leave a freelist.
+    for i in range(5000):
+        H._buffer.append(
+            ("aircraft", f"aircraft:f{i}", now - (5000 - i) * 60, float(i % 90), 50.0, 0.0, "{}")
+        )
+    rows, H._buffer = H._buffer, []
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, H._flush_sync, rows)
+
+    # Prune all but the newest ~60 rows: frees pages without shrinking the file.
+    deleted = await loop.run_in_executor(None, H.prune, 1)
+    assert deleted > 4000, "prune should have removed most rows"
+
+    con = H._connect()
+    try:
+        page_size = con.execute("PRAGMA page_size").fetchone()[0]
+        page_count = con.execute("PRAGMA page_count").fetchone()[0]
+        freelist = con.execute("PRAGMA freelist_count").fetchone()[0]
+    finally:
+        con.close()
+    in_use = (page_count - freelist) * page_size
+    file_size = os.path.getsize(db)
+    assert freelist > 0, "prune must leave reclaimable free pages (auto_vacuum is off)"
+    assert file_size > in_use, "the un-vacuumed file must exceed in-use bytes"
+
+    # A cap strictly between in-use and the raw file size. The fixed code sees
+    # in_use <= cap and drops nothing; the old getsize code saw file > cap and
+    # would have deleted a chunk of the surviving history.
+    cap = (in_use + file_size) // 2
+    assert H.enforce_size_cap(cap) == 0, "must not delete data that fits once free pages reclaim"
+    # The cap itself still works: below in-use, it drops the oldest rows.
+    assert H.enforce_size_cap(in_use // 2) > 0, "a cap below in-use must still drop rows"
+
+
+@pytest.mark.asyncio
 async def test_timeseries_distinct_counts_and_buckets(tmp_path: pytest.TempPathFactory) -> None:
     """count_timeseries buckets by time and counts DISTINCT ids per kind — the
     metrics-over-time (§8) source. A duplicate id in the same bucket collapses to 1."""

--- a/apps/api/tests/test_history.py
+++ b/apps/api/tests/test_history.py
@@ -318,7 +318,7 @@ async def test_size_cap_ignores_reclaimable_free_pages(tmp_path: pytest.TempPath
     finally:
         con.close()
     in_use = (page_count - freelist) * page_size
-    file_size = os.path.getsize(db)
+    file_size = await loop.run_in_executor(None, os.path.getsize, db)
     assert freelist > 0, "prune must leave reclaimable free pages (auto_vacuum is off)"
     assert file_size > in_use, "the un-vacuumed file must exceed in-use bytes"
 

--- a/apps/api/tests/test_intel_route.py
+++ b/apps/api/tests/test_intel_route.py
@@ -347,3 +347,28 @@ def test_narrative_cache_is_bounded() -> None:
         assert len(intel._NARRATIVE_CACHE) <= intel._NARRATIVE_CACHE_MAX
     finally:
         intel._NARRATIVE_CACHE.clear()
+
+
+def test_dossier_narrative_bounds_a_stalled_model(monkeypatch) -> None:
+    # A stalled reason-tier backend must not pin the worker past the edge budget:
+    # the route wraps the LLM call in asyncio.wait_for and degrades to "model
+    # unavailable" on timeout. Shrink the budget so the test is fast.
+    import asyncio
+
+    from app.routes import intel
+
+    monkeypatch.setattr(intel, "_NARRATIVE_LLM_BUDGET_S", 0.05)
+
+    async def _hang(*_a: object, **_k: object) -> object:
+        await asyncio.sleep(5)  # longer than the budget → wait_for fires
+        return {}, None
+
+    async def _doss(_bare: str) -> dict:
+        return {"track": [], "id": "x"}
+
+    monkeypatch.setattr(intel.llm, "chat_json", _hang)
+    monkeypatch.setattr(intel.dossier, "vessel_dossier", _doss)
+    intel._NARRATIVE_CACHE.clear()
+
+    out = asyncio.run(intel.intel_dossier_narrative(entity_id="vessel:1"))
+    assert out["ok"] is False and out["error"] == "model unavailable"

--- a/apps/api/tests/test_intel_route.py
+++ b/apps/api/tests/test_intel_route.py
@@ -332,3 +332,18 @@ def test_query_limit_capped(client: TestClient) -> None:
     # limit above the hard cap (200) must 422 at the route boundary.
     with _patch_snapshot():
         assert client.get("/api/intel/aircraft", params={"limit": 5000}).status_code == 422
+
+
+def test_narrative_cache_is_bounded() -> None:
+    # A stream of distinct entity ids must not grow the dossier-narrative cache
+    # without limit (it had no eviction). _narrative_cache_put caps it.
+    from app.routes import intel
+
+    intel._NARRATIVE_CACHE.clear()
+    try:
+        far_future = 10.0**12  # nothing expires during the test
+        for i in range(intel._NARRATIVE_CACHE_MAX + 50):
+            intel._narrative_cache_put(f"vessel:{i}", far_future, {"ok": True})
+        assert len(intel._NARRATIVE_CACHE) <= intel._NARRATIVE_CACHE_MAX
+    finally:
+        intel._NARRATIVE_CACHE.clear()

--- a/apps/api/tests/test_llamacpp_sidecar.py
+++ b/apps/api/tests/test_llamacpp_sidecar.py
@@ -337,3 +337,21 @@ async def test_ensure_hot_unknown_key_no_op(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(sc.httpx, "AsyncClient", fail_client)
     await sc.ensure_hot("0" * 12)  # not installed — must not raise or call out
+
+
+def test_load_hot_models_survives_a_failed_warm(monkeypatch) -> None:
+    # The hot-model warm now runs in the background at boot, so one slow/failed
+    # model must not abort the rest or leave an unretrieved exception on the task.
+    import asyncio
+
+    calls: list[str] = []
+
+    async def _ensure(key: str) -> None:
+        calls.append(key)
+        if key == "bad":
+            raise RuntimeError("load timed out")
+
+    monkeypatch.setattr(sc.manager, "get_hot", lambda: ["good1", "bad", "good2"])
+    monkeypatch.setattr(sc, "ensure_hot", _ensure)
+    asyncio.run(sc._load_hot_models())  # must NOT raise
+    assert calls == ["good1", "bad", "good2"]  # all attempted despite the middle failure

--- a/apps/api/tests/test_localllm_manager.py
+++ b/apps/api/tests/test_localllm_manager.py
@@ -676,3 +676,19 @@ def test_models_root_created_with_restrictive_perms() -> None:
     assert root.is_dir()
     mode = oct(os.stat(root).st_mode & 0o777)
     assert mode == oct(0o700)
+
+
+def test_run_job_errors_the_job_on_mkdir_failure(monkeypatch, tmp_path) -> None:
+    # mkdir ran before the try, so a failure killed the fire-and-forget task and
+    # left the job stuck in "queued". It must set status=error instead.
+    import asyncio
+
+    from app.localllm import manager
+
+    a_file = tmp_path / "afile"
+    a_file.write_text("x")  # a FILE — so (a_file / key).mkdir raises NotADirectoryError
+    monkeypatch.setattr(manager, "models_root", lambda: a_file)
+    job = manager.Job(job_id="j1", repo_id="unsloth/x", quant="Q4", key="k1")
+    asyncio.run(manager._run_job(job, {}))
+    assert job.status == "error"
+    assert "model directory" in (job.error or "")

--- a/apps/api/tests/test_maps.py
+++ b/apps/api/tests/test_maps.py
@@ -94,6 +94,16 @@ def test_from_object_tolerates_malformed_state() -> None:
     assert sm.state.layers == [] and sm.state.viewport is None
 
 
+def test_from_object_tolerates_non_string_updated_at() -> None:
+    from app.intel.ontology import Object
+
+    # updated_at is str | None; a crafted int (props is a keyless user blob) would
+    # raise a pydantic ValidationError and 500 the whole /api/maps list. Coerce to None.
+    obj = Object(id="map:x", props={"kind": "map", "name": "m", "state": {}, "updated_at": 123})
+    sm = _from_object(obj)
+    assert sm is not None and sm.updated_at is None
+
+
 # ── keyless-local route contract ─────────────────────────────────────────────────
 
 

--- a/apps/api/tests/test_news_ogimage.py
+++ b/apps/api/tests/test_news_ogimage.py
@@ -32,3 +32,57 @@ def test_is_public_url_rejects_non_http_scheme():
 def test_fetch_og_image_blocks_internal_without_fetching():
     # A loopback target must short-circuit to "" before any GET is attempted.
     assert asyncio.run(fetch_og_image("http://127.0.0.1:8000/admin")) == ""
+
+
+# ── DNS-rebinding TOCTOU: pin the http fetch to the validated IP ─────────────
+
+
+def _fake_addrinfo(ip):
+    async def _f(host, port):
+        return [(2, 1, 6, "", (ip, port or 80))]
+
+    return _f
+
+
+def test_resolve_public_returns_pin_ip_for_public_host(monkeypatch):
+    from app.news import images
+
+    monkeypatch.setattr(images, "_getaddrinfo", _fake_addrinfo("93.184.216.34"))
+    ok, pin = asyncio.run(images._resolve_public("http://example.com/a"))
+    assert ok is True and pin == "93.184.216.34"
+
+
+def test_resolve_public_rejects_dns_rebind_to_metadata(monkeypatch):
+    from app.news import images
+
+    # A host that resolves to the metadata range is rejected — the SSRF gate.
+    monkeypatch.setattr(images, "_getaddrinfo", _fake_addrinfo("169.254.169.254"))
+    ok, pin = asyncio.run(images._resolve_public("http://rebind.evil/a"))
+    assert ok is False and pin is None
+
+
+def test_fetch_og_image_pins_http_to_validated_ip(monkeypatch):
+    from app.news import images
+
+    monkeypatch.setattr(images, "_getaddrinfo", _fake_addrinfo("93.184.216.34"))
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+        headers: dict = {}
+        text = '<meta property="og:image" content="https://i.ex/x.jpg">'
+
+    class _Client:
+        async def get(self, url, **kw):
+            captured["url"] = url
+            captured["host"] = kw.get("headers", {}).get("Host")
+            return _Resp()
+
+    monkeypatch.setattr(images, "get_client", lambda: _Client())
+    images._cache.clear()
+    img = asyncio.run(images.fetch_og_image("http://news.example/story"))
+    assert img == "https://i.ex/x.jpg"
+    # The GET went to the validated IP, not a re-resolved hostname, and carried
+    # the original Host so vhosts still work — the DNS-rebinding gap is closed.
+    assert "93.184.216.34" in captured["url"]
+    assert captured["host"] == "news.example"

--- a/apps/api/tests/test_ontology_local.py
+++ b/apps/api/tests/test_ontology_local.py
@@ -295,6 +295,21 @@ def test_promote_empty_props_still_mints_existence(client: TestClient) -> None:
     assert client.get("/api/ontology/object/incident:i1").status_code == 200
 
 
+def test_removal_tombstone_recorded_after_null_value() -> None:
+    # A prop written as JSON null, then removed, must record BOTH events. The
+    # removal tombstone (value=None → "null") previously deduped away against the
+    # prior null value (same encoded value + source), leaving a provenance gap.
+    async def run() -> None:
+        reg = _reg()
+        await reg.upsert(Object(id="vessel:tomb1", props={"note": None}))
+        await reg.upsert(Object(id="vessel:tomb1", props={}))  # note removed from the blob
+        rows = await reg.get_assertions("vessel:tomb1", prop="note")
+        assert len(rows) == 2
+        assert any(a.derivation and a.derivation.get("op") == "remove" for a in rows)
+
+    asyncio.run(run())
+
+
 def test_size_cap_enforcement_swallows_db_error() -> None:
     # _maybe_enforce_size_cap runs AFTER the caller's write has committed, so a
     # lock contention during its VACUUM (a concurrent writer holds the DB) must

--- a/apps/api/tests/test_ontology_local.py
+++ b/apps/api/tests/test_ontology_local.py
@@ -293,3 +293,26 @@ def test_promote_empty_props_still_mints_existence(client: TestClient) -> None:
     )
     assert r.status_code == 200
     assert client.get("/api/ontology/object/incident:i1").status_code == 200
+
+
+def test_size_cap_enforcement_swallows_db_error() -> None:
+    # _maybe_enforce_size_cap runs AFTER the caller's write has committed, so a
+    # lock contention during its VACUUM (a concurrent writer holds the DB) must
+    # not propagate and 500 an already-persisted write. Best-effort: swallow.
+    import sqlite3
+
+    from app.intel import ontology_local as OL
+    from app.keys import UserCtx
+
+    s = _S.model_copy(update={"ontology_db_max_bytes": 1})  # any real file exceeds 1 byte
+    reg = OL.SqliteRegistry(UserCtx("capbusy", ""), s)
+    asyncio.run(reg.upsert(Object(id="vessel:cap1", props={"a": 1})))  # populate the DB
+
+    OL._next_size_check = 0.0  # force the size check to run this call
+    OL._writes_since_check = 0
+
+    class _RaisingCon:
+        def execute(self, *_a: object, **_k: object) -> object:
+            raise sqlite3.OperationalError("database is locked")
+
+    reg._maybe_enforce_size_cap(_RaisingCon())  # type: ignore[arg-type]  # must NOT raise

--- a/apps/api/tests/test_recon.py
+++ b/apps/api/tests/test_recon.py
@@ -61,3 +61,24 @@ def test_result_download_denies_non_owner(monkeypatch) -> None:
 def test_create_requires_files(client: TestClient) -> None:
     # File(...) is required → FastAPI 422 when absent.
     assert client.post("/api/recon/jobs").status_code == 422
+
+
+def test_register_sat_job_cleans_up_dir_on_missing_rpc(monkeypatch, tmp_path) -> None:
+    # A .tif without its rpc_*.txt sidecar raises 502 AFTER the job dir + chips are
+    # created but BEFORE the job is registered in _JOBS, so _evict_jobs could never
+    # reclaim it. The setup must clean up its own partial dir instead of leaking.
+    import pytest
+    from fastapi import HTTPException
+
+    sat_root = tmp_path / "sat"
+    jobs_root = tmp_path / "jobs"
+    (sat_root / "ds1").mkdir(parents=True)
+    (sat_root / "ds1" / "a.tif").write_bytes(b"II*\x00")  # a .tif, no rpc_a.txt beside it
+    jobs_root.mkdir()
+    monkeypatch.setattr(recon, "_SAT_ROOT", sat_root)
+    monkeypatch.setattr(recon, "_JOBS_ROOT", jobs_root)
+
+    with pytest.raises(HTTPException) as exc:
+        recon.register_sat_job("ds1")
+    assert exc.value.status_code == 502
+    assert list(jobs_root.iterdir()) == []  # no orphaned job dir left behind

--- a/apps/api/tests/test_recon.py
+++ b/apps/api/tests/test_recon.py
@@ -35,6 +35,29 @@ def test_unknown_job_404(client: TestClient) -> None:
     assert client.get("/api/recon/jobs/deadbeef/events").status_code == 404
 
 
+def test_result_download_denies_non_owner(monkeypatch) -> None:
+    # result.ply/spz/camera.json must be owner-scoped like get_job (issue #15), so
+    # a leaked/guessed job id can't pull another analyst's reconstruction while the
+    # job is still tracked in _JOBS.
+    import pytest
+    from fastapi import HTTPException
+
+    recon._JOBS["abcdef12"] = {"id": "abcdef12", "owner": "alice", "status": "done", "created": 0.0}
+    try:
+        monkeypatch.setattr(recon, "_owner_key", lambda req: "bob")
+        with pytest.raises(HTTPException) as e:
+            recon._owned_job_dir("abcdef12", None)  # type: ignore[arg-type]
+        assert e.value.status_code == 404
+        # The owner still gets the dir.
+        monkeypatch.setattr(recon, "_owner_key", lambda req: "alice")
+        assert str(recon._owned_job_dir("abcdef12", None)).endswith("abcdef12")  # type: ignore[arg-type]
+        # A job not tracked (evicted / restart-surviving artifact, no owner record
+        # left) falls through to disk — the metadata routes degrade the same way.
+        assert str(recon._owned_job_dir("beefcafe", None)).endswith("beefcafe")  # type: ignore[arg-type]
+    finally:
+        recon._JOBS.pop("abcdef12", None)
+
+
 def test_create_requires_files(client: TestClient) -> None:
     # File(...) is required → FastAPI 422 when absent.
     assert client.post("/api/recon/jobs").status_code == 422

--- a/apps/api/tests/test_security_hardening.py
+++ b/apps/api/tests/test_security_hardening.py
@@ -44,6 +44,11 @@ def test_compute_endpoint_fails_closed_when_keyless_and_not_opted_in(monkeypatch
         r = c.post("/api/recon/jobs")
         assert r.status_code == 503
         assert "ALLOW_UNAUTHENTICATED" in r.json()["detail"]
+        # /api/imagery/splat launches a GPU 3DGS job just like /api/recon, so it
+        # must fail closed too (it was missing from _COMPUTE_PREFIXES).
+        rs = c.post("/api/imagery/splat?lat=0&lon=0&date=2026-01-01")
+        assert rs.status_code == 503
+        assert "ALLOW_UNAUTHENTICATED" in rs.json()["detail"]
         # The middleware is SELECTIVE: a public/keyless route stays open.
         assert c.get("/api/health").status_code == 200
 

--- a/apps/api/tests/test_situations.py
+++ b/apps/api/tests/test_situations.py
@@ -57,6 +57,21 @@ def test_from_object_skips_non_situation_and_clamps_bad_enum() -> None:
     assert sit is not None and sit.severity == "med" and sit.status == "active"
 
 
+def test_from_object_tolerates_junk_radius_and_updated_at() -> None:
+    # props is a keyless user-writable blob (POST /api/ontology/object); a
+    # non-numeric radius_km or a non-string updated_at must degrade, not raise
+    # out of the list loop and 500 the whole /api/situations response.
+    sit = _from_object(
+        Object(
+            id="situation:x",
+            props={"kind": "situation", "radius_km": "abc", "updated_at": 123},
+        )
+    )
+    assert sit is not None
+    assert sit.radius_km == 50.0  # junk radius → default
+    assert sit.updated_at is None  # non-string updated_at → None
+
+
 # ── keyless-local route contract ─────────────────────────────────────────────────
 
 

--- a/apps/api/tests/test_watch_rules.py
+++ b/apps/api/tests/test_watch_rules.py
@@ -66,3 +66,18 @@ def test_cue_maps_point_to_known_aoi():
     # Strait of Hormuz bbox is configured in sar_vessels.AOIS
     assert cue.aoi_for_point(56.6, 26.6) == "hormuz"
     assert cue.aoi_for_point(0.0, 0.0) is None
+
+
+def test_geofence_exit_pops_state_key() -> None:
+    # On exit the (rule, entity) key must be DROPPED, not stored as False: a False
+    # entry per distinct entity that ever transited an AOI grows _STATE.inside
+    # without bound over uptime. get(key, False) already treats absent as outside.
+    now = 1_000_000.0
+    rule = _rule("ais_gap", 56.6, 26.6)
+    inside = watch.candidates_from_tracks([_dark_track("vessel:1", 56.6, 26.6, now)], now)
+    watch.evaluate_rules([rule], inside)  # enter → key stored
+    assert watch._STATE.inside  # non-empty after enter
+    outside = watch.candidates_from_tracks([_dark_track("vessel:1", 0.0, 0.0, now)], now)
+    firings = watch.evaluate_rules([rule], outside)  # far outside the AOI → exit
+    assert any(f[2] == "exit" for f in firings)
+    assert watch._STATE.inside == {}  # key popped, not left as a False entry

--- a/apps/api/tests/test_weather_metar.py
+++ b/apps/api/tests/test_weather_metar.py
@@ -94,3 +94,22 @@ def test_metar_upstream_failure_502(monkeypatch):
     tc = _make_app(monkeypatch, status_code=503)
     r = tc.get("/api/weather/metar", params={"ids": "KJFK"})
     assert r.status_code == 502
+
+
+def test_json_or_502_degrades_non_json_body() -> None:
+    # A 200 + non-JSON body (a CDN maintenance / rate-limit HTML page) must become
+    # a 502, not raise out of the cache.get_or_fetch loader and 500 the route.
+    import pytest
+    from fastapi import HTTPException
+
+    from app.routes.weather import _json_or_502
+
+    class _R:
+        status_code = 200
+
+        def json(self) -> object:
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+
+    with pytest.raises(HTTPException) as exc:
+        _json_or_502(_R(), "test")
+    assert exc.value.status_code == 502

--- a/apps/api/tests/test_workflows_control.py
+++ b/apps/api/tests/test_workflows_control.py
@@ -296,6 +296,23 @@ def test_check_url_blocks_link_local_metadata() -> None:
     control.check_url("http://192.168.1.50/command")  # private LAN still fine
 
 
+def test_check_url_blocks_ipv6_and_mapped_metadata() -> None:
+    # The IPv4-only guard let the IPv6 metadata surface through: AWS's IPv6 IMDS
+    # host (a ULA), IPv6 link-local, and the IPv4-mapped form of 169.254.169.254.
+    for url in (
+        "http://[fd00:ec2::254]/latest/meta-data/iam/security-credentials/",
+        "http://[fe80::1]/x",
+        "http://[::ffff:169.254.169.254]/x",
+    ):
+        with pytest.raises(WorkflowError) as exc:
+            control.check_url(url)
+        assert exc.value.status_code == 403
+    # A normal IPv6 ULA / loopback control server is NOT a metadata endpoint and
+    # stays reachable — the BYO posture (private LAN open) must not regress.
+    control.check_url("http://[fd12:3456:789a::1]/command")  # IPv6 ULA LAN host
+    control.check_url("http://[::1]:9010/command")  # IPv6 loopback
+
+
 def test_check_url_link_local_allowed_when_explicitly_allowlisted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -351,6 +368,19 @@ def test_pin_http_url_blocks_dns_rebinding_to_metadata(monkeypatch: pytest.Monke
     time is blocked by _pin_http_url even though check_url passed earlier."""
     _fake_getaddrinfo(monkeypatch, {"rebind.evil.example": "169.254.169.254"})
     url, headers, blocked = control._pin_http_url("http://rebind.evil.example/latest/meta-data/", {})
+    assert blocked is not None and "link-local" in blocked
+
+
+def test_pin_http_url_blocks_ipv6_metadata_rebinding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A name that re-resolves to the AWS IPv6 IMDS host at request time is also
+    blocked — the pin guard is no longer IPv4-only."""
+    import socket as _socket
+
+    def fake(host, *a, **kw):
+        return [(_socket.AF_INET6, _socket.SOCK_STREAM, 0, "", ("fd00:ec2::254", 0, 0, 0))]
+
+    monkeypatch.setattr(control.socket, "getaddrinfo", fake)
+    url, headers, blocked = control._pin_http_url("http://rebind6.evil.example/latest/meta-data/", {})
     assert blocked is not None and "link-local" in blocked
 
 

--- a/apps/web/src/entity-panel/AiAssessmentCard.tsx
+++ b/apps/web/src/entity-panel/AiAssessmentCard.tsx
@@ -96,6 +96,12 @@ export function AiAssessmentCard({ id, kind, properties, altM }: Props): JSX.Ele
   const propsRef = useRef({ kind, properties, altM });
   propsRef.current = { kind, properties, altM };
 
+  // The manual "↻ refresh" runs outside the effect, so its AbortController must
+  // be tracked to be cancelled when the selection changes — otherwise a slow
+  // refresh for entity A resolves after B is selected and paints A's brief into
+  // B's card (the effect path is already covered by its own cleanup abort).
+  const inflightRef = useRef<AbortController | null>(null);
+
   const run = (bypassCache: boolean, signal: AbortSignal): void => {
     if (!bypassCache) {
       const cached = briefCache.get(id);
@@ -155,6 +161,7 @@ export function AiAssessmentCard({ id, kind, properties, altM }: Props): JSX.Ele
     return () => {
       window.clearTimeout(timer);
       aborter.abort();
+      inflightRef.current?.abort(); // cancel any manual refresh still in flight
     };
     // Deliberately keyed on id + enabled only — see propsRef above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -164,7 +171,9 @@ export function AiAssessmentCard({ id, kind, properties, altM }: Props): JSX.Ele
 
   const refresh = (): void => {
     briefCache.delete(id);
+    inflightRef.current?.abort();
     const aborter = new AbortController();
+    inflightRef.current = aborter;
     run(true, aborter.signal);
   };
 

--- a/apps/web/src/entity-panel/DossierNarrativeCard.test.tsx
+++ b/apps/web/src/entity-panel/DossierNarrativeCard.test.tsx
@@ -1,0 +1,41 @@
+// Regression test: DossierNarrativeCard must reset its generated assessment when
+// the selection changes. The card instance persists across selections (EntityPanel
+// is toggled by display, never re-keyed), so without the reset effect it would
+// show the previous contact's analytic assessment under the new contact.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DossierNarrativeCard } from './DossierNarrativeCard.js';
+
+vi.mock('../transport/http.js', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../transport/http.js';
+
+const mockedFetch = vi.mocked(apiFetch);
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as unknown as Response;
+}
+
+describe('DossierNarrativeCard: assessment does not leak across selections', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedFetch.mockResolvedValue(jsonResponse({ ok: true, assessment: 'ASSESSMENT_FOR_A' }));
+  });
+
+  it('drops the previous contact assessment on id change', async () => {
+    const { rerender } = render(<DossierNarrativeCard id="aircraft:AAA" kind="aircraft" />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(await screen.findByText('ASSESSMENT_FOR_A')).toBeTruthy();
+
+    // Select a different aircraft — the reset effect must clear A's assessment
+    // rather than render it under B, and the button returns to "Generate".
+    rerender(<DossierNarrativeCard id="aircraft:BBB" kind="aircraft" />);
+    await waitFor(() => expect(screen.queryByText('ASSESSMENT_FOR_A')).toBeNull());
+    const btn = screen.getByRole('button');
+    expect(btn.textContent).toContain('Generate');
+    expect(btn.textContent).not.toContain('Regenerate');
+  });
+});

--- a/apps/web/src/entity-panel/DossierNarrativeCard.tsx
+++ b/apps/web/src/entity-panel/DossierNarrativeCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Widget, Btn, Badge, Caveat } from '../shell/instruments.js';
 import { apiFetch } from '../transport/http.js';
 
@@ -29,6 +29,15 @@ interface Props {
 export function DossierNarrativeCard({ id, kind }: Props): JSX.Element | null {
   const [data, setData] = useState<Narrative | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Reset when the selection changes. This card instance persists across
+  // selections (EntityPanel is toggled by display, never re-keyed), so without
+  // this it would keep showing the previous contact's assessment with the button
+  // reading "↻ Regenerate" — every sibling card already resets on id.
+  useEffect(() => {
+    setData(null);
+    setBusy(false);
+  }, [id, kind]);
 
   // Only aircraft / vessels have a pattern-of-life dossier to narrate.
   if (kind !== 'aircraft' && kind !== 'vessel') return null;

--- a/apps/web/src/entity-panel/DossierNarrativeCard.tsx
+++ b/apps/web/src/entity-panel/DossierNarrativeCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Widget, Btn, Badge, Caveat } from '../shell/instruments.js';
 import { apiFetch } from '../transport/http.js';
 
@@ -29,14 +29,18 @@ interface Props {
 export function DossierNarrativeCard({ id, kind }: Props): JSX.Element | null {
   const [data, setData] = useState<Narrative | null>(null);
   const [busy, setBusy] = useState(false);
+  const inflightRef = useRef<AbortController | null>(null);
 
   // Reset when the selection changes. This card instance persists across
   // selections (EntityPanel is toggled by display, never re-keyed), so without
   // this it would keep showing the previous contact's assessment with the button
-  // reading "↻ Regenerate" — every sibling card already resets on id.
+  // reading "↻ Regenerate" — every sibling card already resets on id. Also abort
+  // an in-flight Generate so a late response for the prior contact can't paint
+  // under the new one (matches AiAssessmentCard's inflightRef).
   useEffect(() => {
     setData(null);
     setBusy(false);
+    return () => inflightRef.current?.abort();
   }, [id, kind]);
 
   // Only aircraft / vessels have a pattern-of-life dossier to narrate.
@@ -44,18 +48,23 @@ export function DossierNarrativeCard({ id, kind }: Props): JSX.Element | null {
   const entityId = id.includes(':') ? id : `${kind}:${id}`;
 
   const generate = async (): Promise<void> => {
+    inflightRef.current?.abort();
+    const aborter = new AbortController();
+    inflightRef.current = aborter;
     setBusy(true);
     try {
       const r = await apiFetch(
         `/api/intel/dossier/narrative?entity_id=${encodeURIComponent(entityId)}`,
-        { method: 'POST' },
+        { method: 'POST', signal: aborter.signal },
       );
       const body = (await r.json().catch(() => null)) as Narrative | null;
+      if (aborter.signal.aborted) return;
       setData(body ?? { ok: false, error: 'Could not load the assessment.' });
-    } catch {
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') return;
       setData({ ok: false, error: 'Could not load the assessment.' });
     } finally {
-      setBusy(false);
+      if (!aborter.signal.aborted) setBusy(false);
     }
   };
 

--- a/apps/web/src/entity-panel/EntityPanel.tsx
+++ b/apps/web/src/entity-panel/EntityPanel.tsx
@@ -152,11 +152,19 @@ export function EntityPanel({ viewer }: Props = {}): JSX.Element {
     // mutated in place (stable ref), so we gate on length and hand TrackCard a
     // fresh slice on change. No more unconditional 1 Hz re-render here.
     let lastLen = -1;
+    let lastT = -1;
     const t = window.setInterval(() => {
-      const len = tracks.points(id);
-      if (len !== lastLen) {
+      const pts = tracks.get(id);
+      const len = pts.length;
+      // Gate on the newest fix's time too, not just length: the ring is capped
+      // at MAX_POINTS_PER_ENTITY, so once a contact reaches the cap shift()+push()
+      // keeps length constant forever and a length-only check would go silent —
+      // exactly when this interval is meant to keep the sparkline advancing.
+      const newestT = len > 0 ? pts[len - 1]!.t : -1;
+      if (len !== lastLen || newestT !== lastT) {
         lastLen = len;
-        setTrack(tracks.get(id).slice());
+        lastT = newestT;
+        setTrack(pts.slice());
       }
     }, 1000);
     return () => window.clearInterval(t);

--- a/apps/web/src/foundry/DatasetsView.tsx
+++ b/apps/web/src/foundry/DatasetsView.tsx
@@ -92,7 +92,18 @@ function ChecksSection({ datasetId }: { datasetId: string }): JSX.Element {
   const [severity, setSeverity] = useState<CheckSeverity>('warn');
 
   useEffect(() => {
-    void loadChecks(datasetId).then(() => void getCheckResults(datasetId).then(setResults));
+    // Guard against a superseded dataset landing last (A -> B -> A rapid switch),
+    // matching the cancelled-flag pattern the sibling effects in this file use.
+    let cancelled = false;
+    void loadChecks(datasetId).then(() => {
+      if (cancelled) return;
+      void getCheckResults(datasetId).then((r) => {
+        if (!cancelled) setResults(r);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasetId]);
 

--- a/apps/web/src/globe/HistoryPlayback.test.ts
+++ b/apps/web/src/globe/HistoryPlayback.test.ts
@@ -137,6 +137,31 @@ describe('HistoryPlayback: multi-domain replay renders interpolated ≥2-point t
     }
   });
 
+  it('re-entrant load then exit restores the live layers — two Pattern-of-life clicks must not blank the globe', async () => {
+    const { viewer } = fakeViewer();
+    // Two live layers already on the globe when replay starts.
+    const live1 = { show: true } as unknown as Cesium.DataSource;
+    const live2 = { show: true } as unknown as Cesium.DataSource;
+    viewer.dataSources.add(live1);
+    viewer.dataSources.add(live2);
+
+    const controller = installHistoryPlayback(viewer);
+
+    await controller.load(WINDOW_SEC); // first Pattern-of-life click
+    expect(live1.show).toBe(false);
+    expect(live2.show).toBe(false);
+
+    // Second click with no "◼ exit" between — load() runs again while active.
+    await controller.load(WINDOW_SEC, 'aircraft:ABC123');
+    expect(live1.show).toBe(false); // still hidden during replay
+
+    controller.clear(); // "◼ exit"
+    // Pre-fix, the second load wiped the saved set and these stayed false — the
+    // whole live globe blanked until a page reload.
+    expect(live1.show).toBe(true);
+    expect(live2.show).toBe(true);
+  });
+
   it('interpolates a midpoint position for BOTH aircraft and vessel (glide, not teleport-hold) — the sanctioned replay motion (docs/decisions.md 2026-07-11)', async () => {
     const { viewer, getDs } = fakeViewer();
     const controller = installHistoryPlayback(viewer);

--- a/apps/web/src/globe/HistoryPlayback.ts
+++ b/apps/web/src/globe/HistoryPlayback.ts
@@ -61,7 +61,12 @@ export function installHistoryPlayback(viewer: Cesium.Viewer): PlaybackControlle
   // Hide every other (live) data source so the replay reads cleanly; remember
   // exactly which we hid so clear() restores them and nothing else.
   function hideLive(): void {
-    hiddenLive = [];
+    // Re-entrant safe: a second load() (two Pattern-of-life clicks with no exit
+    // between) must not lose the saved set. If we skip already-hidden sources
+    // while hiddenLive is freshly emptied, restoreLive() later has nothing to
+    // un-hide and the live globe stays blank until reload. Restore first, then
+    // re-capture whatever is currently visible.
+    restoreLive();
     for (let i = 0; i < viewer.dataSources.length; i++) {
       const d = viewer.dataSources.get(i);
       if (d === ds || !d.show) continue;

--- a/apps/web/src/osint/CountriesPanel.tsx
+++ b/apps/web/src/osint/CountriesPanel.tsx
@@ -6,7 +6,7 @@
 // so the country's linked graph (country: -has_resource-> resource: -hosted_at->
 // domain:) lands in the Investigation canvas.
 
-import { type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '../transport/http.js';
 import { useInvestigation } from '../graph/investigationStore.js';
 import { useSelection } from '../state/stores.js';
@@ -87,18 +87,31 @@ export function CountriesPanel(): JSX.Element {
       .catch((e: unknown) => setListError(e instanceof Error ? e.message : String(e)));
   }, []);
 
+  const latestCodeRef = useRef<string | null>(null);
+
   function selectCountry(code: string): void {
+    latestCodeRef.current = code;
     setSelected(code);
     setDetail(null);
     setDetailError(null);
     setIngestResult(null);
     setIngestError(null);
     setDetailLoading(true);
+    // Guard every state write against the CURRENT selection: click France then
+    // Germany quickly and, if France resolves last, its detail would otherwise
+    // paint under a Germany selection and Ingest (keyed off `selected`) would act
+    // on Germany with France's resources on screen.
     apiFetch(`/api/osint/countries/${code}`)
       .then((r) => (r.ok ? (r.json() as Promise<CountryDetail>) : Promise.reject(new Error(String(r.status)))))
-      .then(setDetail)
-      .catch((e: unknown) => setDetailError(e instanceof Error ? e.message : String(e)))
-      .finally(() => setDetailLoading(false));
+      .then((d) => {
+        if (latestCodeRef.current === code) setDetail(d);
+      })
+      .catch((e: unknown) => {
+        if (latestCodeRef.current === code) setDetailError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (latestCodeRef.current === code) setDetailLoading(false);
+      });
   }
 
   async function ingest(): Promise<void> {

--- a/apps/web/src/situations/CoaCards.test.tsx
+++ b/apps/web/src/situations/CoaCards.test.tsx
@@ -1,0 +1,43 @@
+// Regression: proposed COAs must not leak across situations. CoaCards (inside
+// SituationPanel) persists across selections and is not re-keyed, so without the
+// reset effect a "Verify" click would file the previous situation's course of
+// action under the newly-selected one — a wrong-data write, not a display glitch.
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CoaCards } from './CoaCards.js';
+
+vi.mock('../transport/http.js', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../transport/http.js';
+
+const mockedFetch = vi.mocked(apiFetch);
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as unknown as Response;
+}
+
+describe('CoaCards: proposed COAs do not leak across situations', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedFetch.mockResolvedValue(
+      jsonResponse({
+        ok: true,
+        coas: [{ title: 'COA_FOR_A', side: 'enemy', likelihood: 'high', rationale: 'r' }],
+      }),
+    );
+  });
+
+  it('clears proposed COAs when the situation changes', async () => {
+    const { rerender } = render(<CoaCards situationId="situation:A" />);
+    fireEvent.click(screen.getByRole('button', { name: /Propose/ }));
+    expect(await screen.findByText('COA_FOR_A')).toBeTruthy();
+
+    // Select a different situation — the reset effect must clear A's COAs so a
+    // subsequent Verify can't file A's course of action under B.
+    rerender(<CoaCards situationId="situation:B" />);
+    await waitFor(() => expect(screen.queryByText('COA_FOR_A')).toBeNull());
+  });
+});

--- a/apps/web/src/situations/CoaCards.tsx
+++ b/apps/web/src/situations/CoaCards.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge, Btn, Caveat, StatusDot, type BadgeTone } from '../shell/instruments.js';
 import { useSituations } from './situationStore.js';
 import { apiFetch } from '../transport/http.js';
@@ -33,6 +33,15 @@ export function CoaCards({ situationId }: { situationId: string }): JSX.Element 
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
   const linkChild = useSituations((s) => s.linkChild);
+
+  // Reset when the situation changes. SituationPanel/CoaCards persists across
+  // selections (it is not re-keyed), so without this a Verify click would file
+  // the PREVIOUS situation's proposed COA under the newly-selected one.
+  useEffect(() => {
+    setCoas([]);
+    setBusy(false);
+    setNote(null);
+  }, [situationId]);
 
   const propose = async (): Promise<void> => {
     setBusy(true);

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -745,10 +745,10 @@ The current baseline lives in `CLAUDE.md` (Environment facts) and stays a
 three-line fact there. One line per wave, newest first — when the CLAUDE.md
 number changes, the displaced line lands here.
 
-- **1745 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
-  bug-hunt wave. Three audit rounds (security/backend/frontend, then
-  ontology/foundry/collab/recon/imagery, then alerts/correlate/weather + the
-  remaining FE panels). Third round added: correlation ingest loops surviving a
+- **1747 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
+  bug-hunt wave. Four audit rounds (security/backend/frontend, then
+  ontology/foundry/collab/recon/imagery, then alerts/correlate/weather + FE
+  panels, then the AI/LLM route + MCP layer). Third round added: correlation ingest loops surviving a
   non-JSON body (were killed permanently → blind to 7500/7600/7700 squawks),
   weather/seismic/cams parse guards, a haversine domain-error clamp, a bounded
   geofence-state dict, and three more cross-selection state leaks (CoaCards filing

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -745,9 +745,14 @@ The current baseline lives in `CLAUDE.md` (Environment facts) and stays a
 three-line fact there. One line per wave, newest first — when the CLAUDE.md
 number changes, the displaced line lands here.
 
-- **1741 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
-  bug-hunt wave. Two audit rounds (security/backend/frontend, then
-  ontology/foundry/collab/recon/imagery). Fixed IPv6+mapped SSRF metadata bypass
+- **1745 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
+  bug-hunt wave. Three audit rounds (security/backend/frontend, then
+  ontology/foundry/collab/recon/imagery, then alerts/correlate/weather + the
+  remaining FE panels). Third round added: correlation ingest loops surviving a
+  non-JSON body (were killed permanently → blind to 7500/7600/7700 squawks),
+  weather/seismic/cams parse guards, a haversine domain-error clamp, a bounded
+  geofence-state dict, and three more cross-selection state leaks (CoaCards filing
+  a COA under the wrong situation, CountriesPanel, DatasetsView). Fixed IPv6+mapped SSRF metadata bypass
   in the workflow HTTP guard, replay-exit blanking the live globe, history
   byte-cap sizing off the un-vacuumed file, three entity-panel cross-selection
   state leaks, three feed-parser trust-boundary crashes, the `/api/imagery/splat`

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -745,7 +745,7 @@ The current baseline lives in `CLAUDE.md` (Environment facts) and stays a
 three-line fact there. One line per wave, newest first — when the CLAUDE.md
 number changes, the displaced line lands here.
 
-- **1747 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
+- **1750 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
   bug-hunt wave. Four audit rounds (security/backend/frontend, then
   ontology/foundry/collab/recon/imagery, then alerts/correlate/weather + FE
   panels, then the AI/LLM route + MCP layer). Third round added: correlation ingest loops surviving a
@@ -761,7 +761,9 @@ number changes, the displaced line lands here.
   the owner check, foundry join-fanout OOM + unhashable group keys, the foundry
   SQL-console 500-on-bad-input, the news og:image SSRF rebinding TOCTOU, a
   spurious 500 when the ontology soft-cap VACUUM hits a lock, and a dropped
-  removal-tombstone provenance gap.
+  removal-tombstone provenance gap. Round 4 (AI/LLM) also bounded the four
+  reason/fast-tier LLM routes under the 100 s edge budget (asyncio.wait_for) and
+  moved the llama.cpp hot-model warm off the boot path.
 - **1719 +1 skip** — 2026-07-15, platform-hardening-and-copy-pass: sidecar
   freshness+supervision wave (frozen `:8093` union refused instead of
   republished as live, honest AIS status feed, both sidecars supervised on a

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -745,6 +745,18 @@ The current baseline lives in `CLAUDE.md` (Environment facts) and stays a
 three-line fact there. One line per wave, newest first — when the CLAUDE.md
 number changes, the displaced line lands here.
 
+- **1741 +1 skip** — 2026-07-18, overnight-hardening-2026-07-18: overnight
+  bug-hunt wave. Two audit rounds (security/backend/frontend, then
+  ontology/foundry/collab/recon/imagery). Fixed IPv6+mapped SSRF metadata bypass
+  in the workflow HTTP guard, replay-exit blanking the live globe, history
+  byte-cap sizing off the un-vacuumed file, three entity-panel cross-selection
+  state leaks, three feed-parser trust-boundary crashes, the `/api/imagery/splat`
+  compute fail-closed gap, situations/maps 500 on crafted ontology props, collab
+  clearance failing OPEN on an ACL-store hiccup, recon result downloads missing
+  the owner check, foundry join-fanout OOM + unhashable group keys, the foundry
+  SQL-console 500-on-bad-input, the news og:image SSRF rebinding TOCTOU, a
+  spurious 500 when the ontology soft-cap VACUUM hits a lock, and a dropped
+  removal-tombstone provenance gap.
 - **1719 +1 skip** — 2026-07-15, platform-hardening-and-copy-pass: sidecar
   freshness+supervision wave (frozen `:8093` union refused instead of
   republished as live, honest AIS status feed, both sidecars supervised on a


### PR DESCRIPTION
## Summary

A hardening pass across the platform: four review sweeps (security/auth, backend
correctness, frontend correctness, and the AI/LLM layer) plus a review of the diff
itself. 30 defects fixed, each with a regression test. `bash scripts/verify.sh` is
green (1750 passed, 1 skipped) and the app boots and serves live.

Severity trended down across the sweeps, so the later ones are mostly MED/LOW —
the platform was already in good shape; this closes the sharp edges.

## Security / auth

- **Workflow HTTP guard was IPv4-only.** `169.254.0.0/16` was blocked but IPv6
  cloud-metadata (`fd00:ec2::254`) and the IPv4-mapped form `[::ffff:169.254.169.254]`
  slipped past. Both `check_url` and the DNS-rebinding pin now share one classifier
  that unwraps mapped forms and covers both families.
- **`/api/imagery/splat` bypassed the compute fail-closed gate** — it launches a GPU
  job but was missing from `_COMPUTE_PREFIXES`, so a keyless box served anonymous
  recon jobs. Added it (also closes the rate-limit exemption).
- **Collab clearance gate failed *open*** on an ACL-store hiccup: `_doc_acl`
  returned `None` for both "new doc" and "store error". Split them — a store error
  now denies.
- **Recon result downloads had no owner check** (`result.ply/spz/camera.json`),
  unlike the job-metadata routes. Owner-scoped now.
- **Two DNS-rebinding SSRF TOCTOUs** — the news og:image fetch now pins to the
  validated IP.
- **Foundry binding wiped an existing object's props** when entity-resolution matched
  a pre-existing object (sparse `prop_map` + wholesale upsert). It now merges onto
  the existing blob in the resolve-onto-foreign case; foundry-minted objects stay
  wholesale-replaced.

## Availability / correctness

- **Correlation ingest loops died permanently on a non-JSON 200.** `_mil/_emerg/
  _quake/_opensky_loop` caught only `httpx.HTTPError`, so the documented
  airplanes.live "200 + text/plain" throttle raised a `ValueError` that killed the
  (unrespawned) loop — the platform went blind to 7500/7600/7700 squawks until a
  restart. Broadened to match the sibling loops.
- **Feed parsers 500'd on malformed upstream bodies** — adsb.lol/adsb.fi/USGS quakes/
  weather/seismic/AIS/Digitraffic/cams now guard the JSON parse and per-row coord
  conversions.
- **History byte-cap over-pruned** — it sized off the un-vacuumed file, so it dropped
  extra history every pass. Now sizes off in-use pages `(page_count - freelist) *
  page_size`.
- **Replay exit blanked the live globe** after two Pattern-of-life clicks
  (`hideLive` lost its saved set on a re-entrant load).
- **Six cross-selection state leaks** — entity-panel cards, `CoaCards` (which could
  file a course of action under the *wrong* situation), `CountriesPanel`, and
  `DatasetsView` now reset/guard on selection change.
- **Foundry:** join fan-out could OOM the API (now capped), unhashable group/join
  keys aborted a build (now canonicalized), and the SQL console 500'd on odd input
  (now a clean 4xx).
- **Ontology:** a soft-cap VACUUM under a writer lock 500'd an already-committed
  write (now best-effort), and a removal tombstone was deduped away (provenance gap,
  now recorded).
- **AI/LLM:** the dossier/selection/country/extract routes had no total time bound
  and could pin a worker past the 100s edge limit — each is now wrapped in
  `asyncio.wait_for`. Boot no longer freezes on hot-model loads (the warm runs in the
  background). The dossier cache is bounded, a stranded-download-on-mkdir-failure is
  fixed, and a raw model-error string no longer leaks into the dashboard.

## Verification

- `bash scripts/verify.sh` green: 1750 passed, 1 skipped (baseline was 1719).
- Every fix has a test plus a falsification (revert the fix, the test fails, restore).
- Reviewed the full diff for regressions — none found; the load-bearing invariants
  (BYO-posture SSRF ranges, wholesale-replace-vs-merge, two-sources-coexist dedup,
  the join cap boundary, fail-closed collab) were each verified.
- Booted the app; every hardened route serves 200, status operational.

## Not included / needs a decision

The `history.db` byte cap is enforced hourly, so the file overshoots to ~4 GB
against a 2 GB cap between prunes (measured). A mid-cycle vacuum valve would bound
it, but that trades vacuum frequency for disk headroom on retention code with a
scarred history — left out deliberately as a tuning call.
