### PR TITLE
History cache-density knobs: decimation, incremental vacuum, blob compression

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -475,6 +475,28 @@ class Settings(BaseSettings):
     # history_max_bytes (documented, logged once at boot — never a silent no-op).
     history_disk_budget_gb: float = 0.0  # HISTORY_DISK_BUDGET_GB
 
+    # ── Cache-density knobs (store more useful replay per byte, same disk) ──
+    # These trade CPU (and, for decimation, old-data resolution) for density.
+    # All OFF by default so the current on-disk format/behaviour is unchanged.
+    #
+    # 1) Tiered resolution: beyond history_decimate_after_hours, thin each track
+    #    to one fix in every history_decimate_stride, deleting the rest in the
+    #    maintenance pass. 0 hours disables. Old data becomes coarse, so far more
+    #    time-span fits under the same byte cap. Recent data stays full-fidelity.
+    history_decimate_after_hours: int = 0  # 0 disables
+    history_decimate_stride: int = 4  # keep 1-in-N old fixes per id (>= 2)
+    # 2) Free-page reclaim: use INCREMENTAL auto_vacuum so deleted pages return to
+    #    the file continuously (a cheap PRAGMA incremental_vacuum each maintenance
+    #    pass) instead of a periodic full VACUUM — keeps the file from carrying
+    #    dead pages between hourly passes. Applies to a FRESH history.db; an
+    #    existing store converts on its next full VACUUM. 0/False keeps full VACUUM.
+    history_incremental_vacuum: bool = False
+    # 3) Compress the per-fix `extra` JSON blob (alt/squawk/… metadata) with zlib
+    #    before storing it. The blob is write-only today (no query reads it), so
+    #    this is a pure density win at write-CPU cost. A future reader must
+    #    zlib-decompress; see history._encode_extra / _decode_extra.
+    history_compress_extra: bool = False
+
     # ── Ontology local spine ──
     # Default (keyless) backend for the ontology: local SQLite next to
     # history.db. Objects keep a materialized props blob for frontend parity;

--- a/apps/api/app/history.py
+++ b/apps/api/app/history.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sqlite3
 import time
+import zlib
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,32 @@ from app import memtier
 from app.config import get_settings
 
 log = logging.getLogger(__name__)
+
+
+def _encode_extra(extra: dict[str, Any]) -> str | bytes:
+    """Encode the per-fix ``extra`` blob for storage. With
+    ``history_compress_extra`` on, zlib-compress the compact JSON (a pure density
+    win — the column is write-only today, so there is no read path to update);
+    otherwise store compact JSON text. A future reader must go through
+    ``_decode_extra``."""
+    raw = json.dumps(extra, separators=(",", ":"))
+    if get_settings().history_compress_extra:
+        return zlib.compress(raw.encode("utf-8"))
+    return raw
+
+
+def _decode_extra(value: Any) -> dict[str, Any]:
+    """Inverse of ``_encode_extra``, tolerant of a mixed column (rows written
+    before/after the flag flipped): a zlib blob is decompressed, plain text is
+    parsed, anything undecodable degrades to ``{}`` — never crash a reader."""
+    if value is None:
+        return {}
+    try:
+        if isinstance(value, (bytes, bytearray)):
+            return json.loads(zlib.decompress(bytes(value)).decode("utf-8"))
+        return json.loads(str(value))
+    except Exception:  # noqa: BLE001 — best-effort decode of a write-only blob
+        return {}
 
 # ── tunable constants ──────────────────────────────────────────────────────────
 _FLUSH_INTERVAL_S: float = 3.0       # background flush cadence
@@ -110,6 +137,12 @@ def _connect() -> sqlite3.Connection:
     path = _resolved_db_path()
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     con = sqlite3.connect(path, check_same_thread=False)
+    # auto_vacuum only takes on a FRESH db (or after a full VACUUM), and must be
+    # set before the first table is created — so issue it here, ahead of the
+    # CREATE TABLE below. On an existing store it is a no-op until the next full
+    # VACUUM converts it; the maintenance pass falls back to full VACUUM then.
+    if get_settings().history_incremental_vacuum:
+        con.execute("PRAGMA auto_vacuum=INCREMENTAL")
     con.execute("PRAGMA journal_mode=WAL")
     # A WAL only checkpoints past its OLDEST live reader. The recorder writes
     # continuously, so one long-running read holds every frame written during
@@ -164,7 +197,7 @@ def _buffer_point(
         _last.popitem(last=False)
 
     _last[entity_id] = (t, lon, lat)
-    _buffer.append((kind, entity_id, t, lon, lat, track, json.dumps(extra)))
+    _buffer.append((kind, entity_id, t, lon, lat, track, _encode_extra(extra)))
 
 
 # ── public ingest API ─────────────────────────────────────────────────────────
@@ -300,7 +333,17 @@ async def _maintenance_pass() -> None:
     settings = get_settings()
     hours = _clamped_retention_hours()
     size_cap = _size_cap_bytes(settings)
-    deleted = await loop.run_in_executor(None, prune, hours)
+    deleted = 0
+    # Tiered resolution (opt-in): thin OLD data first so the byte cap then bounds a
+    # denser, coarser tail rather than dropping whole recent slices.
+    if settings.history_decimate_after_hours > 0:
+        deleted += await loop.run_in_executor(
+            None,
+            decimate,
+            settings.history_decimate_after_hours,
+            max(2, settings.history_decimate_stride),
+        )
+    deleted += await loop.run_in_executor(None, prune, hours)
     deleted += await loop.run_in_executor(None, enforce_size_cap, size_cap)
     if deleted:
         # Archive mode skips the full-file VACUUM here on purpose: at archive
@@ -309,13 +352,13 @@ async def _maintenance_pass() -> None:
         # already ran above), so reclaiming disk space isn't needed until the
         # configured budget is hit.
         if not settings.archive_mode:
-            await loop.run_in_executor(None, _vacuum)
+            await loop.run_in_executor(None, _reclaim)
         log.info(
             "history: pruned %d rows (>%dh / >%d bytes)%s",
             deleted,
             hours,
             size_cap,
-            "" if settings.archive_mode else ", vacuumed",
+            "" if settings.archive_mode else ", reclaimed",
         )
 
 
@@ -531,6 +574,38 @@ def prune(retention_hours: int) -> int:
         return 0
 
 
+def decimate(after_hours: int, stride: int) -> int:
+    """Thin each track OLDER than *after_hours* to one fix in every *stride*,
+    deleting the rest; recent data (within the window) is untouched. Kept fixes
+    are evenly spaced along each track and always include the segment's first fix,
+    so a short old track keeps at least one point rather than vanishing. Returns
+    the deleted row count. Tiered resolution: far more time-span fits the byte
+    cap at the cost of old-data precision."""
+    if after_hours <= 0 or stride < 2:
+        return 0
+    cutoff = time.time() - after_hours * 3600
+    try:
+        con = _connect()
+        try:
+            cur = con.execute(
+                "DELETE FROM positions WHERE rowid IN ("
+                "  SELECT rowid FROM ("
+                "    SELECT rowid, ROW_NUMBER() OVER (PARTITION BY id ORDER BY t) AS rn"
+                "    FROM positions WHERE t < ?"
+                "  ) WHERE rn % ? != 1"
+                ")",
+                (cutoff, stride),
+            )
+            deleted = cur.rowcount
+            con.commit()
+            return deleted
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        log.exception("history: decimate error")
+        return 0
+
+
 def enforce_size_cap(max_bytes: int) -> int:
     """Drop the oldest rows until the DB's IN-USE size is under *max_bytes*.
 
@@ -590,6 +665,33 @@ def _vacuum() -> None:
         con.close()
     except Exception:  # noqa: BLE001
         log.exception("history: vacuum error")
+
+
+def _reclaim() -> None:
+    """Return freed pages to the filesystem. In INCREMENTAL auto_vacuum mode
+    (history_incremental_vacuum, once the store was created/converted that way) a
+    PRAGMA incremental_vacuum reclaims the freelist cheaply without the full-file
+    rewrite; otherwise fall back to a full VACUUM. A bare DELETE alone leaves the
+    file at its high-water mark (the "10 GB history.db" bug)."""
+    if not get_settings().history_incremental_vacuum:
+        _vacuum()
+        return
+    try:
+        con = _connect()
+        try:
+            # 2 == INCREMENTAL. An existing non-auto_vacuum store reports 0 until a
+            # full VACUUM converts it, so do that once and let the next pass go
+            # incremental.
+            mode = con.execute("PRAGMA auto_vacuum").fetchone()[0]
+            if mode == 2:
+                con.execute("PRAGMA incremental_vacuum")
+                con.commit()
+            else:
+                con.execute("VACUUM")
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        log.exception("history: reclaim error")
 
 
 # ── lifecycle ─────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_history.py
+++ b/apps/api/tests/test_history.py
@@ -660,3 +660,79 @@ def test_coverage_route_returns_expected_keys(
         assert set(body.keys()) >= {"recording_since", "total_bytes", "row_count", "buckets"}
     finally:
         H.override_db_path(None)
+
+
+def test_encode_decode_extra_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Plain mode → compact JSON text that round-trips.
+    enc = H._encode_extra({"alt": 1000, "sq": "7700"})
+    assert isinstance(enc, str)
+    assert H._decode_extra(enc) == {"alt": 1000, "sq": "7700"}
+    # Compressed mode → zlib bytes; still round-trips, and _decode_extra tolerates
+    # a mixed column (legacy text rows) and undecodable garbage.
+    monkeypatch.setenv("HISTORY_COMPRESS_EXTRA", "1")
+    get_settings.cache_clear()
+    try:
+        enc2 = H._encode_extra({"alt": 2000})
+        assert isinstance(enc2, (bytes, bytearray))
+        assert H._decode_extra(enc2) == {"alt": 2000}
+        assert H._decode_extra('{"legacy": true}') == {"legacy": True}
+        assert H._decode_extra(b"not-zlib-data") == {}
+    finally:
+        monkeypatch.delenv("HISTORY_COMPRESS_EXTRA", raising=False)
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_decimate_thins_old_tracks_keeps_recent(tmp_path: pytest.TempPathFactory) -> None:
+    db = str(tmp_path / "dec.db")
+    _reset_module(db)
+    now = time.time()
+    loop = asyncio.get_running_loop()
+    rows = []
+    for i in range(20):  # d1: 20 OLD fixes (~2 days ago), 1 s apart
+        rows.append(("aircraft", "aircraft:d1", now - 2 * 86400 - (20 - i), float(i % 90), 50.0, 0.0, "{}"))
+    for i in range(5):  # d1: 5 RECENT fixes (now)
+        rows.append(("aircraft", "aircraft:d1", now - (5 - i), float(i % 90), 50.0, 0.0, "{}"))
+    for i in range(2):  # d2: a SHORT old track (2 fixes) — must not vanish
+        rows.append(("aircraft", "aircraft:d2", now - 2 * 86400 - (2 - i), 1.0, 51.0, 0.0, "{}"))
+    await loop.run_in_executor(None, H._flush_sync, rows)
+
+    deleted = await loop.run_in_executor(None, H.decimate, 24, 4)  # older than 24h → 1-in-4
+    assert deleted == 16  # d1: 20→5 (drop 15); d2: 2→1 (drop 1)
+
+    con = H._connect()
+    try:
+        old = con.execute("SELECT COUNT(*) FROM positions WHERE t < ? AND id='aircraft:d1'", (now - 86400,)).fetchone()[0]
+        recent = con.execute("SELECT COUNT(*) FROM positions WHERE t >= ?", (now - 86400,)).fetchone()[0]
+        d2 = con.execute("SELECT COUNT(*) FROM positions WHERE id='aircraft:d2'").fetchone()[0]
+    finally:
+        con.close()
+    assert recent == 5  # recent data untouched
+    assert old == 5  # old thinned to 1-in-4
+    assert d2 == 1  # short old track keeps its first fix, never fully deleted
+
+
+@pytest.mark.asyncio
+async def test_incremental_vacuum_mode_and_reclaim(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+) -> None:
+    db = str(tmp_path / "iv.db")
+    monkeypatch.setenv("HISTORY_INCREMENTAL_VACUUM", "1")
+    get_settings.cache_clear()
+    try:
+        _reset_module(db)
+        now = time.time()
+        loop = asyncio.get_running_loop()
+        rows = [("aircraft", f"aircraft:a{i}", now - i - 10, 0.0, 50.0, 0.0, "{}") for i in range(300)]
+        await loop.run_in_executor(None, H._flush_sync, rows)
+        con = H._connect()
+        try:
+            mode = con.execute("PRAGMA auto_vacuum").fetchone()[0]
+        finally:
+            con.close()
+        assert mode == 2  # fresh db created in INCREMENTAL auto_vacuum mode
+        await loop.run_in_executor(None, H.prune, 0)  # delete all → freelist pages
+        H._reclaim()  # incremental_vacuum path must not raise
+    finally:
+        monkeypatch.delenv("HISTORY_INCREMENTAL_VACUUM", raising=False)
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Makes the position-archive cache density tunable — store more replay per byte at
fixed disk. Three opt-in knobs, all **OFF by default** so the current on-disk
format and behaviour are unchanged. `bash scripts/verify.sh` green (1753 passed).

## The knobs (`Settings`)

| Setting | What it does | Lever |
|---|---|---|
| `history_decimate_after_hours` + `history_decimate_stride` | Thin each track older than N hours to one fix in every `stride` during the maintenance pass. Recent data stays full-fidelity; the first fix of an old segment is always kept so short tracks don't vanish. | **Tiered resolution** — old data goes coarse, so far more time-span fits the byte cap. Biggest density gain. |
| `history_incremental_vacuum` | INCREMENTAL `auto_vacuum` + a cheap `PRAGMA incremental_vacuum` each pass instead of a periodic full `VACUUM`. Falls back to full `VACUUM` on an existing store until its next `VACUUM` converts it. | **Free-page reclaim** — deleted pages return to the file continuously instead of accumulating between hourly passes. |
| `history_compress_extra` | zlib-compress the per-fix `extra` JSON blob (alt/squawk/… metadata). The blob is write-only today — no query reads it — so there's no read path to change. | **Compression** — a pure density win at write-CPU cost. |

`_encode_extra` / `_decode_extra` handle the (de)compression and tolerate a mixed
column, so the flag can be flipped without a migration and a future reader has a
decode path.

## Not included (deliberately)

- **Coordinate quantization** (lat/lon/track `REAL` → scaled `INT`) is the other
  big density lever, but it's a *schema migration* over the whole archive, not a
  runtime flag — a follow-up with its own migration, not a dead config knob here.
- **Value-based eviction** — for a uniform time-series the value metric is
  recency, which the existing time-window + byte-cap retention already implements.
  Decimation is the density knob; no separate setting needed.

## Tradeoffs

Decimation loses old-data precision; compression and incremental vacuum add CPU.
That's the intended trade — density for compute/fidelity, not disk. All default
off, so nothing changes until an operator opts in.

## Tests

- `test_decimate_thins_old_tracks_keeps_recent` — exact-count thinning, recent
  data untouched, and a short old track keeps its first fix (falsified: dropping
  the first-fix rule makes the short track vanish and the test fails).
- `test_incremental_vacuum_mode_and_reclaim` — a fresh DB comes up in INCREMENTAL
  mode and `_reclaim` runs without error.
- `test_encode_decode_extra_roundtrip` — both modes round-trip, and decode
  tolerates a mixed column and garbage.
