### PR TITLE
Improve layer panel legibility and fix motion badge overlap

### DIFF
--- a/apps/web/src/AppRouter.tsx
+++ b/apps/web/src/AppRouter.tsx
@@ -119,8 +119,10 @@ function PredictedMotionBadge(): JSX.Element | null {
   // The console home ("/") has a ~158px timeline footer; sit above it so the badge
   // never overlaps the lane labels. The 2D route has a clear bottom.
   const bottomClass = loc.pathname === '/' ? 'bottom-[172px]' : 'bottom-2';
+  // Centered so it never sits under the left tool flyout (Layers/Feeds/etc.),
+  // which overlays the map's bottom-left corner where this used to pin.
   return (
-    <div className={`absolute ${bottomClass} left-2 z-[var(--z-dock)] mono text-[10px] px-2 py-1 rounded-sm border border-accent-line bg-bg-1/90 text-accent pointer-events-none flex items-center gap-1.5`}>
+    <div className={`absolute ${bottomClass} left-1/2 -translate-x-1/2 z-[var(--z-dock)] mono text-[10px] px-2 py-1 rounded-sm border border-accent-line bg-bg-1/90 text-accent pointer-events-none flex items-center gap-1.5`}>
       <span className="inline-block w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
       Predicted motion: aircraft positions estimated between ADS-B fixes
     </div>

--- a/apps/web/src/layer-rail/LayerCatalog.tsx
+++ b/apps/web/src/layer-rail/LayerCatalog.tsx
@@ -23,7 +23,7 @@ export function LayerCatalog({ registry }: { registry: LayerRegistry; viewer?: C
   useEffect(() => registry.subscribe(force), [registry]);
 
   return (
-    <div className="p-2 flex flex-col gap-1">
+    <div className="p-2 flex flex-col gap-2">
       {MAP_LAYER_FOLDERS.map((folder) => (
         <Folder key={folder.id} folder={folder} registry={registry} />
       ))}
@@ -36,7 +36,7 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
   const { on, total } = folderCounts(registry, folder);
   return (
     <div className="rounded-sm border border-line/60 overflow-hidden">
-      <div className="flex items-center gap-1.5 px-2 h-8 bg-bg-1">
+      <div className="flex items-center gap-1.5 px-2 h-9 bg-bg-1">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
@@ -45,7 +45,7 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
         >
           <Icon name={open ? 'chevron-down' : 'chevron-right'} className="w-3 h-3 shrink-0 text-txt-3" />
           <Icon name={folder.icon} className="w-3.5 h-3.5 shrink-0 text-txt-2" />
-          <span className="font-label uppercase tracking-[0.6px] text-[11px] truncate">{folder.label}</span>
+          <span className="font-label font-semibold uppercase tracking-[0.8px] text-[13px] truncate">{folder.label}</span>
         </button>
         <span className={`mono text-[10px] tabular-nums ${on > 0 ? 'text-accent' : 'text-txt-3'}`}>
           {on}/{total}
@@ -70,18 +70,26 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
                 key={row.label}
                 type="button"
                 onClick={() => toggleRow(registry, row)}
-                className="flex items-center gap-2 w-full px-2.5 py-1.5 text-left hover:bg-bg-2 border-t border-line/40"
+                className={`flex items-center gap-2 w-full px-2.5 py-2 text-left border-t border-line/50 border-l-2 transition-colors ${
+                  en ? 'border-l-accent bg-accent-dim/30 hover:bg-accent-dim/50' : 'border-l-transparent hover:bg-bg-2'
+                }`}
                 aria-pressed={en}
               >
                 <span
                   className={`w-2 h-2 rounded-full shrink-0 ${en ? 'bg-accent' : 'bg-txt-4'}`}
                   style={en ? { boxShadow: '0 0 6px var(--accent)' } : undefined}
                 />
-                <Icon name={row.icon} className={`w-3.5 h-3.5 shrink-0 ${en ? 'text-txt-1' : 'text-txt-3'}`} />
-                <span className={`text-[11px] flex-1 truncate ${en ? 'text-txt-0' : 'text-txt-2'}`}>{row.label}</span>
-                <span className={`mono text-[10px] uppercase tracking-[0.4px] ${en ? 'text-accent' : 'text-txt-4'}`}>
-                  {en ? 'on' : 'off'}
+                <Icon name={row.icon} className={`w-4 h-4 shrink-0 ${en ? 'text-accent' : 'text-txt-3'}`} />
+                <span className={`text-[12px] flex-1 truncate ${en ? 'text-txt-0 font-medium' : 'text-txt-2'}`}>
+                  {row.label}
                 </span>
+                {en ? (
+                  <span className="mono text-[10px] uppercase tracking-[0.4px] px-1.5 py-[1px] rounded-sm border border-accent-line bg-accent-dim text-accent shrink-0">
+                    on
+                  </span>
+                ) : (
+                  <span className="mono text-[10px] uppercase tracking-[0.4px] text-txt-4 shrink-0">off</span>
+                )}
               </button>
             );
           })}

--- a/apps/web/src/layer-rail/LayerRail.tsx
+++ b/apps/web/src/layer-rail/LayerRail.tsx
@@ -217,7 +217,7 @@ export function LayerRail({ registry, viewer }: Props): JSX.Element {
   ];
 
   return (
-    <div className="p-3 space-y-2.5">
+    <div className="p-3 space-y-3.5">
       <SectionLabel title="Layers" count={`${layers.length} REG`} />
 
       {/* Filter — find a layer without hunting through folders. */}
@@ -279,13 +279,13 @@ export function LayerRail({ registry, viewer }: Props): JSX.Element {
             <button
               type="button"
               onClick={() => setCollapsed((c) => ({ ...c, [group]: !c[group] }))}
-              className="group flex items-center gap-1.5 w-full text-left border-t border-[rgba(255,255,255,0.06)] pt-1.5 hover:border-accent-line/40"
+              className="group flex items-center gap-1.5 w-full text-left border-t border-[rgba(255,255,255,0.1)] pt-3 hover:border-accent-line/40"
             >
               {/* Sequence number — Gotham numbered-group idiom */}
               <span className="mono text-[10px] tabular-nums text-txt-4 group-hover:text-accent shrink-0 w-[14px]">
                 {seq}
               </span>
-              <span className="mono text-[10px] tracking-[0.9px] uppercase text-txt-2 group-hover:text-accent">
+              <span className="mono text-[11px] font-semibold tracking-[0.11em] uppercase text-txt-1 group-hover:text-accent">
                 {GROUP_LABEL[group] ?? group}
               </span>
               <span className="flex-1 h-px bg-line" />
@@ -306,7 +306,7 @@ export function LayerRail({ registry, viewer }: Props): JSX.Element {
               </span>
             </button>
             {!isCollapsed && (
-              <ul className="mt-0.5">
+              <ul className="mt-1.5">
                 {list.map((l) => {
                   const enabled = registry.isEnabled(l.id);
                   const feed = feeds[l.id];
@@ -316,14 +316,14 @@ export function LayerRail({ registry, viewer }: Props): JSX.Element {
                   return (
                     <li
                       key={l.id}
-                      className="py-[5px] border-b border-[rgba(255,255,255,0.035)]"
+                      className="py-2 border-b border-[rgba(255,255,255,0.07)]"
                     >
                       <div className="flex items-center gap-2">
                         <span
                           className={`h-[9px] w-[9px] rounded-sm shrink-0 ${STATUS_DOT[status] ?? 'bg-txt-3'}`}
                           aria-hidden="true"
                         />
-                        <span className="text-txt-1 text-[11px] flex-1 truncate" title={l.title}>
+                        <span className="text-txt-1 text-[12px] flex-1 truncate" title={l.title}>
                           {l.title}
                         </span>
                         {enabled && (
@@ -355,7 +355,7 @@ export function LayerRail({ registry, viewer }: Props): JSX.Element {
                           </span>
                         </div>
                       )}
-                      <div className="pl-[17px] mt-0.5">
+                      <div className="pl-[17px] mt-1">
                         <span className="mono text-[10px] tracking-[0.7px] uppercase text-txt-3">
                           {l.auth} · {l.refresh.ttlSec ? `${l.refresh.ttlSec}s` : l.refresh.mode}
                         </span>


### PR DESCRIPTION
## What

The left **Layers** panel had a flat type scale: folder headers and layer rows were both 11px, so folders didn't read as headers and rows were a uniform wall that was hard to scan.

- **Type hierarchy:** folder headers 13px semibold · rows 12px · on/off 10px, with more row padding and folder spacing.
- **Active-layer differentiation:** enabled rows now get a left accent bar, tint, colored icon, and an `ON` pill, so it's obvious at a glance which layers are live.
- **Advanced rail:** same header/row size fix applied to the "All sources" rail, whose headers were actually *smaller* than its rows.
- **Motion badge:** centered the "Predicted motion" chip so it no longer overlaps the left tool flyout (it used to sit pinned in the bottom-left corner, covering the panel's bottom rows).

## Verification

- `pnpm typecheck` + eslint green on all touched files.
- Booted the app and screenshotted the live rendered panel: folder headers read as headers, active rows pop out, badge no longer overlaps the flyout.

Pure presentation changes (className tweaks + one badge position); no logic touched.