### PR TITLE
Dashboard panels: coloured Layers headers, dark-grey rails, consistent styled section headers

### DIFF
--- a/apps/web/src/layer-rail/LayerCatalog.tsx
+++ b/apps/web/src/layer-rail/LayerCatalog.tsx
@@ -27,7 +27,7 @@ const FOLDER_TONE: Record<string, { bg: string; edge: string }> = {
   air: { bg: '#15323f', edge: '#38bdf8' }, // cyan-blue
   maritime: { bg: '#123a32', edge: '#2dd4bf' }, // teal
   space: { bg: '#241f47', edge: '#a78bfa' }, // indigo
-  ground: { bg: '#3a2b14', edge: '#f5b544' }, // bronze (hazard)
+  ground: { bg: '#3d191b', edge: '#ff6b5c' }, // deep hazard red
   signals: { bg: '#3a1d1a', edge: '#f2765b' }, // rust (alert)
   infra: { bg: '#183320', edge: '#4ade80' }, // forest
   reference: { bg: '#232a33', edge: '#94a3b8' }, // slate

--- a/apps/web/src/layer-rail/LayerCatalog.tsx
+++ b/apps/web/src/layer-rail/LayerCatalog.tsx
@@ -17,6 +17,23 @@ import {
 // the same pure `layerCatalog.ts` data. "All sources" (raw registry LayerRail) is
 // a separate rail entry for the advanced view.
 //
+// Colour lives ONLY on the folder headers, as a deep hand-tuned background per
+// domain (not a bright hue mixed toward black, which muddied warm colours into
+// olive). Each tone is dark enough for crisp white text and saturated enough to
+// tell apart; a brighter same-hue edge sharpens it. Cool hues read as benign
+// domains, warm hues as hazard/conflict, so colour also hints at content. Rows
+// stay monochrome — one app accent for on-state — so the panel reads clean.
+const FOLDER_TONE: Record<string, { bg: string; edge: string }> = {
+  air: { bg: '#15323f', edge: '#38bdf8' }, // cyan-blue
+  maritime: { bg: '#123a32', edge: '#2dd4bf' }, // teal
+  space: { bg: '#241f47', edge: '#a78bfa' }, // indigo
+  ground: { bg: '#3a2b14', edge: '#f5b544' }, // bronze (hazard)
+  signals: { bg: '#3a1d1a', edge: '#f2765b' }, // rust (alert)
+  infra: { bg: '#183320', edge: '#4ade80' }, // forest
+  reference: { bg: '#232a33', edge: '#94a3b8' }, // slate
+};
+const FALLBACK_TONE = { bg: '#232a33', edge: 'var(--accent)' };
+
 // ponytail: registry.subscribe → forceUpdate on toggle; no local mirror of state.
 export function LayerCatalog({ registry }: { registry: LayerRegistry; viewer?: Cesium.Viewer | null }): JSX.Element {
   const [, force] = useReducer((n: number) => n + 1, 0);
@@ -34,28 +51,35 @@ export function LayerCatalog({ registry }: { registry: LayerRegistry; viewer?: C
 function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRegistry }): JSX.Element {
   const [open, setOpen] = useState(folder.defaultOpen ?? false);
   const { on, total } = folderCounts(registry, folder);
+  const tone = FOLDER_TONE[folder.id] ?? FALLBACK_TONE;
   return (
     <div className="rounded-sm border border-line/60 overflow-hidden">
-      <div className="flex items-center gap-1.5 px-2 h-9 bg-bg-1">
+      {/* Big title: deep coloured background, white words, brighter same-hue edge. */}
+      <div
+        className="flex items-center gap-1.5 px-2 h-9 border-l-[3px] text-white"
+        style={{ borderLeftColor: tone.edge, background: tone.bg }}
+      >
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="flex items-center gap-1.5 flex-1 min-w-0 text-left text-txt-1 hover:text-txt-0"
+          className="flex items-center gap-1.5 flex-1 min-w-0 text-left text-white"
           aria-expanded={open}
         >
-          <Icon name={open ? 'chevron-down' : 'chevron-right'} className="w-3 h-3 shrink-0 text-txt-3" />
-          <Icon name={folder.icon} className="w-3.5 h-3.5 shrink-0 text-txt-2" />
-          <span className="font-label font-semibold uppercase tracking-[0.8px] text-[13px] truncate">{folder.label}</span>
+          <Icon name={open ? 'chevron-down' : 'chevron-right'} className="w-3 h-3 shrink-0 text-white/60" />
+          <Icon name={folder.icon} className="w-4 h-4 shrink-0 text-white" />
+          <span className="font-label font-semibold uppercase tracking-[0.8px] text-[13px] truncate text-white">
+            {folder.label}
+          </span>
         </button>
-        <span className={`mono text-[10px] tabular-nums ${on > 0 ? 'text-accent' : 'text-txt-3'}`}>
+        <span className={`mono text-[10px] tabular-nums ${on > 0 ? 'text-white' : 'text-white/55'}`}>
           {on}/{total}
         </span>
         <button
           type="button"
           onClick={() => toggleFolder(registry, folder)}
           title={on > 0 ? 'Turn all off' : 'Turn all on'}
-          className={`w-5 h-5 flex items-center justify-center rounded-sm border ${
-            on > 0 ? 'border-accent-line text-accent bg-accent-dim' : 'border-line text-txt-3 hover:text-txt-1'
+          className={`w-5 h-5 flex items-center justify-center rounded-sm border transition-colors ${
+            on > 0 ? 'border-white/50 text-white bg-white/15' : 'border-white/25 text-white/60 hover:text-white'
           }`}
         >
           <Icon name="crosshair" className="w-3 h-3" />
@@ -65,6 +89,7 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
         <div className="bg-bg-0/40">
           {folder.rows.map((row) => {
             const en = rowEnabled(registry, row);
+            // Small titles: monochrome. A single accent marks "on"; off is grey.
             return (
               <button
                 key={row.label}
@@ -75,11 +100,8 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
                 }`}
                 aria-pressed={en}
               >
-                <span
-                  className={`w-2 h-2 rounded-full shrink-0 ${en ? 'bg-accent' : 'bg-txt-4'}`}
-                  style={en ? { boxShadow: '0 0 6px var(--accent)' } : undefined}
-                />
-                <Icon name={row.icon} className={`w-4 h-4 shrink-0 ${en ? 'text-accent' : 'text-txt-3'}`} />
+                <span className={`w-2 h-2 rounded-full shrink-0 ${en ? 'bg-accent' : 'bg-txt-4'}`} />
+                <Icon name={row.icon} className={`w-4 h-4 shrink-0 ${en ? 'text-txt-1' : 'text-txt-3'}`} />
                 <span className={`text-[12px] flex-1 truncate ${en ? 'text-txt-0 font-medium' : 'text-txt-2'}`}>
                   {row.label}
                 </span>

--- a/apps/web/src/layer-rail/LayerCatalog.tsx
+++ b/apps/web/src/layer-rail/LayerCatalog.tsx
@@ -67,7 +67,7 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
         >
           <Icon name={open ? 'chevron-down' : 'chevron-right'} className="w-3 h-3 shrink-0 text-white/60" />
           <Icon name={folder.icon} className="w-4 h-4 shrink-0 text-white" />
-          <span className="font-label font-semibold uppercase tracking-[0.8px] text-[13px] truncate text-white">
+          <span className="font-label font-bold uppercase tracking-[0.8px] text-[13px] truncate text-white [text-shadow:0_1px_2px_rgba(0,0,0,0.55)]">
             {folder.label}
           </span>
         </button>
@@ -102,7 +102,7 @@ function Folder({ folder, registry }: { folder: CatalogFolder; registry: LayerRe
               >
                 <span className={`w-2 h-2 rounded-full shrink-0 ${en ? 'bg-accent' : 'bg-txt-4'}`} />
                 <Icon name={row.icon} className={`w-4 h-4 shrink-0 ${en ? 'text-txt-1' : 'text-txt-3'}`} />
-                <span className={`text-[12px] flex-1 truncate ${en ? 'text-txt-0 font-medium' : 'text-txt-2'}`}>
+                <span className={`text-[12px] flex-1 truncate ${en ? 'text-txt-0 font-medium' : 'text-txt-1'}`}>
                   {row.label}
                 </span>
                 {en ? (

--- a/apps/web/src/shell/ConsoleShell.tsx
+++ b/apps/web/src/shell/ConsoleShell.tsx
@@ -50,7 +50,9 @@ interface Props {
 
 const ICON_RAIL_W = 44;
 
-const RAIL_BG = 'rgba(8,10,15,0.95)';
+// Shared rail/panel surface. Neutral dark grey (theme-aware) so left and right
+// rails read as the same material; was a cool near-black.
+const RAIL_BG = 'var(--panel-bg)';
 
 // Resizable rails — widths persist to localStorage, clamped to sane bounds. The
 // LEFT rail keeps its local width state; the RIGHT rail's bounds (RIGHT_MIN/MAX)

--- a/apps/web/src/shell/LeftIconRail.tsx
+++ b/apps/web/src/shell/LeftIconRail.tsx
@@ -73,7 +73,7 @@ export function LeftIconRail({
     <div className="relative h-full" role="toolbar" aria-label={ariaLabel}>
       {/* 44px icon column (in flow). Scrolls internally when the item list is
           taller than the viewport (short screens) so no icon is clipped. */}
-      <div className="w-11 h-full min-h-0 overflow-y-auto overflow-x-hidden flex flex-col items-center bg-bg-1 py-1">
+      <div className="w-11 h-full min-h-0 overflow-y-auto overflow-x-hidden flex flex-col items-center bg-[var(--panel-bg)] py-1">
         {primary.map(btn)}
         {more.length > 0 && <div className="my-1 h-px w-6 bg-line-2" />}
         {more.map(btn)}
@@ -81,10 +81,10 @@ export function LeftIconRail({
       {/* flyout floats over the map to the right of the rail (design §6.1) */}
       {active && (
         <div
-          className="absolute left-full top-0 h-full w-[300px] bg-bg-1 border-r border-line-2 flex flex-col z-[var(--z-rail)] shadow-[6px_0_22px_-12px_rgba(0,0,0,0.6)]"
+          className="absolute left-full top-0 h-full w-[300px] bg-[var(--panel-bg)] border-r border-line-2 flex flex-col z-[var(--z-rail)] shadow-[6px_0_22px_-12px_rgba(0,0,0,0.6)]"
         >
           <div className="flex items-center justify-between px-3 h-8 shrink-0 border-b border-line-2">
-            <span className="font-label uppercase tracking-[0.9px] text-[11px] text-txt-1 flex items-center gap-1.5">
+            <span className="font-label uppercase tracking-[0.9px] text-[11px] text-txt-0 flex items-center gap-1.5">
               <Icon name={active.icon} className="w-3.5 h-3.5" />
               {active.label}
             </span>

--- a/apps/web/src/shell/instruments.tsx
+++ b/apps/web/src/shell/instruments.tsx
@@ -9,10 +9,11 @@
 import type { CSSProperties, ReactNode } from 'react';
 
 // ── section divider label (.seclbl) ────────────────────────────────────────
-// Section title + optional count. Sentence case (frontend.md §type-scale
-// mandates "sentence case everywhere except machine codes"); the old
-// uppercase + 0.09em tracking read as "AI-dashboard" chrome. A hair more weight
-// carries the structural role now that it isn't shouting in caps.
+// Section title + optional count, rendered as a styled header BAR so every
+// panel's sections read the same way as the Layers folder headers: a subtle
+// accent-tinted fill + a left accent edge + a bright title. Sentence case
+// (frontend.md §type-scale mandates "sentence case everywhere except machine
+// codes"); the old uppercase + 0.09em tracking read as "AI-dashboard" chrome.
 export function SectionLabel({
   title,
   count,
@@ -25,10 +26,17 @@ export function SectionLabel({
   style?: CSSProperties;
 }): JSX.Element {
   return (
-    <div className={`flex items-center justify-between gap-2 ${className}`} style={style}>
-      <span className="text-[12px] font-semibold text-txt-1">{title}</span>
+    <div
+      className={`flex items-center justify-between gap-2 px-2 py-1.5 rounded-sm border-l-[3px] ${className}`}
+      style={{
+        borderLeftColor: 'var(--accent)',
+        background: 'color-mix(in srgb, var(--accent) 12%, var(--panel-bg))',
+        ...style,
+      }}
+    >
+      <span className="text-[12px] font-semibold text-txt-0">{title}</span>
       {count !== undefined && count !== '' && (
-        <span className="mono text-[11px] text-txt-3 tabular-nums">{count}</span>
+        <span className="mono text-[11px] text-txt-2 tabular-nums">{count}</span>
       )}
     </div>
   );

--- a/apps/web/src/theme/tokens.css
+++ b/apps/web/src/theme/tokens.css
@@ -10,6 +10,10 @@
   --bg-2: #282623;
   --bg-3: #322f2b;
   --bg-4: #3f3b36;
+  /* left tool panels (icon rail + flyout) — a neutral dark grey, deliberately
+     cooler/greyer than the warm substrate so the panels read as their own
+     surface. Light theme keeps the white panel below. */
+  --panel-bg: #26282c;
   /* hairlines — warm white; a notch stronger since the lighter bg eats alpha */
   --line: rgba(255, 246, 234, 0.08);
   --line-2: rgba(255, 246, 234, 0.15);
@@ -124,6 +128,7 @@
   --bg-2: #f3f5f8;
   --bg-3: #e7ebf0;
   --bg-4: #d9dfe6;
+  --panel-bg: #ffffff;
   --line: rgba(15, 22, 32, 0.1);
   --line-2: rgba(15, 22, 32, 0.16);
   --txt-0: #10151c;


### PR DESCRIPTION
## What

A visual pass making the dashboard side panels legible and consistent. Commits:

1. **Colour the Layers folder headers with deep domain tones** — each folder header is a deep, hand-tuned background (cyan-blue / teal / indigo / hazard-red / rust / forest / slate) with a brighter same-hue edge and white title. Rows stay monochrome (one accent for on-state) — clean, not a per-row rainbow.
2. **Dark-grey rail panels + legible white text** — the left tool rail/flyout and the right selection panel share a neutral dark-grey surface (new theme-aware `--panel-bg`; `RAIL_BG` points at it). White text lifted (bold + shadow on folder titles, brighter flyout title, brighter off-row labels).
3. **Ground & Hazards → hazard red** — the earlier bronze read muddy; deep red with a coral edge instead.
4. **Every panel's section headers get a styled header bar** — the shared `SectionLabel` now renders as a bar (subtle accent-tinted fill + left accent edge + bright title), so Feeds, Ops, the right inspector, entity sections, and the rest all match the Layers folder headers. Sentence case preserved.

## Verification

- `pnpm typecheck` + eslint green.
- Full web unit suite green (**396 tests**), incl. contrast, ConsoleShell, invariants.
- Booted the app and screenshotted live: Layers folder headers, dark-grey left+right panels, and the styled section headers on Feeds / Ops / Selection.

Files: `LayerCatalog.tsx`, `tokens.css`, `LeftIconRail.tsx`, `ConsoleShell.tsx`, `instruments.tsx`. Presentation only.