### PR TITLE
Fix Chrome renderer leak in AIS/ADS-B browser sidecars

### DIFF
--- a/tools/adsb-globe-feeder/index.js
+++ b/tools/adsb-globe-feeder/index.js
@@ -123,25 +123,34 @@ async function ensureBrowser() {
 async function openPage(url) {
   await ensureBrowser();
   const context = await browser.newContext({ userAgent: UA, viewport: { width: 1366, height: 900 } });
-  const page = await context.newPage();
-  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
-  // Wait for Cloudflare to clear + tar1090 globals to exist.
-  await page.waitForFunction('typeof OLMap !== "undefined" && typeof g !== "undefined"', { timeout: 60000 });
-  // Zoom to the whole world ONCE — this single move makes tar1090 fetch +
-  // decode + parse every aircraft into g.planesOrdered. Do NOT keep re-moving
-  // it (that resets the load); a slow keep-alive nudge refreshes it later.
-  await page.evaluate(zoomFn, { z: ZOOM, c: CENTER });
-  // Poll (same READ_FN the loop uses) until the store populates. tar1090
-  // typically fills within ~3 s of the zoom.
-  let loaded = 0;
-  for (let i = 0; i < 14; i++) {
-    await page.waitForTimeout(2500);
-    const ac = await page.evaluate(readFn);
-    if (Array.isArray(ac) && ac.length >= MIN_PLANES) { loaded = ac.length; break; }
+  try {
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    // Wait for Cloudflare to clear + tar1090 globals to exist.
+    await page.waitForFunction('typeof OLMap !== "undefined" && typeof g !== "undefined"', { timeout: 60000 });
+    // Zoom to the whole world ONCE — this single move makes tar1090 fetch +
+    // decode + parse every aircraft into g.planesOrdered. Do NOT keep re-moving
+    // it (that resets the load); a slow keep-alive nudge refreshes it later.
+    await page.evaluate(zoomFn, { z: ZOOM, c: CENTER });
+    // Poll (same READ_FN the loop uses) until the store populates. tar1090
+    // typically fills within ~3 s of the zoom.
+    let loaded = 0;
+    for (let i = 0; i < 14; i++) {
+      await page.waitForTimeout(2500);
+      const ac = await page.evaluate(readFn);
+      if (Array.isArray(ac) && ac.length >= MIN_PLANES) { loaded = ac.length; break; }
+    }
+    if (loaded) log('opened', url, '-', loaded, 'aircraft');
+    else log('warn: planes not populated for', url, '(loop will keep trying)');
+    return page;
+  } catch (e) {
+    // Close THIS context on failure so its renderers don't orphan on the SHARED
+    // browser (multi-source: browser.close() would kill sibling tabs, so scope
+    // teardown to the context). A goto/waitForFunction timeout during a
+    // Cloudflare re-challenge otherwise leaked this context's renderer per reload.
+    try { await context.close(); } catch (_) {}
+    throw e;
   }
-  if (loaded) log('opened', url, '-', loaded, 'aircraft');
-  else log('warn: planes not populated for', url, '(loop will keep trying)');
-  return page;
 }
 
 // Tiny alternating pan to keep tar1090's fetch loop alive (headless tabs can be

--- a/tools/ais-myshiptracking-feeder/index.js
+++ b/tools/ais-myshiptracking-feeder/index.js
@@ -145,19 +145,28 @@ async function waitForApi(p) {
 async function openPage() {
   await ensureBrowser();
   const context = await browser.newContext({ userAgent: UA, viewport: { width: 1366, height: 900 } });
-  const p = await context.newPage();
   try {
-    await p.goto(SITE, { waitUntil: 'commit', timeout: 45000 });
+    const p = await context.newPage();
+    try {
+      await p.goto(SITE, { waitUntil: 'commit', timeout: 45000 });
+    } catch (e) {
+      log('goto warning -', e.message, '- probing API anyway');
+    }
+    if (!(await waitForApi(p))) {
+      throw new Error('myshiptracking vessel API not reachable yet');
+    }
+    // Settle past any early SPA reroute (same one-shot reroute footgun as the
+    // MarineTraffic feeder) before the first grid sweep fires.
+    await p.waitForTimeout(3000);
+    return p;
   } catch (e) {
-    log('goto warning -', e.message, '- probing API anyway');
+    // Close THIS context on any failed open so its chrome renderer processes
+    // don't orphan on the browser. While the site blocks us, initPage() reloads
+    // every cycle and each failed openPage (waitForApi false / goto throw) used
+    // to leave its context alive — ~1-2 leaked renderers per 30 s, hundreds/hr.
+    try { await context.close(); } catch (_) {}
+    throw e;
   }
-  if (!(await waitForApi(p))) {
-    throw new Error('myshiptracking vessel API not reachable yet');
-  }
-  // Settle past any early SPA reroute (same one-shot reroute footgun as the
-  // MarineTraffic feeder) before the first grid sweep fires.
-  await p.waitForTimeout(3000);
-  return p;
 }
 
 async function initPage() {


### PR DESCRIPTION
## Summary
The MyShipTracking (`:8093`) and tar1090 (`:8090`) headless-browser feeders leaked Chrome renderer processes — one browser context per failed page open — until the host ran out of memory.

## Root cause
`openPage()` creates a browser context + page, then can throw on a failed open (site blocked, `goto`/`waitForApi` timeout). It threw **without closing the context it had just created**, so that context's renderer processes stayed orphaned on the browser. The AIS feeder reloads every ~30s while MyShipTracking blocks the sidecar, so each stalled cycle leaked ~1-2 renderers.

## Impact (measured live)
- **496 orphaned Chrome renderers** (459 AIS + 36 ADS-B) after ~1h40m.
- Held tens of GB; `MemAvailable` down to 35 GB and falling, swap 50% used — heading for OOM.

## Fix
Close the context on any failed open before rethrowing (`tools/ais-myshiptracking-feeder/index.js`, `tools/adsb-globe-feeder/index.js`). For the shared multi-source ADS-B browser the teardown is scoped to the context so sibling source tabs survive.

## Verification
After reclaiming the leaked processes and restarting the backend with the patched feeders:
- `MemAvailable` 35 GB → 86 GB (peaked 104 GB right after reclaim).
- Backend healthy: 10,517 aircraft + 35,199 vessels, feeds green.
- Renderer count stays **bounded at ~49-56** across the observation window under the *same* blocking condition (AIS `:8093` still serving 0 while it retries) that previously drove it to 496.
