### PR TITLE
Recover the governed write-back path: the one commit not already on master

### DIFF
--- a/apps/api/app/intel/action_log_local.py
+++ b/apps/api/app/intel/action_log_local.py
@@ -1,0 +1,135 @@
+"""Local SQLite ``action_log`` sink — keyless audit persistence for governed
+write-backs (Track C1, deferred "Phase-4" item named in
+``docs/decisions.md#ontology-local-first-store-2026-07-07``).
+
+``intel/actions.py``'s ``_append_audit`` historically had exactly one
+backend: Supabase PostgREST ``action_log``. On a keyless boot (no
+``SUPABASE_URL``) that table doesn't exist — the Supabase ontology backend
+was deleted 2026-07-07 — so every governed action 502'd on its final step.
+The fail-hard contract ("an unaudited action must not silently succeed") only
+makes sense if a keyless deployment has a sink to succeed INTO, which is what
+this module gives it.
+
+Same idiom as ``ontology_local.py`` / ``alert_rules_local.py``: WAL SQLite
+under ``./data``, a fresh connection per operation run off the event loop's
+default executor, and an ``override_db_path()`` test hook. Unlike those two
+this module does not read its path from ``Settings`` — it is a single-table,
+single-purpose sink, so a hardcoded default keeps it self-contained rather
+than reaching into the shared config module for a value nobody has asked to
+relocate (ponytail: no config for a value that never changes). Add
+``action_log_db_path`` to ``Settings`` if a deployment ever needs to move it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_DB_PATH = "./data/action_log.db"
+
+# ── DB path injection (for tests) ─────────────────────────────────────────────
+
+_db_path_override: str | None = None
+
+
+def override_db_path(path: str | None) -> None:
+    """Set a custom DB path (tests). Pass None to clear."""
+    global _db_path_override
+    _db_path_override = path
+
+
+def _resolved_db_path() -> str:
+    return _db_path_override or _DEFAULT_DB_PATH
+
+
+# ── connection / schema ───────────────────────────────────────────────────────
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS action_log (
+  id        INTEGER PRIMARY KEY,
+  user_id   TEXT NOT NULL,
+  action    TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  params    TEXT NOT NULL DEFAULT '{}',
+  ts        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_action_log_ts ON action_log(ts DESC);
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    path = _resolved_db_path()
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path, check_same_thread=False)
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA busy_timeout=5000")
+    con.executescript(_SCHEMA)
+    con.commit()
+    return con
+
+
+async def _run(fn: Any) -> Any:
+    return await asyncio.get_running_loop().run_in_executor(None, fn)
+
+
+async def append_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Persist one ``action_log`` row (the exact shape ``actions.audit_row``
+    produces) and return it unchanged, so the caller echoes the same receipt
+    the Supabase-backed path would.
+
+    Raises on failure (a bad ``sqlite3`` write propagates as-is) — the
+    fail-hard contract this sink exists to preserve: a swallowed error here
+    would let an unaudited action silently "succeed".
+    """
+
+    def _sync() -> None:
+        con = _connect()
+        try:
+            con.execute(
+                "INSERT INTO action_log (user_id, action, target_id, params, ts)"
+                " VALUES (?,?,?,?,?)",
+                (
+                    row["user_id"],
+                    row["action"],
+                    row["target_id"],
+                    json.dumps(row["params"]),
+                    row["ts"],
+                ),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    await _run(_sync)
+    return row
+
+
+async def list_rows(limit: int = 100) -> list[dict[str, Any]]:
+    """Recent audit rows, newest first — the read-back proof a governed
+    action actually landed (tests / a future keyless ``/api/audit``)."""
+
+    def _sync() -> list[dict[str, Any]]:
+        con = _connect()
+        try:
+            rows = con.execute(
+                "SELECT user_id, action, target_id, params, ts FROM action_log"
+                " ORDER BY ts DESC, id DESC LIMIT ?",
+                (int(limit),),
+            ).fetchall()
+        finally:
+            con.close()
+        return [
+            {
+                "user_id": r[0],
+                "action": r[1],
+                "target_id": r[2],
+                "params": json.loads(r[3]),
+                "ts": r[4],
+            }
+            for r in rows
+        ]
+
+    return await _run(_sync)

--- a/apps/api/app/intel/actions.py
+++ b/apps/api/app/intel/actions.py
@@ -24,15 +24,18 @@ First actions:
   - ``add_watch``        — create a standing geofence ``alert_rules`` row (wraps the
                            same POST as ``routes/alert_rules.py``).
 
-Everything degrades gracefully when Supabase is unconfigured (the registry / REST
-calls raise 503 with the "store not configured" contract). The module imports with
-no side effects.
+The ontology mutation always lands (SQLite, local-first — see
+``docs/decisions.md#ontology-local-first-store-2026-07-07``). The audit append and
+the ``add_watch`` side effect fall back to a local SQLite store on a keyless boot
+(``action_log_local.py`` / ``alert_rules_local.py``); ``nominate_target``'s
+supplementary ``target_board`` reflection has no local store yet (deliberately
+deferred — see ``_handle_nominate_target``) and is skipped rather than sinking the
+whole action. The module imports with no side effects.
 """
 
 from __future__ import annotations
 
 import time
-import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -40,7 +43,9 @@ from fastapi import HTTPException
 from pydantic import BaseModel, Field, ValidationError
 
 from app.config import Settings, get_settings
+from app.intel import action_log_local, alert_rules_local
 from app.intel.ontology import Link, Object, get_registry
+from app.intel.promotion import stable_id
 from app.keys import UserCtx, _client, _headers
 
 # ── audit log ─────────────────────────────────────────────────────────────────
@@ -77,8 +82,23 @@ async def _append_audit(
     silently 'succeed' (C1 is on the critical path, per the plan). The audit is
     the LAST step of every handler, so a 502 here means the mutation landed but
     the receipt didn't, which the caller can retry.
+
+    Keyless boot (no ``supabase_url``): there is no PostgREST ``action_log``
+    table (the Supabase ontology backend was deleted 2026-07-07 —
+    docs/decisions.md), so the row goes to the local-SQLite sink
+    (``action_log_local.py``, same idiom as ``ontology_local``/
+    ``alert_rules_local``) instead of 503ing. Still fail-hard: a local write
+    error is re-raised as the same 502, never swallowed.
     """
     row = audit_row(ctx, action, target_id, params)
+    if not s.supabase_url:
+        try:
+            await action_log_local.append_row(row)
+        except Exception as exc:  # noqa: BLE001 — fail-hard, never swallowed
+            raise HTTPException(
+                status_code=502, detail="could not write audit log"
+            ) from exc
+        return row
     async with _client() as c:
         r = await c.post(
             _action_log_url(s),
@@ -172,7 +192,11 @@ async def _handle_promote_incident(
     ctx: UserCtx, s: Settings, p: PromoteIncidentParams
 ) -> ActionResult:
     reg = get_registry(ctx, s)
-    incident_id = f"incident:{uuid.uuid4()}"
+    # Stable, deterministic id (promotion.py's helper, shared with the
+    # auto-promotion path) so approving the SAME target twice UPDATES one
+    # incident node instead of minting a duplicate — a fresh uuid4 per call
+    # cannot do that. See docs/decisions.md.
+    incident_id = stable_id("incident", p.target_id)
     # Ensure the source object exists, create the incident node, and wire the
     # promotion edge so the incident is reachable from the source and vice-versa.
     await reg.upsert(Object(id=p.target_id))
@@ -188,7 +212,10 @@ async def _handle_promote_incident(
         )
     )
     await reg.link(Link(src=p.target_id, dst=incident_id, rel="promoted_to"))
-    await reg.link(Link(src=incident_id, dst=p.target_id, rel="evidence_of"))
+    # Canonical direction per ontology.py KNOWN_RELS ("signal/track → incident
+    # it supports"): member entity → incident, matching promotion.py's
+    # auto-promote path. Was inverted here (incident → target) — fixed.
+    await reg.link(Link(src=p.target_id, dst=incident_id, rel="evidence_of"))
     audit = await _append_audit(ctx, s, "promote_incident", incident_id, p.model_dump())
     return ActionResult(
         action="promote_incident",
@@ -205,26 +232,35 @@ async def _handle_nominate_target(
     # (unique(user_id, entity_id) upserts, so re-nominating moves nothing). We
     # POST directly rather than calling the route handler to avoid the in-process
     # FastAPI dependency machinery.
-    if not s.supabase_url:
-        raise HTTPException(status_code=503, detail="Supabase is not configured")
-    board_url = s.supabase_url.rstrip("/") + "/rest/v1/target_board"
-    row = {
-        "user_id": ctx.user_id,
-        "entity_id": p.target_id,
-        "stage": "confirm",
-        "priority": p.priority,
-        "note": p.note,
-    }
-    headers = {
-        **_headers(ctx, s, write=True),
-        "Prefer": "resolution=merge-duplicates,return=representation",
-    }
-    async with _client() as c:
-        r = await c.post(board_url, json=row, headers=headers)
-    if r.status_code not in (200, 201):
-        raise HTTPException(status_code=502, detail="could not nominate target")
-    created = r.json()
-    target = created[0] if isinstance(created, list) and created else created
+    #
+    # Unlike alert_rules/action_log, target_board has NO local-SQLite fallback
+    # yet — routes/targets.py's own docstring documents this as deliberate
+    # ("the route answers 503, the store stays local": the frontend Kanban
+    # already keeps a working copy) and docs/decisions.md lists it as still-
+    # deferred Phase-4 territory. So on a keyless boot we skip this
+    # supplementary remote persistence rather than 503ing the WHOLE governed
+    # action — the ontology reflection + audit trail below are what's actually
+    # load-bearing for C1's "no unaudited action" contract.
+    target: dict[str, Any] | None = None
+    if s.supabase_url:
+        board_url = s.supabase_url.rstrip("/") + "/rest/v1/target_board"
+        row = {
+            "user_id": ctx.user_id,
+            "entity_id": p.target_id,
+            "stage": "confirm",
+            "priority": p.priority,
+            "note": p.note,
+        }
+        headers = {
+            **_headers(ctx, s, write=True),
+            "Prefer": "resolution=merge-duplicates,return=representation",
+        }
+        async with _client() as c:
+            r = await c.post(board_url, json=row, headers=headers)
+        if r.status_code not in (200, 201):
+            raise HTTPException(status_code=502, detail="could not nominate target")
+        created = r.json()
+        target = created[0] if isinstance(created, list) and created else created
 
     # Reflect the nomination into the ontology so the board entry is a graph node.
     reg = get_registry(ctx, s)
@@ -249,12 +285,10 @@ async def _handle_nominate_target(
 async def _handle_add_watch(
     ctx: UserCtx, s: Settings, p: AddWatchParams
 ) -> ActionResult:
-    # Side effect: POST to the SAME alert_rules table routes/alert_rules.py owns.
-    if not s.supabase_url:
-        raise HTTPException(status_code=503, detail="Supabase is not configured")
-    rules_url = s.supabase_url.rstrip("/") + "/rest/v1/alert_rules"
-    row = {
-        "user_id": ctx.user_id,
+    # Side effect: create a standing geofence rule in the SAME store
+    # routes/alert_rules.py owns — local SQLite on a keyless boot (the exact
+    # ``_use_local`` predicate that route already uses), Supabase otherwise.
+    rule_body = {
         "label": p.label,
         "lat": p.lat,
         "lon": p.lon,
@@ -264,13 +298,18 @@ async def _handle_add_watch(
         "channel": "inapp",
         "enabled": True,
     }
-    headers = {**_headers(ctx, s, write=True), "Prefer": "return=representation"}
-    async with _client() as c:
-        r = await c.post(rules_url, json=row, headers=headers)
-    if r.status_code not in (200, 201):
-        raise HTTPException(status_code=502, detail="could not add watch")
-    created = r.json()
-    rule = created[0] if isinstance(created, list) and created else created
+    if not s.supabase_url:
+        rule = await alert_rules_local.create_rule(ctx.user_id, rule_body, settings=s)
+    else:
+        rules_url = s.supabase_url.rstrip("/") + "/rest/v1/alert_rules"
+        row = {**rule_body, "user_id": ctx.user_id}
+        headers = {**_headers(ctx, s, write=True), "Prefer": "return=representation"}
+        async with _client() as c:
+            r = await c.post(rules_url, json=row, headers=headers)
+        if r.status_code not in (200, 201):
+            raise HTTPException(status_code=502, detail="could not add watch")
+        created = r.json()
+        rule = created[0] if isinstance(created, list) and created else created
 
     reg = get_registry(ctx, s)
     await reg.upsert(Object(id=p.target_id))

--- a/apps/api/app/intel/agent.py
+++ b/apps/api/app/intel/agent.py
@@ -442,12 +442,19 @@ _WALL_BUDGET_S = 240.0
 _OBS_CHARS = 1800
 
 
-def _tool_catalog(*, with_actions: bool) -> str:
+def _tool_catalog(*, with_actions: bool, with_clarification: bool = True) -> str:
     """The tool menu shown to the model. Read-only tools always; the write-back
     actions + control tools are appended only when an authenticated user is
-    present (``with_actions``) so a keyless run is never told it can mutate."""
+    present (``with_actions``) so a keyless run is never told it can mutate.
+    ``request_clarification`` is a dead end for a headless caller (no operator
+    to answer it), so it's dropped from the catalog when ``with_clarification``
+    is False — same additive-gate idiom as ``with_actions``."""
     lines = [f"- {name}: {desc}" for name, (desc, _) in TOOLS.items()]
-    lines += [f"- {name}: {desc}" for name, desc in CONTROL_TOOLS.items()]
+    lines += [
+        f"- {name}: {desc}"
+        for name, desc in CONTROL_TOOLS.items()
+        if with_clarification or name != "request_clarification"
+    ]
     if with_actions:
         lines += [f"- {name}: {desc}" for name, desc in _ACTION_DESCRIPTIONS.items()]
         lines.append(
@@ -649,6 +656,11 @@ async def run_agent(
     ctx: UserCtx | None = None,
     clearance: int = 0,
     compartments: tuple[str, ...] = (),
+    *,
+    max_steps: int = _MAX_STEPS,
+    wall_budget_s: float = _WALL_BUDGET_S,
+    seed_brief: dict[str, Any] | None = None,
+    interactive: bool = True,
 ) -> AsyncIterator[dict[str, Any]]:
     """Yield the live agent trace as events: thinking | tool_call | tool_result |
     action | app_var | clarification | final | error | done. The route serialises
@@ -659,6 +671,14 @@ async def run_agent(
     ``intel/actions.dispatch`` (mutate + ``action_log`` row); without one the tools
     are hidden from the catalog and a stray call gets a "sign-in required"
     observation. The read-only tools + the control tools work either way.
+
+    Headless callers (e.g. the watch-officer background loop) pass keyword-only:
+    ``max_steps``/``wall_budget_s`` to fit inside their own cycle budget (the
+    module defaults are sized for an interactive caller); ``seed_brief`` to hand
+    over a fused brief ALREADY computed this cycle so the seed skips a second
+    ``incidents.brief()`` call; ``interactive=False`` to drop
+    ``request_clarification`` from the catalog (a dead end with no operator to
+    answer it).
     """
     t0 = time.monotonic()
     can_act = ctx is not None
@@ -683,7 +703,9 @@ async def run_agent(
         "thought": "Seed with the fused cross-domain picture before reasoning.",
     }
     seed_t = time.monotonic()
-    brief = await incidents.brief(bbox)
+    # A headless caller (watch-officer) may already have this cycle's fused brief —
+    # use it instead of re-fusing (that's the "double-fuse" this loop must avoid).
+    brief = seed_brief if seed_brief is not None else await incidents.brief(bbox)
     _index(brief)
     seed_summary = (
         f"{brief.get('incident_count', 0)} incidents · "
@@ -733,7 +755,12 @@ async def run_agent(
            "text": _narrate_brief(brief, changes, news_compact, _scope_label(bbox))}
 
     messages: list[dict[str, str]] = [
-        {"role": "system", "content": _SYS.format(catalog=_tool_catalog(with_actions=can_act))},
+        {
+            "role": "system",
+            "content": _SYS.format(
+                catalog=_tool_catalog(with_actions=can_act, with_clarification=interactive)
+            ),
+        },
         {
             "role": "user",
             "content": json.dumps(
@@ -766,8 +793,8 @@ async def run_agent(
 
     # ── gather loop: a FAST model drives quick tool calls (Claude-Code-style) ──
     evidence: list[str] = []
-    for step in range(1, _MAX_STEPS + 1):
-        if time.monotonic() - t0 > _WALL_BUDGET_S:
+    for step in range(1, max_steps + 1):
+        if time.monotonic() - t0 > wall_budget_s:
             yield {
                 "type": "note",
                 "text": "time budget reached — synthesising from evidence so far",

--- a/apps/api/app/intel/promotion.py
+++ b/apps/api/app/intel/promotion.py
@@ -44,6 +44,18 @@ def _entity_id_from_evidence(ev: dict[str, Any]) -> str | None:
     return None
 
 
+def stable_id(prefix: str, key: str) -> str:
+    """Deterministic ``<prefix>:<sha1(key)[:16]>`` — the same input key always
+    mints the same id, so repeated calls UPDATE one object instead of minting
+    a duplicate. Shared by ``_stable_incident_id`` below (keyed by
+    ``incident_key()``, auto-promoted convergences) and
+    ``actions.py``'s ``_handle_promote_incident`` (keyed by the target object
+    id being manually promoted) so both promotion paths mint idempotently.
+    """
+    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
+    return f"{prefix}:{digest}"
+
+
 def _stable_incident_id(incident: dict[str, Any]) -> str:
     """Deterministic incident:<id> so re-running UPDATES the same object.
 
@@ -53,9 +65,7 @@ def _stable_incident_id(incident: dict[str, Any]) -> str:
     "same real-world convergence" and is what watch_officer._BRIEFS is
     already keyed by.
     """
-    key = incident_key(incident)
-    digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
-    return f"incident:{digest}"
+    return stable_id("incident", incident_key(incident))
 
 
 async def promote_incident(

--- a/apps/api/app/intel/watch_officer.py
+++ b/apps/api/app/intel/watch_officer.py
@@ -3,13 +3,21 @@
 The operator senses far more than they can manually correlate. The cross-domain
 fusion (``incidents.brief``) already narrates + cites converged incidents; this
 loop watches its diff and, when a NEW or ESCALATED incident crosses into
-high/elevated, runs a playbook and files a finished draft brief for the operator
-to triage (ack / dismiss) in the Inbox — no operator labor to produce it.
+high/elevated, lets the real tool-calling agent (``intel.agent.run_agent``)
+actually reason about it — read-only, capped, seeded with THIS cycle's brief so
+it never re-fuses — and files a finished draft brief for the operator to triage
+(ack / dismiss) in the Inbox. The one hardwired response (dark-vessel → SAR
+tip-and-cue via ``cue.run``) still runs alongside it; both are per-cycle budgeted
+so a busy sweep degrades to "dropped + logged", never a firehose.
 
 In-memory + single-process (like ``routes.actions._PROPOSALS``): a restart drops
 open briefs, which is fine — the loop re-derives them on its next cycle. Lifecycle
 mirrors ``intel.watch`` (module ``_TASK``/``_STARTED`` + ``start``/``stop``),
-started from the app lifespan.
+started from the app lifespan. A second background task, ``_supervise``, watches
+the sweep loop's own liveness the way ``adsb_sidecar.supervise()`` watches the
+tar1090 sidecar: a wedged ``await`` inside ``run_once`` (an upstream that never
+returns) would otherwise freeze the loop forever while ``status()`` keeps
+reporting healthy.
 """
 
 from __future__ import annotations
@@ -21,7 +29,7 @@ import uuid
 from typing import Any
 
 from app.config import get_settings
-from app.intel import cue, incidents, promotion
+from app.intel import agent, cue, incidents, promotion
 from app.intel.incident_store import incident_key, incident_store
 from app.intel.ontology import get_registry
 from app.keys import UserCtx
@@ -33,14 +41,41 @@ _CYCLE_S = 120.0
 _MAX_BRIEFS = 100
 _ACTIONABLE = {"high", "elevated"}
 
+# Per-cycle outbound budgets (same shape as promotion.py's
+# MAX_INCIDENT_MINTS_PER_CYCLE): the agent run reaches a real LLM + tool
+# fan-out and the SAR cue reaches a real upstream (sar_vessels/CDSE), so both
+# get a hard per-sweep cap rather than firing once per actionable incident
+# unbounded. Hardcoded — no config.py setting for this slice (same reasoning
+# as promotion.py's own comment).
+_MAX_AGENT_RUNS_PER_CYCLE = 5
+_MAX_CUES_PER_CYCLE = 5
+
+# How long a single incidents.brief() await may run before this sweep gives up
+# and tries again next cycle — well under _CYCLE_S so a wedged upstream can't
+# starve the loop of its own sweep budget.
+_SWEEP_TIMEOUT_S = 45.0
+# Hard ceiling on the per-incident agent response, on top of run_agent's own
+# wall_budget_s check (which only fires between gather-loop steps) — a single
+# step's LLM call with no timeout of its own would otherwise wedge the sweep.
+_AGENT_WATCHDOG_MARGIN_S = 30.0
+# If no successful sweep lands within this many cycles, the loop is presumed
+# wedged (a hung await neither the sweep timeout nor run_agent's own budget
+# caught) and _supervise restarts the task.
+_STALL_CYCLES = 3
+
 # Human-readable roster of the automated responses the loop can run, surfaced in
 # the UI so the operator can see what the officer will DO on a hit — not just
 # that it files a brief. Keep in sync with ``_playbook``.
 PLAYBOOKS: tuple[dict[str, str], ...] = (
     {
+        "id": "agent-response",
+        "trigger": "high/elevated incident",
+        "action": "run the read-only tool-calling agent to investigate + assess (capped/cycle)",
+    },
+    {
         "id": "dark-vessel-sar",
         "trigger": "dark-vessel convergence",
-        "action": "task SAR imagery at the centroid (tip-and-cue)",
+        "action": "task SAR imagery at the centroid (tip-and-cue, capped/cycle)",
     },
     {
         "id": "promote-incident",
@@ -55,10 +90,14 @@ _SWEEPS = 0
 _TOTAL_FILED = 0
 _LAST_SWEEP_AT: float | None = None
 _LAST_FILED_AT: float | None = None
+_LOOP_STARTED_AT: float | None = None
 
 # Same shared local identity Foundry's build-runner / workflow scheduler
 # default to (keys.py:172's keyless fallback) — this loop runs headless, with
-# no request/caller ctx. See docs/ontology-autopopulation-plan.md §2.
+# no request/caller ctx. See docs/ontology-autopopulation-plan.md §2. Used for
+# the deterministic ontology writes (promotion, fired-marker) below; the
+# autonomous agent run below deliberately does NOT use this ctx (see its
+# call site) — a truthy ctx would hand it write-back authority.
 _LOCAL_CTX = UserCtx(user_id="local", token="")
 
 # key (incident_key) -> brief record. Keyed by incident_key so the same
@@ -75,11 +114,11 @@ def _title(inc: dict[str, Any]) -> str:
 
 
 async def _playbook(inc: dict[str, Any]) -> dict[str, Any]:
-    """Run the automated response for an incident; return what was done.
+    """Run the deterministic tip-and-cue response; return what was done.
 
-    MVP wires ONE playbook: dark-vessel convergence tasks SAR at the centroid via
-    tip-and-cue. Other playbooks (POL pull, OSINT investigate) are follow-ups — the
-    incident already carries ``follow_up`` for the operator meanwhile.
+    ONE hardwired playbook: dark-vessel convergence tasks SAR at the centroid via
+    tip-and-cue. Everything else is now the live agent's job (``_run_agent_response``
+    below) rather than another hardcoded branch here.
     """
     out: dict[str, Any] = {}
     domains = set(inc.get("domains") or [])
@@ -96,8 +135,66 @@ async def _playbook(inc: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _make_brief(key: str, inc: dict[str, Any], playbook: dict[str, Any]) -> dict[str, Any]:
-    return {
+def _wants_cue(inc: dict[str, Any]) -> bool:
+    """Would ``_playbook`` actually reach the SAR upstream for this incident?
+    Checked BEFORE calling it so the per-cycle cue budget only counts real
+    attempts, not incidents ``_playbook`` would have no-op'd on anyway."""
+    c = inc.get("centroid") or {}
+    return (
+        "dark-vessel" in (inc.get("domains") or [])
+        and c.get("lon") is not None
+        and c.get("lat") is not None
+    )
+
+
+async def _run_agent_response(inc: dict[str, Any], br: dict[str, Any]) -> dict[str, Any] | None:
+    """Let the real tool-calling agent think about ONE actionable incident.
+
+    Seeded with THIS cycle's already-fused brief (``seed_brief=br``) so it never
+    re-fuses. ``ctx=None`` (NOT ``_LOCAL_CTX``) is deliberate: ``_LOCAL_CTX`` is a
+    truthy ``UserCtx`` and ``run_agent`` gates its AUDITED write-back tools on
+    ``ctx is not None`` — passing it here would hand this autonomous, unattended
+    run flag_entity/promote_incident/nominate_target/add_watch by accident.
+    # ponytail: write-back authority for the autonomous watch-officer tier is a
+    # deliberate follow-up, not an oversight — this stage is read-only-tools only.
+    ``interactive=False`` additionally drops ``request_clarification`` (a dead
+    end with no operator to answer it). Capped to half the sweep cycle so one
+    incident's reasoning can never eat the whole cadence.
+    """
+    q = (
+        f"Investigate and assess: {_title(inc)}. "
+        f"{(inc.get('narrative') or '').strip()}"
+    ).strip()
+
+    async def _drain() -> dict[str, Any] | None:
+        final: dict[str, Any] | None = None
+        async for ev in agent.run_agent(
+            q,
+            None,
+            ctx=None,
+            max_steps=3,
+            wall_budget_s=_CYCLE_S / 2,
+            seed_brief=br,
+            interactive=False,
+        ):
+            if ev.get("type") == "final":
+                final = ev
+        return final
+
+    try:
+        return await asyncio.wait_for(_drain(), timeout=_CYCLE_S / 2 + _AGENT_WATCHDOG_MARGIN_S)
+    except TimeoutError:
+        log.warning("watch_officer: agent response timed out for %s", inc.get("id"))
+        return None
+    except Exception as exc:  # noqa: BLE001 — an agent failure must not sink the brief
+        log.warning("watch_officer: agent response failed for %s: %s", inc.get("id"), exc)
+        return None
+
+
+def _make_brief(
+    key: str, inc: dict[str, Any], playbook: dict[str, Any], agent_result: dict[str, Any] | None
+) -> dict[str, Any]:
+    rec = {
         "id": uuid.uuid4().hex[:12],
         "key": key,
         "created": time.time(),
@@ -111,6 +208,11 @@ def _make_brief(key: str, inc: dict[str, Any], playbook: dict[str, Any]) -> dict
         "playbook": playbook,
         "status": "open",
     }
+    if agent_result is not None:
+        rec["agent_assessment"] = agent_result.get("assessment")
+        rec["agent_findings"] = agent_result.get("findings")
+        rec["agent_follow_up"] = agent_result.get("follow_up")
+    return rec
 
 
 def _evict_if_full() -> None:
@@ -120,12 +222,16 @@ def _evict_if_full() -> None:
 
 
 async def run_once() -> int:
-    """One sweep: fuse → diff → file briefs for new/escalated high incidents.
+    """One sweep: fuse → diff → let the agent think + file briefs for new/
+    escalated high incidents.
 
     Returns the number of briefs filed this sweep.
     """
     try:
-        br = await incidents.brief()
+        br = await asyncio.wait_for(incidents.brief(), timeout=_SWEEP_TIMEOUT_S)
+    except TimeoutError:
+        log.warning("watch_officer: incidents.brief() timed out after %.0fs", _SWEEP_TIMEOUT_S)
+        return 0
     except Exception as exc:  # noqa: BLE001 — a fusion hiccup must not kill the loop
         log.debug("watch_officer: brief failed: %s", exc)
         return 0
@@ -139,6 +245,7 @@ async def run_once() -> int:
     diff = incident_store.record(_SCOPE, incs)
 
     actionable = [i for i in incs if i.get("threat_level") in _ACTIONABLE]
+    reg = None
     try:
         reg = get_registry(_LOCAL_CTX, get_settings())
         minted = await promotion.promote_incidents(
@@ -148,19 +255,76 @@ async def run_once() -> int:
             log.debug("watch_officer: promoted %d incident object(s)", len(minted))
     except Exception as exc:  # noqa: BLE001 — a promotion bug must not sink the loop
         log.debug("watch_officer: promotion failed: %s", exc)
+        reg = None
 
     filed = 0
+    agent_runs = 0
+    cues = 0
     for summary in [*diff.get("new", []), *diff.get("escalated", [])]:
         key = summary.get("key")
         if not key or key in _BRIEFS:
             continue
         if summary.get("threat_level") not in _ACTIONABLE:
             continue
+        # PRECONDITION (stale-facts guard): only act on an incident whose key is
+        # STILL present in THIS sweep's freshly-fused snapshot — a centroid the
+        # area tools derived from a fix that has since aged out must never task
+        # an outbound action. Deterministic, zero tokens: `inc is None` means the
+        # diff's summary no longer matches anything this sweep actually observed.
         inc = by_key.get(key)
         if inc is None:
             continue
-        playbook = await _playbook(inc)
-        _BRIEFS[key] = _make_brief(key, inc, playbook)
+
+        incident_id = promotion._stable_incident_id(inc) if reg is not None else None
+        already_fired = False
+        if reg is not None and incident_id is not None:
+            try:
+                obj = await reg.get(incident_id)
+                already_fired = bool(obj and obj.props.get("agent_fired"))
+            except Exception as exc:  # noqa: BLE001 — a read hiccup must not sink the brief
+                log.debug("watch_officer: fired-marker read failed for %s: %s", key, exc)
+
+        agent_result: dict[str, Any] | None = None
+        playbook: dict[str, Any] = {}
+        # Only mark the incident fired if an action ACTUALLY ran this sweep. A
+        # per-cycle cap that dropped both the agent run and the cue must leave the
+        # marker unwritten so the incident retries next cycle instead of being
+        # suppressed forever.
+        did_act = False
+        if not already_fired:
+            if agent_runs < _MAX_AGENT_RUNS_PER_CYCLE:
+                agent_runs += 1
+                agent_result = await _run_agent_response(inc, br)
+                did_act = True
+            else:
+                log.info(
+                    "watch_officer: per-cycle agent-run cap (%d) hit, dropping %s",
+                    _MAX_AGENT_RUNS_PER_CYCLE, key,
+                )
+
+            wants_cue = _wants_cue(inc)
+            if wants_cue and cues >= _MAX_CUES_PER_CYCLE:
+                log.info(
+                    "watch_officer: per-cycle cue cap (%d) hit, dropping %s",
+                    _MAX_CUES_PER_CYCLE, key,
+                )
+            else:
+                playbook = await _playbook(inc)
+                if wants_cue:
+                    cues += 1
+                    did_act = True
+
+            if did_act and reg is not None and incident_id is not None:
+                try:
+                    await reg.assert_props(
+                        incident_id,
+                        {"agent_fired": True, "agent_fired_at": time.time()},
+                        source="agent:watch_officer",
+                    )
+                except Exception as exc:  # noqa: BLE001 — marker write is best-effort
+                    log.debug("watch_officer: fired-marker write failed for %s: %s", key, exc)
+
+        _BRIEFS[key] = _make_brief(key, inc, playbook, agent_result)
         filed += 1
 
     _evict_if_full()
@@ -235,6 +399,7 @@ def reset_state() -> None:
 # ── background task lifecycle (mirrors intel.watch.start / stop) ─────────────────
 
 _TASK: asyncio.Task[None] | None = None
+_SUPERVISE_TASK: asyncio.Task[None] | None = None
 _STARTED = False
 
 
@@ -249,19 +414,78 @@ async def _run_forever() -> None:
         await asyncio.sleep(_CYCLE_S)
 
 
+async def _supervise(interval_s: float | None = None) -> None:
+    """Restart the sweep task if it has gone quiet.
+
+    ``run_once`` bounds its own awaits (``_SWEEP_TIMEOUT_S`` around ``brief()``,
+    a wrapped timeout around the per-incident agent run), so this is defense in
+    depth for a hang neither of those catches: if ``_LAST_SWEEP_AT`` (only
+    updated on a sweep that actually reached its body) hasn't advanced in
+    ``_STALL_CYCLES`` cycles, the loop task is presumed wedged and is cancelled +
+    replaced — the same shape as ``adsb_sidecar.supervise()`` for its browser
+    sidecar, for exactly the same failure mode: a hung await inside the loop
+    would otherwise freeze it forever while ``status()`` kept reporting healthy.
+
+    ``_CYCLE_S``/``_STALL_CYCLES`` are read fresh from the module each
+    iteration (not bound as defaults) so a test can monkeypatch them and see
+    the new cadence take effect on the very next sleep.
+    """
+    global _TASK
+    while True:
+        await asyncio.sleep(_CYCLE_S if interval_s is None else interval_s)
+        try:
+            if not _STARTED or _TASK is None:
+                continue
+            last = _LAST_SWEEP_AT or _LOOP_STARTED_AT or time.time()
+            age = time.time() - last
+            if age < _CYCLE_S * _STALL_CYCLES:
+                continue
+            if _TASK.done():
+                # Died on its own (shouldn't happen — _run_forever catches
+                # everything — but don't leave it dead either way).
+                log.warning("watch_officer: sweep task exited unexpectedly — restarting")
+            else:
+                log.warning(
+                    "watch_officer: no sweep completed in %.0fs — restarting wedged loop", age
+                )
+                _TASK.cancel()
+                try:
+                    await _TASK
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            _TASK = asyncio.create_task(_run_forever())
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — supervision must never die
+            log.warning("watch_officer: supervise error: %s", exc)
+
+
 async def start() -> None:
     """Start the watch-officer loop (idempotent). Safe to call once from lifespan."""
-    global _TASK, _STARTED
+    global _TASK, _STARTED, _SUPERVISE_TASK, _LOOP_STARTED_AT
     if _STARTED:
         return
     _STARTED = True
+    _LOOP_STARTED_AT = time.time()
     _TASK = asyncio.create_task(_run_forever())
+    _SUPERVISE_TASK = asyncio.create_task(_supervise())
 
 
 async def stop() -> None:
     """Cancel the loop and clear state (clean shutdown / test isolation)."""
-    global _TASK, _STARTED
+    global _TASK, _STARTED, _SUPERVISE_TASK
     _STARTED = False
+    # Cancel supervision BEFORE the loop task, or it can race the teardown below
+    # and restart the very task stop() is killing (same ordering _adsb_sidecar_
+    # /_ais_sidecar_ need in main.py, kept local here since both tasks are owned
+    # by this module).
+    if _SUPERVISE_TASK is not None:
+        _SUPERVISE_TASK.cancel()
+        try:
+            await _SUPERVISE_TASK
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        _SUPERVISE_TASK = None
     if _TASK is not None:
         _TASK.cancel()
         try:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -173,6 +173,18 @@ def _isolate_audit_db(tmp_path: Path) -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_action_log_db(tmp_path: Path) -> Iterator[None]:
+    """Point the local action_log sink at a per-test temp file (mirrors
+    alert_rules) — without this every keyless governed-write test would write
+    ``./data/action_log.db`` into the repo's real data dir."""
+    from app.intel import action_log_local
+
+    action_log_local.override_db_path(str(tmp_path / "action_log.db"))
+    yield
+    action_log_local.override_db_path(None)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_evidence_dir(tmp_path: Path) -> Iterator[None]:
     """Point the evidence-locker blob dir at a per-test temp dir (mirrors the
     ontology/foundry isolation) — route handlers resolve ``evidence_dir`` via

--- a/apps/api/tests/test_actions.py
+++ b/apps/api/tests/test_actions.py
@@ -1,7 +1,8 @@
 """Governed write-back actions — pure-logic + dispatch units (hermetic).
 
 Covers: audit-row shape, registry dispatch (unknown action → 404, bad params →
-400), the route auth gate + 503 contract, and a full happy-path dispatch of
+400), the route auth gate + keyless-boot 200 contract, and a full happy-path
+dispatch of
 flag_entity / nominate_target / add_watch over a mocked PostgREST so the ontology
 mutation + side effect + audit append are all exercised without a network.
 """
@@ -103,16 +104,19 @@ def test_catalog_route_ok_when_authed(client: TestClient) -> None:
         client.app.dependency_overrides.pop(current_user, None)
 
 
-def test_action_503_when_supabase_unconfigured(client: TestClient) -> None:
-    # flag_entity touches the ontology store first; with no supabase_url the
-    # registry raises 503 — the store-not-configured contract.
+def test_action_200_when_supabase_unconfigured(client: TestClient) -> None:
+    # flag_entity touches the ontology store first (local-first since
+    # 2026-07-07, always available); the audit append also falls back to a
+    # local SQLite sink on a keyless boot (test_actions_local.py), so a
+    # missing supabase_url no longer 503s the whole action.
     client.app.dependency_overrides[current_user] = _fake_user
     try:
         r = client.post(
             "/api/actions/flag_entity",
             json={"target_id": "aircraft:abc", "note": "loitering"},
         )
-        assert r.status_code == 503
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
     finally:
         client.app.dependency_overrides.pop(current_user, None)
 

--- a/apps/api/tests/test_actions_local.py
+++ b/apps/api/tests/test_actions_local.py
@@ -1,0 +1,159 @@
+"""Governed write-back on a keyless boot (``Settings(supabase_url="")``).
+
+Before this module existed, ``intel/actions.py``'s ``_append_audit`` had
+exactly one backend (Supabase PostgREST ``action_log``) and 503'd/502'd on
+every dispatch once the local-only ontology store (2026-07-07,
+docs/decisions.md) made the ontology mutation itself succeed but the audit
+step still hit an unconfigured Supabase URL. Proven pre-fix (this exact call,
+against the code before this file's sibling changes)::
+
+    dispatch("flag_entity", {"target_id": "aircraft:proof", "note": "x"},
+              UserCtx("u1", "tok"), Settings(supabase_url=""))
+    -> HTTPException 503 "Supabase is not configured"
+
+These tests hit ``dispatch`` directly (no mocking) against a keyless
+``Settings`` and assert the governed write-backs succeed with a
+locally-persisted, readable-back audit trail instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.config import Settings
+from app.intel import action_log_local, alert_rules_local
+from app.intel.actions import dispatch
+from app.intel.ontology_local import SqliteRegistry
+from app.keys import UserCtx
+
+
+@pytest.fixture(autouse=True)
+def _isolate_action_log_db(tmp_path):
+    """Point the new local action_log sink at a per-test temp file — mirrors
+    conftest's ``_isolate_ontology_db`` / ``_isolate_alert_rules_db``, kept
+    local to this file since ``action_log_local`` has no conftest hook yet."""
+    action_log_local.override_db_path(str(tmp_path / "action_log.db"))
+    yield
+    action_log_local.override_db_path(None)
+
+
+def _ctx() -> UserCtx:
+    return UserCtx("u1", "tok")
+
+
+def _keyless() -> Settings:
+    return Settings(supabase_url="")
+
+
+# ── 1a: local action_log sink ──────────────────────────────────────────────
+
+
+def test_flag_entity_succeeds_and_audit_reads_back_locally() -> None:
+    res = asyncio.run(
+        dispatch(
+            "flag_entity",
+            {"target_id": "aircraft:proof", "note": "loitering", "severity": 4},
+            _ctx(),
+            _keyless(),
+        )
+    )
+    assert res.ok is True
+    assert res.audit["action"] == "flag_entity"
+    assert res.audit["target_id"] == "aircraft:proof"
+
+    rows = asyncio.run(action_log_local.list_rows())
+    assert any(
+        r["action"] == "flag_entity" and r["target_id"] == "aircraft:proof"
+        for r in rows
+    )
+    match = next(r for r in rows if r["target_id"] == "aircraft:proof")
+    assert match["user_id"] == "u1"
+    assert match["params"]["note"] == "loitering"
+
+
+# ── 1b: nominate_target / add_watch no longer 503 early ───────────────────
+
+
+def test_nominate_target_keyless_skips_board_instead_of_503() -> None:
+    res = asyncio.run(
+        dispatch(
+            "nominate_target",
+            {"target_id": "vessel:1", "priority": 2, "note": "dark"},
+            _ctx(),
+            _keyless(),
+        )
+    )
+    assert res.ok is True
+    # No local target_board store exists (deliberately deferred) — the
+    # supplementary board reflection is skipped, not sunk into a 503.
+    assert res.detail["target_board_entry"] is None
+    rows = asyncio.run(action_log_local.list_rows())
+    assert any(r["action"] == "nominate_target" for r in rows)
+
+
+def test_add_watch_keyless_persists_to_local_alert_rules_store() -> None:
+    res = asyncio.run(
+        dispatch(
+            "add_watch",
+            {
+                "target_id": "aircraft:y",
+                "label": "Hormuz watch",
+                "lat": 26.5,
+                "lon": 56.3,
+                "radius_nm": 80,
+                "kinds": ["jamming"],
+            },
+            _ctx(),
+            _keyless(),
+        )
+    )
+    assert res.ok is True
+    assert res.detail["alert_rule"]["id"]
+
+    rules = asyncio.run(alert_rules_local.list_rules("u1", settings=_keyless()))
+    assert any(r["label"] == "Hormuz watch" for r in rules)
+
+
+# ── 1c: stable incident id + correct evidence_of direction ────────────────
+
+
+def test_promote_incident_is_idempotent_not_uuid4_per_call() -> None:
+    res1 = asyncio.run(
+        dispatch(
+            "promote_incident",
+            {"target_id": "aircraft:dup", "title": "first"},
+            _ctx(),
+            _keyless(),
+        )
+    )
+    res2 = asyncio.run(
+        dispatch(
+            "promote_incident",
+            {"target_id": "aircraft:dup", "title": "second approval"},
+            _ctx(),
+            _keyless(),
+        )
+    )
+    # Approving the same promotion twice must land on ONE incident node, not
+    # mint a second uuid4-keyed one.
+    assert res1.target_id == res2.target_id
+
+
+def test_promote_incident_evidence_of_edge_points_target_to_incident() -> None:
+    res = asyncio.run(
+        dispatch(
+            "promote_incident",
+            {"target_id": "aircraft:evd", "title": "t"},
+            _ctx(),
+            _keyless(),
+        )
+    )
+    reg = SqliteRegistry(_ctx(), _keyless())
+    links = asyncio.run(reg._links_touching(["aircraft:evd"]))
+    evidence_links = [lk for lk in links if lk.rel == "evidence_of"]
+    assert evidence_links, "expected an evidence_of edge to the incident"
+    # Canonical direction (ontology.py KNOWN_RELS): member entity -> incident.
+    assert evidence_links[0].src == "aircraft:evd"
+    assert evidence_links[0].dst == res.target_id

--- a/apps/api/tests/test_agent_budget.py
+++ b/apps/api/tests/test_agent_budget.py
@@ -1,0 +1,230 @@
+"""``run_agent`` per-call budget + headless mode (Stage 2).
+
+Watch-officer (Stage 3) drives ``run_agent`` from a background loop, which
+diverges from the interactive /api/intel/agent route in three ways: it needs a
+SMALLER wall budget than the interactive default (240s would blow through the
+watch-officer's own 120s cycle), it has ALREADY computed this cycle's fused
+brief and must not pay for a second ``incidents.brief()`` call, and it has no
+operator to answer a ``request_clarification``. These tests are hermetic (the
+LLM is a scripted fake, brief/news/history are stubbed) and prove: (1)
+``max_steps`` actually bounds the gather loop, (2) ``seed_brief`` actually
+skips the seed's ``incidents.brief()`` call, (3) the existing-style call
+(no new kwargs) is untouched — still 6 steps / 240s — and (4) ``interactive``
+gates ``request_clarification`` out of the catalog the same way ``with_actions``
+gates the write-back tools.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import pytest
+
+from app.intel import agent
+from app.intel.geo import BBox
+from app.keys import UserCtx
+
+# ── scripted-LLM fake (same shape as test_agent_actions.py's) ────────────────
+
+
+class _FakeLlmResult:
+    def __init__(self, text: str | None) -> None:
+        self.text = text
+        self.usage: dict[str, Any] = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        self.backend = "fake"
+        self.model = "fake/scripted"
+        self.error = None
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.text)
+
+
+def _script_llm(monkeypatch: pytest.MonkeyPatch, turns: list[dict[str, Any]]) -> list[dict]:
+    """Replace ``agent.llm.chat_json`` with a fake that returns ``turns`` in order,
+    then a benign ``done`` forever once exhausted (so a synthesis call at the end
+    never blows up). Records every call's kwargs so a test can tell a GATHER call
+    (``fast=True``) from the SYNTHESIS call (``tier="reason"``) apart."""
+    calls: list[dict] = []
+    queue = list(turns)
+
+    async def fake_chat_json(messages: list[dict], **kwargs: Any) -> tuple[Any, _FakeLlmResult]:
+        calls.append({"messages": messages, **kwargs})
+        obj = queue.pop(0) if queue else {"action": "done", "say": "done."}
+        return obj, _FakeLlmResult(text="{}")
+
+    monkeypatch.setattr(agent.llm, "chat_json", fake_chat_json)
+    return calls
+
+
+def _stub_seed(monkeypatch: pytest.MonkeyPatch, *, brief_calls: list[Any] | None = None) -> None:
+    """Neutralise the agent's seed I/O so the loop is hermetic — no
+    global_snapshot fetch, no news engine, no watch loop. If ``brief_calls`` is
+    given, every ``incidents.brief`` call appends to it (so a test can assert
+    it was never invoked when ``seed_brief`` was supplied instead)."""
+
+    async def fake_brief(_bbox: BBox | None, **_k: Any) -> dict[str, Any]:
+        if brief_calls is not None:
+            brief_calls.append(_bbox)
+        return {
+            "incident_count": 0,
+            "by_level": {},
+            "top_threat_level": None,
+            "signals_considered": 0,
+            "incidents": [],
+        }
+
+    monkeypatch.setattr(agent.incidents, "brief", fake_brief)
+    monkeypatch.setattr(agent, "_world_news", _disabled_news)
+    monkeypatch.setattr(
+        agent.incident_store, "last_changes", lambda _scope: {"had_baseline": False}
+    )
+
+
+async def _disabled_news() -> dict[str, Any]:
+    return {"enabled": False, "note": "off"}
+
+
+def _tool_call_events(events: list[dict[str, Any]], tool: str) -> list[dict[str, Any]]:
+    return [e for e in events if e["type"] == "tool_call" and e.get("tool") == tool]
+
+
+async def _drain(q: str, bbox: BBox | None, ctx: UserCtx | None, **kw: Any) -> list[dict[str, Any]]:
+    """Run the agent to completion, collecting every emitted event."""
+    return [ev async for ev in agent.run_agent(q, bbox, ctx, **kw)]
+
+
+# ── check 1: max_steps bounds the gather loop ────────────────────────────────
+
+
+def test_max_steps_bounds_the_gather_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_seed(monkeypatch)
+    # control_view is a pure view-nudge tool — no dispatch, no live-data fetch —
+    # so it's safe to call repeatedly in a hermetic test. Queue far MORE turns
+    # than max_steps so the model is always "requesting another tool".
+    calls = _script_llm(
+        monkeypatch,
+        [{"action": "tool", "tool": "control_view", "args": {}} for _ in range(5)],
+    )
+
+    events = asyncio.run(_drain("status check", None, UserCtx("u1", "tok"), max_steps=2))
+
+    # Exactly 2 tool-calling steps reached the trace, not 5 and not the module
+    # default of 6.
+    assert len(_tool_call_events(events, "control_view")) == 2
+    # And exactly 2 GATHER calls (fast=True) were made to the LLM — the 3rd
+    # chat_json call on record, if any, is the synthesis call (tier="reason").
+    gather_calls = [c for c in calls if c.get("fast")]
+    assert len(gather_calls) == 2
+    assert events[-1]["type"] == "done"
+
+
+# ── check 2: seed_brief skips the seed's incidents.brief() call ──────────────
+
+
+def test_seed_brief_skips_incidents_brief_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    brief_calls: list[Any] = []
+    _stub_seed(monkeypatch, brief_calls=brief_calls)
+    _script_llm(monkeypatch, [{"action": "done", "say": "ok"}])
+
+    injected = {
+        "incident_count": 3,
+        "by_level": {"high": 1, "elevated": 2},
+        "top_threat_level": "high",
+        "signals_considered": 42,
+        "incidents": [
+            {
+                "id": "inc-1",
+                "threat_level": "high",
+                "domains": ["dark-vessel"],
+                "signal_count": 4,
+                "centroid": {"lat": 1.0, "lon": 2.0},
+                "narrative": "test convergence",
+            }
+        ],
+    }
+
+    events = asyncio.run(
+        _drain("what changed", None, UserCtx("u1", "tok"), seed_brief=injected)
+    )
+
+    # incidents.brief() was NEVER called — the injected dict was used as-is.
+    assert brief_calls == []
+    # The seed still narrates + indexes the INJECTED brief (proves it was
+    # actually threaded through, not silently dropped).
+    tool_results = [
+        e for e in events if e["type"] == "tool_result" and e.get("tool") == "intel_brief"
+    ]
+    assert len(tool_results) == 1
+    assert "3 incidents" in tool_results[0]["summary"]
+    narrations = [e for e in events if e["type"] == "narration" and e.get("step") == 0]
+    assert narrations and "3 active convergence" in narrations[0]["text"]
+
+
+# ── check 3: existing-style call keeps the old defaults ──────────────────────
+
+
+def test_defaults_unchanged_for_existing_style_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The declared defaults are still exactly the module constants.
+    sig = inspect.signature(agent.run_agent)
+    assert sig.parameters["max_steps"].default == agent._MAX_STEPS == 6
+    assert sig.parameters["wall_budget_s"].default == agent._WALL_BUDGET_S == 240.0
+
+    _stub_seed(monkeypatch)
+    # Queue MORE turns than the default step budget to prove the loop still
+    # stops at 6, not fewer and not more, with no new kwargs passed at all —
+    # the exact call shape routes/intel.py uses today.
+    calls = _script_llm(
+        monkeypatch,
+        [{"action": "tool", "tool": "control_view", "args": {}} for _ in range(8)],
+    )
+
+    events = asyncio.run(_drain("status check", None, UserCtx("u1", "tok")))
+
+    assert len(_tool_call_events(events, "control_view")) == 6
+    gather_calls = [c for c in calls if c.get("fast")]
+    assert len(gather_calls) == 6
+
+
+# ── check 4: interactive=False gates request_clarification like with_actions ─
+
+
+def test_interactive_false_hides_clarification_from_catalog() -> None:
+    cat_interactive = agent._tool_catalog(with_actions=False, with_clarification=True)
+    cat_headless = agent._tool_catalog(with_actions=False, with_clarification=False)
+    assert "request_clarification" in cat_interactive
+    assert "request_clarification" not in cat_headless
+    # control_view is a view nudge, not a clarification — stays either way.
+    assert "control_view" in cat_headless
+
+
+def test_tool_catalog_default_keeps_clarification() -> None:
+    # No with_clarification arg at all (the shape every existing caller uses) —
+    # behaviour must be identical to before this change.
+    assert "request_clarification" in agent._tool_catalog(with_actions=False)
+
+
+def test_interactive_false_threads_through_to_tool_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # End-to-end: run_agent(interactive=False) must actually call
+    # _tool_catalog(with_clarification=False) — not just that the helper
+    # supports the flag. (The static _SYS prose separately NAMES
+    # request_clarification as a behaviour note; that's out of scope here —
+    # see agent.py's docstring on why _SYS itself is untouched.)
+    _stub_seed(monkeypatch)
+    _script_llm(monkeypatch, [{"action": "done", "say": "ok"}])
+    seen: list[dict[str, Any]] = []
+    real_catalog = agent._tool_catalog
+
+    def spy_catalog(*, with_actions: bool, with_clarification: bool = True) -> str:
+        seen.append({"with_actions": with_actions, "with_clarification": with_clarification})
+        return real_catalog(with_actions=with_actions, with_clarification=with_clarification)
+
+    monkeypatch.setattr(agent, "_tool_catalog", spy_catalog)
+
+    asyncio.run(_drain("status check", None, UserCtx("u1", "tok"), interactive=False))
+
+    assert seen == [{"with_actions": True, "with_clarification": False}]

--- a/apps/api/tests/test_watch_officer.py
+++ b/apps/api/tests/test_watch_officer.py
@@ -9,8 +9,23 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from app.intel import cue, incidents, watch_officer
+import pytest
+
+from app.intel import agent, cue, incidents, watch_officer
 from app.intel.incident_store import incident_store
+
+
+@pytest.fixture(autouse=True)
+def _stub_agent(monkeypatch) -> None:
+    """Stub the tool-calling agent that run_once() now invokes per incident.
+
+    This file tests the loop's file/dedup/triage contract, not the LLM — the
+    real-agent wiring is covered by test_watch_officer_agent.py. Without this the
+    suite would drive the live local model once per incident (~72s each).
+    """
+    async def fake_run_agent(*a, **k):
+        yield {"type": "final", "assessment": "stub", "findings": [], "follow_up": []}
+    monkeypatch.setattr(agent, "run_agent", fake_run_agent)
 
 
 def _incident(level: str, domains: list[str], lon: float, lat: float) -> dict[str, Any]:

--- a/apps/api/tests/test_watch_officer_agent.py
+++ b/apps/api/tests/test_watch_officer_agent.py
@@ -1,0 +1,218 @@
+"""Watch-officer Stage 3 — agent wiring, per-cycle ceilings, idempotency, watchdog.
+
+``incidents.brief``/``cue.run`` are stubbed (as in test_watch_officer.py); here
+``agent.run_agent`` is ALSO stubbed so these tests exercise our dispatch/budget/
+dedup contract, never a real LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from app.intel import agent, cue, incidents, watch_officer
+from app.intel.incident_store import incident_store
+from app.intel.ontology import get_registry
+
+
+def _incident(level: str, domains: list[str], lon: float, lat: float, iid: str = "x") -> dict[str, Any]:
+    return {
+        "id": iid,
+        "threat_level": level,
+        "score": 12.0,
+        "domains": domains,
+        "centroid": {"lon": lon, "lat": lat},
+        "narrative": f"{level} {'+'.join(domains)}",
+        "evidence": [{"domain": domains[0], "severity": "high", "summary": "s",
+                      "lon": lon, "lat": lat, "ref": "r", "kind": "measured"}],
+        "follow_up": ["look here"],
+    }
+
+
+def _reset(scope: str = "watch-officer") -> None:
+    watch_officer.reset_state()
+    incident_store._history.pop(scope, None)
+    incident_store._last_changes.pop(scope, None)
+
+
+def _stub_brief(incs: list[dict[str, Any]], monkeypatch) -> None:
+    async def fake_brief(*a, **k) -> dict[str, Any]:
+        return {"incidents": incs}
+    monkeypatch.setattr(incidents, "brief", fake_brief)
+
+
+def _stub_agent(monkeypatch, calls: list[Any]) -> None:
+    async def fake_run_agent(q, bbox, **kwargs):
+        calls.append((q, kwargs.get("ctx"), kwargs.get("interactive"), kwargs.get("max_steps")))
+        yield {"type": "final", "assessment": "stubbed", "findings": [], "follow_up": []}
+    monkeypatch.setattr(agent, "run_agent", fake_run_agent)
+
+
+def _stub_cue(monkeypatch, calls: list[Any]) -> None:
+    async def fake_cue(lon: float, lat: float) -> dict[str, Any]:
+        calls.append((lon, lat))
+        return {"status": "ok", "aoi": "hormuz"}
+    monkeypatch.setattr(cue, "run", fake_cue)
+
+
+def _wipe_ontology(*incident_ids: str) -> None:
+    """Best-effort local-registry cleanup so a stable id from a prior test
+    doesn't carry an ``agent_fired`` marker into this one."""
+    reg = get_registry(watch_officer._LOCAL_CTX, __import__("app.config", fromlist=["get_settings"]).get_settings())
+
+    async def _wipe() -> None:
+        for oid in incident_ids:
+            obj = await reg.get(oid)
+            if obj is not None:
+                await reg.assert_props(oid, {"agent_fired": False}, source="test")
+
+    asyncio.run(_wipe())
+
+
+# ── 3a: run_agent replaces the hardcoded branch, read-only (ctx=None) ────────
+
+
+def test_actionable_incident_runs_agent_read_only(monkeypatch) -> None:
+    _reset()
+    agent_calls: list[Any] = []
+    _stub_agent(monkeypatch, agent_calls)
+    _stub_brief([_incident("high", ["military"], 5.0, 5.0, "a1")], monkeypatch)
+
+    filed = asyncio.run(watch_officer.run_once())
+
+    assert filed == 1
+    assert len(agent_calls) == 1
+    _q, ctx, interactive, max_steps = agent_calls[0]
+    # ctx must be None (NOT the truthy _LOCAL_CTX) — withholds write-back tools.
+    assert ctx is None
+    assert interactive is False
+    assert max_steps == 3
+    brief = watch_officer.list_briefs()[0]
+    assert brief["agent_assessment"] == "stubbed"
+
+
+# ── check 1 + 2: fires once per convergence; new/absent/reappear dedup ───────
+
+
+def test_action_fires_once_then_not_again_when_resolved_then_reappears(monkeypatch) -> None:
+    _reset()
+    agent_calls: list[Any] = []
+    cue_calls: list[Any] = []
+    _stub_agent(monkeypatch, agent_calls)
+    _stub_cue(monkeypatch, cue_calls)
+
+    inc = _incident("elevated", ["dark-vessel"], 56.3, 26.5, "v1")
+    from app.intel import promotion
+    _wipe_ontology(promotion._stable_incident_id(inc))
+
+    # Sweep 1: incident present + actionable → agent + cue both fire once.
+    _stub_brief([inc], monkeypatch)
+    filed1 = asyncio.run(watch_officer.run_once())
+    assert filed1 == 1
+    assert len(agent_calls) == 1
+    assert len(cue_calls) == 1
+
+    # Sweep 2: incident resolved (absent this sweep) → no action attempt.
+    _stub_brief([], monkeypatch)
+    filed2 = asyncio.run(watch_officer.run_once())
+    assert filed2 == 0
+    assert len(agent_calls) == 1
+    assert len(cue_calls) == 1
+
+    # Sweep 3: SAME incident_key reappears → incident_store reports it "new"
+    # again, but the persisted fired-marker must prevent a second real action.
+    _stub_brief([inc], monkeypatch)
+    filed3 = asyncio.run(watch_officer.run_once())
+    # A brief may legitimately re-file (operator should still see it again),
+    # but the action must NOT re-fire.
+    assert len(agent_calls) == 1, "agent must not re-fire for an already-fired incident"
+    assert len(cue_calls) == 1, "cue must not re-fire for an already-fired incident"
+    assert filed3 in (0, 1)
+
+
+# ── check 4: per-cycle ceilings drop + log ────────────────────────────────────
+
+
+def test_agent_run_cap_drops_and_logs(monkeypatch, caplog) -> None:
+    _reset()
+    agent_calls: list[Any] = []
+    _stub_agent(monkeypatch, agent_calls)
+    monkeypatch.setattr(watch_officer, "_MAX_AGENT_RUNS_PER_CYCLE", 1)
+
+    from app.intel import promotion
+    incs = [
+        _incident("high", ["military"], 1.0, 1.0, "n1"),
+        _incident("high", ["military"], 2.0, 2.0, "n2"),
+    ]
+    _wipe_ontology(*(promotion._stable_incident_id(i) for i in incs))
+    _stub_brief(incs, monkeypatch)
+
+    with caplog.at_level(logging.INFO, logger="app.watch_officer"):
+        filed = asyncio.run(watch_officer.run_once())
+
+    assert filed == 2  # both still get briefs filed
+    assert len(agent_calls) == 1  # but only ONE agent run happened
+    assert any("agent-run cap" in r.message for r in caplog.records)
+
+
+def test_cue_cap_drops_and_logs(monkeypatch, caplog) -> None:
+    _reset()
+    agent_calls: list[Any] = []
+    cue_calls: list[Any] = []
+    _stub_agent(monkeypatch, agent_calls)
+    _stub_cue(monkeypatch, cue_calls)
+    monkeypatch.setattr(watch_officer, "_MAX_CUES_PER_CYCLE", 1)
+
+    from app.intel import promotion
+    incs = [
+        _incident("elevated", ["dark-vessel"], 10.0, 10.0, "d1"),
+        _incident("elevated", ["dark-vessel"], 11.0, 11.0, "d2"),
+    ]
+    _wipe_ontology(*(promotion._stable_incident_id(i) for i in incs))
+    _stub_brief(incs, monkeypatch)
+
+    with caplog.at_level(logging.INFO, logger="app.watch_officer"):
+        filed = asyncio.run(watch_officer.run_once())
+
+    assert filed == 2
+    assert len(cue_calls) == 1
+    assert any("cue cap" in r.message for r in caplog.records)
+
+
+# ── 3d: a wedged run_once gets the loop restarted, not left frozen ───────────
+
+
+def test_watchdog_restarts_wedged_loop(monkeypatch) -> None:
+    _reset()
+    monkeypatch.setattr(watch_officer, "_CYCLE_S", 0.02)
+    monkeypatch.setattr(watch_officer, "_STALL_CYCLES", 1)
+
+    hung = asyncio.Event()
+    calls = {"n": 0}
+
+    async def fake_run_once() -> int:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await hung.wait()  # never set — this call hangs forever
+            return 0
+        watch_officer._LAST_SWEEP_AT = __import__("time").time()
+        return 0
+
+    monkeypatch.setattr(watch_officer, "run_once", fake_run_once)
+
+    async def _drive() -> None:
+        await watch_officer.start()
+        try:
+            # Give the wedged first sweep a moment to start, then let the
+            # supervisor (interval = _CYCLE_S = 0.02s) notice the stall
+            # (age >= _CYCLE_S * _STALL_CYCLES) and restart the loop task.
+            for _ in range(200):
+                await asyncio.sleep(0.02)
+                if calls["n"] >= 2:
+                    break
+        finally:
+            await watch_officer.stop()
+
+    asyncio.run(_drive())
+    assert calls["n"] >= 2, "watchdog never restarted the wedged loop task"


### PR DESCRIPTION
## The one piece of stranded work

Recovers `92415bc` from `agent-system-autonomy-2026-07`, the only commit on any
local branch whose content is not already on master.

`apps/api/app/intel/action_log_local.py` (new), plus the governed write-back
path, watch-officer reasoning, agent budget, and ~600 lines of tests across
`test_actions_local.py`, `test_agent_budget.py`, `test_watch_officer_agent.py`.
11 files, +1146/-73.

## Why only one commit

I went looking for stranded work across 16 local branches. `git cherry` reported
110 unmerged commits, which is misleading: PRs #53-#58 and #60 were all
**squash-merged**, and squashing rewrites patch-ids, so every commit in those
branches looks absent while its content is on master. Verified per branch by
finding the squash commit and matching each subject:

| branch | reality |
|---|---|
| `overnight-hardening-2026-07-18` | merged, #53 (`91b55be`) |
| `worldmonitor-gaps-2026-07` | merged, #57 (`af3ca08`) |
| `history-cache-density` | merged, #54 |
| `layers-panel-legibility-pr` | merged, #55 (`b7dcf2a`) |
| `layers-panel-color` | merged, #56 (`7798361`) |
| `fix-ci-spa-dist-tests` | merged, #58 |
| `fix/sidecar-chrome-renderer-leak` | merged, #60 (`2ff71f9`) |
| `rot-fixes-launch-plan`, `intel-depth-polish` | merged, #41 and direct commits |
| `agent-system-autonomy-2026-07` | 4 of 5 commits absorbed into #57; **1 stranded** |
| 6 others | 0 unmerged, fully absorbed |

Bundling those branches into one integration branch, which is what I was asked
for and started doing, would have re-applied already-merged work and, worse,
resolved conflicts in `history.py`, `ratelimit.py`, `LeftIconRail.tsx` and
`AppSurface.tsx` in favour of month-old versions, silently reverting newer master
work. The trial merge conflicted in all six. That is why this is one cherry-pick
instead.

## Conflict resolved

One, in `apps/api/tests/conftest.py`: master had added an `_isolate_audit_db`
autouse fixture and this commit adds `_isolate_action_log_db`. Both kept, since
they isolate different sqlite files and dropping either lets a test write into
the repo's real data dir.

## Verification

Not run locally on this branch by request. CI is the gate.
