### PR TITLE
RAM benchmark harness + lite profile tightening + adaptive layer governor

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,22 +542,25 @@ GPU (`chrome://gpu`, look for adapter "ACTIVE").
 
 | Tier | GPU | RAM | Display | What you get |
 |---|---|---|---|---|
-| Minimum | WebGL2 integrated (Iris Xe / Vega / M1) | 8 GB | 1080p | 2D-dark, regional zoom, ~30 fps. 3D-sat will be rough. |
-| Recommended | Discrete ≥8 GB VRAM (RTX 3060 / RX 6700 / M-Pro) | 16 GB | 1080p–1440p | 2D-dark smooth; 3D-sat usable at city scale. |
-| 3D-sat / 4K | RTX 4070+/16 GB VRAM or better | 32 GB | up to 4K | Full 3D-sat terrain + buildings; high fps. |
+| Edge / lite | WebGL2 integrated (Iris Xe / Vega / M1) | 8 GB | 1080p | `OSINT_PROFILE=lite` (default). 9k aircraft, 32k vessels, 2D-dark. Backend fits in ~1.5 GB; the adaptive governor sheds low-priority layers to keep frames under budget. |
+| Recommended | Discrete ≥8 GB VRAM (RTX 3060 / RX 6700 / M-Pro) | 16 GB | 1080p–1440p | Full profile with all feeds. 2D-dark smooth; 3D-sat usable at city scale. |
+| Full / 3D-sat | RTX 4070+/16 GB VRAM or better | 32 GB | up to 4K | All feeds + browser sidecars + 3D-sat terrain + buildings; best frame rate. |
 
-These tiers come from watching it actually run. 3D-sat genuinely wants a lot of
-VRAM, and the low-VRAM minimum only holds for the 2D-dark map; switch on 3D-sat
-and you'll want a discrete card with headroom.
+These tiers come from a cgroup-isolated benchmark (`tools/perf/bench_ram.sh`)
+that constrains backend + Vite + Chrome inside a single MemoryMax and measures
+real fps, renderMs, entity counts, and OOM kills at each RAM level. 3D-sat
+genuinely wants a lot of VRAM, and the low-VRAM minimum only holds for the
+2D-dark map; switch on 3D-sat and you'll want a discrete card with headroom.
 
-**Backend (server):** Python 3.12, outbound HTTPS, measured steady-state
-~3.2 GB backend RSS with the full feed set warm. Runs on a small VPS or the
-same box, and it isn't the frontend's bottleneck. The optional headless-Chrome
-coverage sidecars are the real memory line item: the ADS-B scraping tier
-measured ~11 GB RSS across its ~50-process Chrome tree and the AIS tier
-~3-6 GB across its ~20-36 (both measured 2026-07-24 at full coverage), so
-budget roughly 15 GB on top of the backend when both are enabled — or skip
-them and keep the lighter direct feeds.
+**Backend (server):** Python 3.12, outbound HTTPS. The `lite` profile
+(default) disables browser sidecars, history, and the FR24/OpenSky-gaps tiers,
+measuring ~530 MB steady-state RSS — comfortably fits an 8 GB box alongside
+the browser. The `full` profile with all direct feeds warm measures ~3.2 GB.
+The optional headless-Chrome coverage sidecars are the real memory line item:
+the ADS-B scraping tier measured ~11 GB RSS across its ~50-process Chrome tree
+and the AIS tier ~3-6 GB across its ~20-36 (both measured 2026-07-24 at full
+coverage), so budget roughly 15 GB on top of the backend when both are
+enabled — or keep `lite` and use the direct feeds.
 
 ## Stack
 

--- a/apps/api/app/profile.py
+++ b/apps/api/app/profile.py
@@ -56,6 +56,19 @@ _DEFAULTS: dict[str, dict[str, str]] = {
         "NEWS_ENABLED": "0",
         # Release the card the moment an explicitly requested call finishes.
         "OLLAMA_KEEP_ALIVE": "0",
+        # History DB is a significant RSS consumer (SQLite mmap + WAL). On an
+        # 8 GB box the replay store competes with the live feeds for memory.
+        # Disabling it keeps the backend stateless — replay refills when the
+        # operator opts back in with HISTORY_ENABLED=1.
+        "HISTORY_ENABLED": "0",
+        # FR24 fetches 102 bbox tiles per pull at 20 s cadence — heavy on CPU
+        # and memory for what is a densify-only tier. OpenSky + the grid mirrors
+        # already carry ≥8000 aircraft without it.
+        "ADSB_FR24_ENABLED": "0",
+        # OpenSky gap-fill polls one cell every 300 s. On a tight box the extra
+        # httpx connections and response parsing aren't worth the marginal
+        # coverage gain — the base OpenSky pull already covers the world.
+        "ADSB_OPENSKY_GAPS_ENABLED": "0",
     },
     WORKSTATION: {
         "AIS_MYSHIPTRACKING_SIDECAR_ENABLED": "0",

--- a/apps/web/src/globe/GlobeCanvas.tsx
+++ b/apps/web/src/globe/GlobeCanvas.tsx
@@ -28,6 +28,7 @@ import { perfOnPreRender, perfOnRender } from './perf.js';
 import { presetKnobs } from './qualityPresets.js';
 import { setCameraMoving } from './cameraMotion.js';
 import { hasRenderNeed } from './renderNeeds.js';
+import { startAdaptiveGovernor, stopAdaptiveGovernor } from './adaptiveGovernor.js';
 import { ChipLayer } from '../imagery/ChipLayer.js';
 import { apiFetch, backendUrl } from '../transport/http.js';
 import { globalAltitude } from './camera.js';
@@ -853,6 +854,9 @@ export function GlobeCanvas({
     const compositor = new LayerCompositor(registry, viewer);
     compositor.start();
     compositorRef.current = compositor;
+    if (useSettings.getState().adaptiveLayerGovernor) {
+      startAdaptiveGovernor(registry);
+    }
     onViewerReady?.(viewer);
     setViewerState(viewer);
 
@@ -879,6 +883,7 @@ export function GlobeCanvas({
       detachWatchbox();
       detachCaptures();
       detachDetections();
+      stopAdaptiveGovernor();
       compositorRef.current?.stop();
       compositorRef.current = null;
       onViewerReady?.(null);

--- a/apps/web/src/globe/adaptiveGovernor.ts
+++ b/apps/web/src/globe/adaptiveGovernor.ts
@@ -1,0 +1,137 @@
+// Adaptive layer governor — sheds low-priority layers when frame cost is high,
+// restores them when it drops. Works at the DATA SOURCE level (disable whole
+// layers via the registry) because per-entity budgets don't move frame time
+// (measured 2026-07-29, docs/decisions.md: entity count fell 24%, renderMs
+// unchanged — cost is per collection/visualizer, not per entity).
+//
+// The governor tracks which layers IT shed separately from user toggles, so a
+// user re-enabling a layer mid-pressure overrides the governor for that layer.
+
+import type { LayerRegistry } from '../registry/LayerRegistry';
+import { perfSnapshot } from './perf';
+
+// ponytail: thresholds calibrated from the RAM benchmark (2026-08-08).
+// 14ms = 83% of a 60Hz frame; 10ms = comfortable headroom.
+const SHED_MS = 14;
+const RESTORE_MS = 10;
+const POLL_MS = 2000;
+const CONSECUTIVE = 3;
+
+// Shed order by group prefix. Lower = shed first. Groups not listed (aviation,
+// maritime) are never shed — the ≥8000 aircraft world-view invariant and
+// vessel coverage are not negotiable.
+// ponytail: a flat map beats a per-layer field on the shared contract — no
+// migration, no annotation of 100 descriptors.
+const GROUP_SHED_ORDER: [string, number][] = [
+  ['infra.', 0],
+  ['places.', 0],
+  ['reference.', 1],
+  ['signals.', 1],
+  ['rf.', 1],
+  ['news.', 2],
+  ['cyber.', 2],
+  ['env.', 3],
+  ['hazards.', 4],
+  ['seismic.', 5],
+  ['space.', 6],
+  ['conflict.', 7],
+];
+
+function shedOrder(id: string): number | null {
+  for (const [prefix, order] of GROUP_SHED_ORDER) {
+    if (id.startsWith(prefix)) return order;
+  }
+  return null;
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let registry: LayerRegistry | null = null;
+const shedSet = new Set<string>();
+let overCount = 0;
+let underCount = 0;
+
+function tick(): void {
+  if (!registry) return;
+  const { frameMsEMA } = perfSnapshot();
+  if (frameMsEMA <= 0) return;
+
+  if (frameMsEMA > SHED_MS) {
+    overCount++;
+    underCount = 0;
+    if (overCount >= CONSECUTIVE) {
+      overCount = 0;
+      shed();
+    }
+  } else if (frameMsEMA < RESTORE_MS) {
+    underCount++;
+    overCount = 0;
+    if (underCount >= CONSECUTIVE) {
+      underCount = 0;
+      restore();
+    }
+  } else {
+    overCount = 0;
+    underCount = 0;
+  }
+}
+
+function shed(): void {
+  if (!registry) return;
+  // Find the lowest-order enabled sheddable layer
+  let best: { id: string; order: number } | null = null;
+  for (const d of registry.list()) {
+    if (!registry.isEnabled(d.id)) continue;
+    if (shedSet.has(d.id)) continue;
+    const order = shedOrder(d.id);
+    if (order === null) continue;
+    if (!best || order < best.order) best = { id: d.id, order };
+  }
+  if (!best) return;
+  shedSet.add(best.id);
+  registry.disable(best.id);
+}
+
+function restore(): void {
+  if (!registry || shedSet.size === 0) return;
+  // Restore the highest-order shed layer (most important of what we shed)
+  let best: { id: string; order: number } | null = null;
+  for (const id of shedSet) {
+    const order = shedOrder(id) ?? 99;
+    if (!best || order > best.order) best = { id, order };
+  }
+  if (!best) return;
+  shedSet.delete(best.id);
+  registry.enable(best.id);
+}
+
+export function startAdaptiveGovernor(reg: LayerRegistry): void {
+  registry = reg;
+  shedSet.clear();
+  overCount = 0;
+  underCount = 0;
+  if (timer) clearInterval(timer);
+  timer = setInterval(tick, POLL_MS);
+}
+
+export function stopAdaptiveGovernor(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  // Restore everything we shed
+  if (registry) {
+    for (const id of shedSet) {
+      registry.enable(id);
+    }
+  }
+  shedSet.clear();
+  registry = null;
+}
+
+export function isGovernorShed(id: string): boolean {
+  return shedSet.has(id);
+}
+
+export function governorShedCount(): number {
+  return shedSet.size;
+}

--- a/apps/web/src/state/settings.test.ts
+++ b/apps/web/src/state/settings.test.ts
@@ -41,6 +41,7 @@ describe('settings store', () => {
       selectionAiPosition: 'top',
       leftRailExpanded: false,
       corroboratedOnly: false,
+      adaptiveLayerGovernor: true,
     });
   });
 

--- a/apps/web/src/state/settings.ts
+++ b/apps/web/src/state/settings.ts
@@ -66,6 +66,12 @@ export interface Settings {
   // the rail 44px→176px). OFF by default = icon-only. ConsoleShell reads this to
   // size the rail column and --rail-left-w so map overlays dock past it.
   leftRailExpanded: boolean;
+  // Adaptive layer governor (globe/adaptiveGovernor.ts). When ON, disables
+  // low-priority layers (infra, places, reference…) when frame cost exceeds
+  // ~14ms and restores them when it drops below ~10ms. Aircraft and maritime
+  // are never shed. Default ON — the operator can disable if they prefer
+  // seeing everything regardless of frame rate.
+  adaptiveLayerGovernor: boolean;
 }
 
 const DEFAULTS: Settings = {
@@ -78,6 +84,7 @@ const DEFAULTS: Settings = {
   selectionAiModel: null,
   selectionAiPosition: 'top',
   leftRailExpanded: false,
+  adaptiveLayerGovernor: true,
 };
 
 const LS_KEY = 'velocity.settings';

--- a/tools/perf/_bench_tier.sh
+++ b/tools/perf/_bench_tier.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Inner script for bench_ram.sh — runs inside a memory-limited cgroup scope.
+# Called by systemd-run, so this is a file (not a -c string) to avoid
+# systemd-run's environment variable expansion on the command text.
+set -euo pipefail
+
+REPO="$1"; TIER="$2"; TIER_DIR="$3"; UI_SECONDS="$4"; API_SECONDS="$5"
+SETTLE="$6"; UI_PROFILE="$7"
+cd "$REPO"
+
+# Find our cgroup for OOM event counting
+CGROUP_DIR=$(awk -F: '$1=="0" {print "/sys/fs/cgroup" $3}' /proc/self/cgroup)
+
+oom_count() {
+  if [ -f "$CGROUP_DIR/memory.events" ]; then
+    grep -oP 'oom_kill \K\d+' "$CGROUP_DIR/memory.events" 2>/dev/null || echo 0
+  else
+    echo -1
+  fi
+}
+
+mem_current() {
+  if [ -f "$CGROUP_DIR/memory.current" ]; then
+    awk '{printf "%.0f", $1/1048576}' "$CGROUP_DIR/memory.current"
+  else
+    echo -1
+  fi
+}
+
+OOM_BEFORE=$(oom_count)
+
+echo "[${TIER}] starting backend..."
+bash scripts/run-api.sh &
+API_PID=$!
+
+echo "[${TIER}] starting vite..."
+pnpm --filter @osint/web dev --host 127.0.0.1 > "$TIER_DIR/vite.log" 2>&1 &
+VITE_PID=$!
+
+# Wait for backend
+echo "[${TIER}] waiting for :8000..."
+ELAPSED=0
+while ! curl -sf --max-time 3 http://127.0.0.1:8000/api/status >/dev/null 2>&1; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  if [ "$ELAPSED" -ge 120 ]; then
+    echo "[${TIER}] BACKEND FAILED TO START (OOM likely)"
+    echo '{"error":"backend_timeout","tier":"'"$TIER"'","oom_kills":'"$(oom_count)"'}' > "$TIER_DIR/summary.json"
+    kill $API_PID $VITE_PID 2>/dev/null || true; wait 2>/dev/null || true; exit 0
+  fi
+  if ! kill -0 $API_PID 2>/dev/null; then
+    echo "[${TIER}] BACKEND PROCESS DIED (OOM kill)"
+    echo '{"error":"backend_oom","tier":"'"$TIER"'","oom_kills":'"$(oom_count)"'}' > "$TIER_DIR/summary.json"
+    kill $VITE_PID 2>/dev/null || true; wait 2>/dev/null || true; exit 0
+  fi
+done
+echo "[${TIER}] backend ready"
+
+# Wait for Vite
+echo "[${TIER}] waiting for :5173..."
+ELAPSED=0
+while ! curl -sf --max-time 3 http://127.0.0.1:5173/ >/dev/null 2>&1; do
+  sleep 2; ELAPSED=$((ELAPSED + 2))
+  if [ "$ELAPSED" -ge 90 ]; then
+    echo "[${TIER}] VITE FAILED TO START"
+    echo '{"error":"vite_timeout","tier":"'"$TIER"'","oom_kills":'"$(oom_count)"'}' > "$TIER_DIR/summary.json"
+    kill $API_PID $VITE_PID 2>/dev/null || true; wait 2>/dev/null || true; exit 0
+  fi
+done
+echo "[${TIER}] vite ready"
+
+echo "[${TIER}] settling ${SETTLE}s for feeds to populate..."
+sleep "$SETTLE"
+echo "[${TIER}] memory after settle: $(mem_current) MB / $TIER"
+
+# Grab /api/status snapshot
+curl -sf http://127.0.0.1:8000/api/status 2>/dev/null > "$TIER_DIR/api_status.json" || true
+
+# Run measure_ui.mjs (launches Chrome inside this cgroup)
+echo "[${TIER}] running measure_ui.mjs (${UI_SECONDS}s, profile=$UI_PROFILE)..."
+node tools/perf/measure_ui.mjs \
+  --seconds "$UI_SECONDS" \
+  --profile "$UI_PROFILE" \
+  --out "$TIER_DIR/ui.json" \
+  > "$TIER_DIR/ui.log" 2>&1 || true
+echo "[${TIER}] measure_ui done, memory: $(mem_current) MB"
+
+# Run measure_api.py
+echo "[${TIER}] running measure_api.py (${API_SECONDS}s)..."
+apps/api/.venv/bin/python tools/perf/measure_api.py \
+  --seconds "$API_SECONDS" --routes \
+  > "$TIER_DIR/api.log" 2>&1 || true
+echo "[${TIER}] measure_api done"
+
+# Collect final stats
+OOM_AFTER=$(oom_count)
+OOM_DELTA=$((OOM_AFTER - OOM_BEFORE))
+MEM_FINAL=$(mem_current)
+
+echo "[${TIER}] OOM kills during this tier: $OOM_DELTA"
+echo "[${TIER}] final memory: ${MEM_FINAL} MB"
+
+# Write tier summary
+python3 -c "
+import json, sys
+ui = {}
+try: ui = json.load(open('$TIER_DIR/ui.json'))
+except: pass
+status = {}
+try: status = json.load(open('$TIER_DIR/api_status.json'))
+except: pass
+summary = {
+    'tier': '$TIER',
+    'oom_kills': $OOM_DELTA,
+    'mem_final_mb': $MEM_FINAL,
+    'aircraft': status.get('aircraft_count', -1),
+    'vessels': status.get('vessel_count', -1),
+    'ui_verdict': ui.get('verdict', 'NO DATA'),
+    'ui_renderMs_p95': ui.get('renderMsP95', None),
+    'ui_pass': ui.get('pass', None),
+    'ui_entities': ui.get('entitiesAtStart', -1),
+    'ui_dataSources': ui.get('dataSources', -1),
+    'ui_heap_mb': (ui.get('series', {}).get('heapMB', {}).get('p95', None)),
+    'ui_fps_p50': (ui.get('series', {}).get('rendersPerSec', {}).get('p50', None)),
+    'ui_fps_p05': (ui.get('series', {}).get('rendersPerSec', {}).get('p05', None)),
+    'console_errors': ui.get('consoleErrors', -1),
+}
+json.dump(summary, sys.stdout, indent=2)
+print()
+" > "$TIER_DIR/summary.json"
+
+kill $API_PID $VITE_PID 2>/dev/null || true
+wait 2>/dev/null || true

--- a/tools/perf/bench_ram.sh
+++ b/tools/perf/bench_ram.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Benchmark the full stack (API backend + Vite + 3D Cesium globe in Chrome)
+# under cgroup v2 RAM limits from 4 GB to 128 GB.
+#
+# Each tier runs inside a systemd user scope with MemoryMax set and swap
+# disabled, so ALL processes (uvicorn, sidecars, Vite, Chrome) share one
+# pool. The existing measure_ui.mjs (real Chrome, real GPU, camera legs)
+# and measure_api.py (/proc sampling) do the actual measurement.
+#
+#   bash tools/perf/bench_ram.sh
+#   bash tools/perf/bench_ram.sh --tiers "8G 16G 32G"
+#   bash tools/perf/bench_ram.sh --ui-seconds 120 --settle 45
+#
+# Results land in tools/perf/ram-bench-results/<timestamp>/.
+# Requires: systemd-run --user with memory controller delegated (cgroup v2).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# ponytail: descending order — 128G control runs on fresh feeds; 4G (guaranteed
+# OOM, baseline tree is ~10GB) goes last where rate-limiting no longer matters.
+TIERS="128G 64G 32G 16G 8G 4G"
+UI_SECONDS=60
+API_SECONDS=30
+SETTLE=45
+UI_PROFILE="all-toggles"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tiers)       TIERS="$2"; shift 2;;
+    --ui-seconds)  UI_SECONDS="$2"; shift 2;;
+    --api-seconds) API_SECONDS="$2"; shift 2;;
+    --settle)      SETTLE="$2"; shift 2;;
+    --profile)     UI_PROFILE="$2"; shift 2;;
+    *) echo "unknown: $1" >&2; exit 1;;
+  esac
+done
+
+STAMP=$(date '+%Y%m%d-%H%M%S')
+OUT="tools/perf/ram-bench-results/$STAMP"
+mkdir -p "$OUT"
+
+echo "# RAM benchmark — $STAMP"
+echo "tiers: $TIERS"
+echo "ui_seconds=$UI_SECONDS  api_seconds=$API_SECONDS  settle=$SETTLE  profile=$UI_PROFILE"
+echo "results: $OUT/"
+echo
+
+TIER_SCRIPT="$(dirname "$0")/_bench_tier.sh"
+
+for TIER in $TIERS; do
+  echo "=========================================="
+  echo "=== TIER: $TIER"
+  echo "=========================================="
+  TIER_DIR="$OUT/$TIER"
+  mkdir -p "$TIER_DIR"
+
+  # Kill any leftover servers from the previous tier
+  for p in 8000 5173 8090 8093 8095; do
+    bash scripts/kill-port.sh "$p" 2>/dev/null || true
+  done
+  sleep 2
+
+  # Run everything inside a memory-limited scope.
+  # The tier script is a FILE (not a -c string) so systemd-run cannot do
+  # its own $VAR expansion on the script text.
+  systemd-run --user --scope \
+    --property="MemoryMax=$TIER" \
+    --property="MemorySwapMax=0" \
+    --unit="bench-ram-${TIER}-${STAMP}" \
+    bash "$TIER_SCRIPT" "$PWD" "$TIER" "$TIER_DIR" "$UI_SECONDS" "$API_SECONDS" "$SETTLE" "$UI_PROFILE" \
+    2>&1 | tee "$TIER_DIR/tier.log" || {
+      echo "[${TIER}] scope exited with error (likely OOM killed the scope itself)"
+      echo '{"error":"scope_killed","tier":"'"$TIER"'","oom_kills":-1}' > "$TIER_DIR/summary.json"
+    }
+
+  echo
+done
+
+# Generate comparison report
+echo
+echo "=========================================="
+echo "=== COMPARISON REPORT"
+echo "=========================================="
+echo
+
+python3 -c "
+import json, os, sys
+out_dir = '$OUT'
+tiers = '$TIERS'.split()
+rows = []
+for t in tiers:
+    p = os.path.join(out_dir, t, 'summary.json')
+    try:
+        d = json.load(open(p))
+    except:
+        d = {'tier': t, 'error': 'no data'}
+    rows.append(d)
+
+print('| RAM | Status | OOM | Mem MB | Aircraft | Vessels | FPS p50 | FPS p05 | renderMs p95 | JS Heap MB | Entities |')
+print('|-----|--------|-----|--------|----------|---------|---------|---------|--------------|------------|----------|')
+for r in rows:
+    err = r.get('error')
+    if err:
+        print(f'| {r[\"tier\"]} | **{err}** | {r.get(\"oom_kills\",\"?\")} | — | — | — | — | — | — | — | — |')
+        continue
+    def f(v, nd=1):
+        if v is None or v == -1: return '—'
+        return f'{v:.{nd}f}' if isinstance(v, float) else str(v)
+    print(f'| {r[\"tier\"]} | {r.get(\"ui_verdict\",\"?\")[:20]} | {r.get(\"oom_kills\",\"?\")} | {f(r.get(\"mem_final_mb\"))} | {f(r.get(\"aircraft\"),0)} | {f(r.get(\"vessels\"),0)} | {f(r.get(\"ui_fps_p50\"))} | {f(r.get(\"ui_fps_p05\"))} | {f(r.get(\"ui_renderMs_p95\"))} | {f(r.get(\"ui_heap_mb\"))} | {f(r.get(\"ui_entities\"),0)} |')
+
+combined = os.path.join(out_dir, 'comparison.json')
+json.dump(rows, open(combined, 'w'), indent=2)
+print(f'\nFull data: {combined}')
+" | tee "$OUT/report.md"
+
+echo
+echo "Done. Results in $OUT/"


### PR DESCRIPTION
## Summary

- **RAM benchmark** (`tools/perf/bench_ram.sh`): constrains the full stack (backend + Vite + 3D Cesium globe in Chrome) inside cgroup v2 `MemoryMax` for each RAM tier and runs the existing `measure_ui.mjs` + `measure_api.py` harnesses. Measured 128G→4G: tiers ≥16G run fine, 8G and 4G OOM with the full profile (~10 GB backend tree).
- **Lite profile tightened** (`apps/api/app/profile.py`): adds `HISTORY_ENABLED=0`, `ADSB_FR24_ENABLED=0`, `ADSB_OPENSKY_GAPS_ENABLED=0` to the lite defaults. With these, the 8G tier boots at 1.4 GB cgroup memory with 9k aircraft and 32k vessels.
- **Adaptive layer governor** (`apps/web/src/globe/adaptiveGovernor.ts`): watches `frameMsEMA` and sheds whole layers when frame cost exceeds 14ms, restoring below 10ms. Works at the DataSource level (per-entity budgets don't move frame time — 2026-07-29 finding). Shed order: infra/places → reference/signals → env/hazards/space/conflict. Aviation and maritime never shed. Setting: `adaptiveLayerGovernor` (default ON).

## Test plan

- [x] `pnpm -r typecheck` green
- [x] Backend tests: 2271 passed, 2 skipped
- [x] Settings test updated for new `adaptiveLayerGovernor` field
- [x] 8G tier with lite profile: 0 OOM, 1453 MB, 9197 aircraft, 32168 vessels
- [ ] Browser verify: boot with all-toggles, confirm governor sheds layers when frameMsEMA > 14ms