### PR TITLE
Measure upstream health instead of asserting it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,8 @@ undo and why it was made.
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **2393 passed + 2 skipped in ~152 s** (skip = opt-in live probes;
-  measured 2026-08-08, branch gotham-parity-2026-08, connection wire coverage).
+  Baseline: **2400 passed + 2 skipped in ~143 s** (skip = opt-in live probes;
+  measured 2026-08-20, branch feed-honesty-2026-08, measured source health).
   Runs SERIAL by default: `-n auto --dist
   loadfile` groups different files per worker on different core counts, so a
   suite with module-state leaks answers differently per machine and CI (4 cores)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ undo and why it was made.
 - Backend tests from the **repo ROOT** (from `apps/api` the `.env` auth
   resolves → wall of 401s):
   `OSINT_DISABLE_BACKGROUND=1 apps/api/.venv/bin/pytest apps/api -q`
-  Baseline: **2400 passed + 2 skipped in ~143 s** (skip = opt-in live probes;
+  Baseline: **2401 passed + 2 skipped in ~156 s** (skip = opt-in live probes;
   measured 2026-08-20, branch feed-honesty-2026-08, measured source health).
   Runs SERIAL by default: `-n auto --dist
   loadfile` groups different files per worker on different core counts, so a

--- a/apps/api/app/routes/_feedgeo.py
+++ b/apps/api/app/routes/_feedgeo.py
@@ -19,7 +19,7 @@ from typing import Any
 import httpx
 from fastapi import HTTPException
 
-from app.upstream import cache, get_client
+from app.upstream import cache, get_client, record_failure
 
 Feature = dict[str, Any]
 
@@ -41,10 +41,20 @@ async def fetch_json(
     except (httpx.HTTPError, OSError) as exc:  # pragma: no cover - network shape
         raise HTTPException(502, f"upstream error: {exc}") from exc
     if r.status_code != 200:
+        # 4xx/5xx are already in the health registry (the shared client records
+        # them). A non-error non-200 is not, so say so here.
+        if r.status_code < 400:
+            record_failure(str(r.request.url.host), f"HTTP {r.status_code}", r.status_code)
         raise HTTPException(502, f"upstream {r.status_code}")
     try:
         return r.json()
     except ValueError as exc:
+        # The ONE failure no client-level capture point can see: the upstream
+        # answered 200, so the wire says success, and the body is a throttle
+        # notice in text/plain. This is airplanes.live's documented behaviour and
+        # the registry would otherwise go green at the exact moment the feed dies
+        # its most common death.
+        record_failure(str(r.request.url.host), "HTTP 200 with a non-JSON body", 200)
         raise HTTPException(502, "upstream returned a non-JSON body") from exc
 
 
@@ -60,6 +70,8 @@ async def fetch_text(
     except (httpx.HTTPError, OSError) as exc:  # pragma: no cover - network shape
         raise HTTPException(502, f"upstream error: {exc}") from exc
     if r.status_code != 200:
+        if r.status_code < 400:
+            record_failure(str(r.request.url.host), f"HTTP {r.status_code}", r.status_code)
         raise HTTPException(502, f"upstream {r.status_code}")
     return r.text
 
@@ -90,11 +102,66 @@ def polygon(fid: str, ring: list[list[float]], props: dict[str, Any]) -> Feature
     }
 
 
+# An empty answer expires fast. A real one keeps its full TTL.
+#
+# The 2026-08-20 sweep made this concrete: 17 routes answered 200 with an empty
+# body, and because every one of those loaders catches its own upstream failure
+# and RETURNS the empty rather than raising, the empty is a normal successful
+# value — so get_or_fetch stores it for the loader's full TTL. GDELT's summary
+# pinned `{"summary": {}}` for 10 minutes and the vessel-name index pinned `{}`
+# for 12 hours, after ONE failed fetch. The upstream could recover five seconds
+# later and the route would keep serving nothing.
+#
+# `cache.shorten` is the existing fix for exactly this (8 call sites, e.g. the
+# ADS-B empty-cell TTL). Applying it once here covers every feed route instead
+# of asking each of ~127 loaders to remember.
+_EMPTY_TTL_S = 45.0
+
+
+def _carries_nothing(payload: Any) -> bool:
+    """True for a well-formed envelope with no data in it. Conservative: any
+    non-empty collection anywhere makes it real."""
+    if payload is None:
+        return True
+    if isinstance(payload, list):
+        return not payload
+    if not isinstance(payload, dict):
+        return False
+    if not payload:
+        return True
+    for v in payload.values():
+        if isinstance(v, (list, dict)):
+            if v:
+                return False
+        elif v not in (None, "", 0):
+            return False
+    return True
+
+
 async def cached(
     key: str, ttl: float, loader: Callable[[], Awaitable[dict[str, Any]]]
 ) -> dict[str, Any]:
-    """Thin alias over ``cache.get_or_fetch`` so feed routes import one module."""
-    return await cache.get_or_fetch(key, ttl, loader)
+    """``cache.get_or_fetch``, but an empty result is not pinned for the full TTL."""
+    out = await cache.get_or_fetch(key, ttl, loader)
+    if ttl > _EMPTY_TTL_S and _carries_nothing(out):
+        cache.shorten(key, _EMPTY_TTL_S)
+    return out
+
+
+def degraded_fc(note: str) -> dict[str, Any]:
+    """An empty FeatureCollection that says WHY it is empty.
+
+    A layer with no features and no explanation is indistinguishable from a
+    working layer over a quiet area. This is the shape routes/events.py already
+    uses; feed routes that swallow an upstream failure should answer with it
+    rather than a bare `fc([])`.
+    """
+    return {"type": "FeatureCollection", "features": [], "degraded": True, "note": note}
+
+
+def degraded(payload: dict[str, Any], note: str) -> dict[str, Any]:
+    """Same idea for the non-GeoJSON envelopes."""
+    return {**payload, "degraded": True, "note": note}
 
 
 def num(v: Any) -> float | None:

--- a/apps/api/app/routes/civil_defense.py
+++ b/apps/api/app/routes/civil_defense.py
@@ -99,9 +99,11 @@ async def ukraine_alerts_alt() -> dict[str, Any]:
             raw = await fg.fetch_json(UA_SIREN_URL)
         except Exception:
             # A second relay of the same alerts. If it is down the primary layer
-            # still carries the picture, so this one goes quiet rather than
-            # putting an error on a map that is not missing anything.
-            return fg.fc([])
+            # still carries the picture, so this one does not put an error on a
+            # map that is not missing anything -- but it says so in the BODY,
+            # because "no sirens" and "we could not ask" are different answers
+            # and the caller is entitled to know which one it got.
+            return fg.degraded_fc("The Ukraine siren relay did not answer.")
         states = raw if isinstance(raw, list) else (raw or {}).get("states", [])
         out: list[fg.Feature] = []
         for s in states if isinstance(states, list) else []:

--- a/apps/api/app/routes/mega_feeds.py
+++ b/apps/api/app/routes/mega_feeds.py
@@ -109,7 +109,7 @@ async def mineral_sites(
             text = await fg.fetch_text(MRDS_URL, params=params)
             root = ET.fromstring(text)
         except Exception:
-            return fg.fc([])
+            return fg.degraded_fc("The USGS MRDS feed did not answer.")
         out: list[fg.Feature] = []
         for member in root.iter(f"{_GML_NS}featureMember"):
             site = member.find(f"{_MS_NS}mrds")
@@ -254,7 +254,7 @@ async def wikimapia(
         try:
             raw = await fg.fetch_json(WIKIMAPIA_URL, params=params)
         except Exception:
-            return fg.fc([])
+            return fg.degraded_fc("Wikimapia did not answer.")
         folders = (raw or {}).get("folder", [])
         out: list[fg.Feature] = []
         for f in folders or []:
@@ -337,7 +337,7 @@ async def courtlistener(q: str = Query(..., max_length=200)) -> dict[str, Any]:
                 params={"q": q, "type": "o", "format": "json"},
             )
         except Exception:
-            return {"count": 0, "results": []}
+            return fg.degraded({"count": 0, "results": []}, "CourtListener did not answer.")
         results = (raw or {}).get("results", [])
         return {
             "count": (raw or {}).get("count", len(results)),
@@ -476,7 +476,7 @@ async def fr24_search(q: str = Query(..., max_length=32)) -> dict[str, Any]:
         try:
             raw = await fg.fetch_json(FR24_URL, params={"query": q, "limit": "20"})
         except Exception:
-            return {"results": []}
+            return fg.degraded({"results": []}, "The FR24 search endpoint did not answer.")
         results = (raw or {}).get("results", [])
         return {
             "count": len(results),
@@ -644,7 +644,10 @@ async def gdelt_summary(q: str = Query("conflict", max_length=200)) -> dict[str,
                 params={"d": q, "output": "json"},
             )
         except Exception:
-            return {"summary": {}}
+            # Was a bare `{"summary": {}}` cached for the full 600 s TTL below,
+            # so one failed fetch silently emptied this route for ten minutes.
+            # fg.cached now caps an empty answer's TTL; this states the reason.
+            return fg.degraded({"summary": {}}, "GDELT did not answer.")
 
     return await fg.cached(f"gdelt_summary:{q}", 600.0, load)
 
@@ -768,7 +771,8 @@ async def gpsjam_manifest() -> dict[str, Any]:
                 headers={"Accept-Encoding": "gzip, deflate"},
             )
         except Exception:
-            return {"dates": [], "count": 0}
+            return fg.degraded({"dates": [], "count": 0},
+                               "The ESRI Wayback manifest did not answer.")
         reader = csv.reader(io.StringIO(text))
         dates: list[str] = []
         for row in reader:

--- a/apps/api/app/routes/source_catalog.py
+++ b/apps/api/app/routes/source_catalog.py
@@ -611,7 +611,7 @@ async def kiwisdr_stations() -> dict[str, Any]:
         try:
             text = await fg.fetch_text(KIWISDR_URL)
         except Exception:
-            return fg.fc([])
+            return fg.degraded_fc("The KiwiSDR receiver list did not answer.")
         match = re.search(r"var\s+kiwisdr_com\s*=\s*(\[.*\])", text, re.DOTALL)
         if not match:
             return fg.fc([])
@@ -681,7 +681,7 @@ async def splat_search(
                 },
             )
         except Exception:
-            return {"results": [], "count": 0}
+            return fg.degraded({"results": [], "count": 0}, "The upstream did not answer.")
         results = (raw or {}).get("results", [])
         return {
             "count": len(results),
@@ -720,7 +720,8 @@ async def hf_splat_datasets(
         try:
             raw = await fg.fetch_json(HF_URL, params={"search": q, "limit": "30"})
         except Exception:
-            return {"datasets": [], "count": 0}
+            return fg.degraded({"datasets": [], "count": 0},
+                               "The Hugging Face dataset search did not answer.")
         items = raw if isinstance(raw, list) else []
         return {
             "count": len(items),

--- a/apps/api/app/routes/status.py
+++ b/apps/api/app/routes/status.py
@@ -25,8 +25,40 @@ router = APIRouter(tags=["status"])
 _AIRCRAFT_FLOOR = 8000
 
 
-def _feed(name: str, ok: bool, detail: str, **extra: Any) -> dict[str, Any]:
-    return {"name": name, "status": "green" if ok else "degraded", "detail": detail, **extra}
+def _feed(name: str, ok: bool | None, detail: str, **extra: Any) -> dict[str, Any]:
+    """One feed row. ``ok=None`` is the THIRD state and is not a synonym for green.
+
+    "Never attempted" used to render as green here, because two feeds were
+    hardcoded ``True`` and four more read a key being CONFIGURED as proof it
+    worked. A feed nobody has called yet is unknown, and saying so is the same
+    honesty rule the note at the bottom of this route already states about
+    coverage.
+    """
+    state = "unknown" if ok is None else ("green" if ok else "degraded")
+    return {"name": name, "status": state, "detail": detail, **extra}
+
+
+def _measured(host: str) -> tuple[bool | None, str]:
+    """(state, detail) for `host` from the upstream health registry.
+
+    Returns ``(None, ...)`` when the host has not been called this process —
+    which is a real answer, not a failure and not a pass.
+    """
+    try:
+        from app import upstream  # noqa: PLC0415
+
+        for row in upstream.source_health():
+            if row["host"] != host:
+                continue
+            if row["state"] == "ok":
+                age = row.get("success_age_s")
+                return True, f"last fetch OK{f' {age:.0f}s ago' if age is not None else ''}"
+            if row["state"] == "failing":
+                return False, f"last attempt failed: {row.get('last_error') or 'unknown'}"
+            return None, "no fetch attempted yet"
+    except Exception:  # noqa: BLE001 — status must never 500
+        return None, "health registry unavailable"
+    return None, "no fetch attempted yet"
 
 
 def _extra(payload: dict[str, Any]) -> dict[str, Any]:
@@ -97,6 +129,9 @@ async def status() -> dict[str, Any]:
         ais_stats.get("myshiptracking_vessels") or 0
     )
 
+    sar_state, sar_detail = _measured("catalogue.dataspace.copernicus.eu")
+    firms_state, firms_detail = _measured("firms.modaps.eosdis.nasa.gov")
+
     feeds = [
         _feed(
             "ADS-B aircraft (OpenSky + airplanes.live grid)",
@@ -149,16 +184,30 @@ async def status() -> dict[str, Any]:
             aircraft > 0,
             "Inference from ADS-B NACp/NIC degradation — not a direct RF/SIGINT cut.",
         ),
-        _feed("USGS earthquakes", True, "Keyless, always on."),
+        # Was hardcoded `True` with the detail "Keyless, always on." The 2026-08-20
+        # sweep is what made that indefensible: keyless does not mean reachable,
+        # and nothing here had ever checked. Now measured.
+        _feed(
+            "USGS earthquakes",
+            *_measured("earthquake.usgs.gov"),
+        ),
+        # Also previously hardcoded `True`. The coverage caveat is still true and
+        # still worth stating; whether the provider answered is now measured
+        # rather than asserted.
         _feed(
             "Sentinel-1 SAR dark-vessel",
-            True,
-            "Curated chokepoint AOIs only (e.g. Strait of Hormuz); ~6 h revisit.",
+            sar_state,
+            "Curated chokepoint AOIs only (e.g. Strait of Hormuz); ~6 h revisit · "
+            + sar_detail,
         ),
+        # `bool(firms_map_key)` answered "is a key set", never "does it work".
+        # A revoked or rate-limited key read green here indefinitely.
         _feed(
             "NASA FIRMS fires",
-            bool(s.firms_map_key),
-            "Key configured." if s.firms_map_key else "Needs MAP_KEY (degrades off).",
+            firms_state if s.firms_map_key else False,
+            ("Key configured · " + firms_detail)
+            if s.firms_map_key
+            else "Needs MAP_KEY (degrades off).",
         ),
         _feed(
             "AISStream global AIS",
@@ -396,6 +445,89 @@ async def status_provenance() -> dict[str, Any]:
         }
     except Exception:  # noqa: BLE001 — diagnostics must never 500
         out["aircraft"] = {"error": "unavailable"}
+    return out
+
+
+# ── /api/status/sources ──────────────────────────────────────────────────────
+
+# Upstream calls that do NOT go through the shared client, and so cannot appear
+# in the registry below. Naming them is the point: a health page that lists only
+# what it can see, without saying what it cannot, is the same overclaim in a new
+# place. The localhost sidecar probes (adsb_sidecar, ais_sidecar, browser_fetch,
+# llamacpp/vllm/mavlink, ai_models) are deliberately omitted — they are covered
+# by the sidecar entries in /api/status and are not external sources.
+#
+# routes/adsb.py:1140 is first because it matters most: it is the SYNC client
+# behind the ADS-B feed path, the highest-value feed on the platform, and
+# _fetch_one_feed_sync swallows every failure into an empty aircraft list.
+# → guarded by tests/test_feed_honesty.py
+_UNMEASURED: list[tuple[str, str]] = [
+    ("routes/adsb.py:1140",
+     "sync ADS-B feed client (thread-bound; the async client cannot be used there)"),
+    ("adsb_fr24.py:199", "FR24 tier"),
+    ("adsb_opensky_gaps.py:243", "OpenSky gap filler"),
+    ("correlate/runner.py:215", "correlation runner"),
+    ("imagery/vhr.py:42", "VHR imagery provider"),
+    ("llm.py:402", "hosted LLM"),
+    ("llm.py:536", "hosted LLM (streaming)"),
+    ("localllm/binary.py:149", "local model binary download"),
+    ("mcp_server.py:221", "MCP self-call"),
+    ("mcp_server.py:248", "MCP self-call"),
+    ("mcp_server.py:303", "MCP self-call"),
+    ("mcp_server.py:331", "MCP self-call"),
+    ("mcp_server.py:350", "MCP self-call"),
+    ("keys.py:187", "API-key validation probe"),
+    ("auth.py:131", "Supabase JWKS fetch"),
+    ("warp.py:127", "WARP tunnel health"),
+    ("workflows/control.py:70", "operator-configured outbound actuation"),
+]
+
+
+@router.get("/api/status/sources")
+async def status_sources() -> dict[str, Any]:
+    """Measured per-upstream health: who answered, who failed, and how long ago.
+
+    Every other health surface on this platform is an ASSERTION. /api/status
+    hardcoded two feeds green and inferred four more from a key being present in
+    the config rather than from a fetch that worked; /api/health is the constant
+    ``{"status": "ok"}``. Before this endpoint the process recorded last_success
+    for zero of its ~100 upstreams.
+
+    This is the measurement instead. Rows come from app.upstream's registry,
+    written on every request through the shared client, so a host appears here
+    because it was actually called - not because someone listed it.
+
+    Read `unmeasured` as part of the answer, not a footnote: those upstreams
+    build their own httpx client and are invisible here.
+
+    Diagnostics contract, same as its siblings: never 500, never triggers a
+    fan-out of its own.
+    """
+    out: dict[str, Any] = {"as_of": time.time()}
+    try:
+        from app import upstream  # noqa: PLC0415
+
+        rows = upstream.source_health()
+        out["sources"] = rows
+        out["counts"] = {
+            "total": len(rows),
+            "ok": sum(1 for r in rows if r["state"] == "ok"),
+            "failing": sum(1 for r in rows if r["state"] == "failing"),
+            "unknown": sum(1 for r in rows if r["state"] == "unknown"),
+        }
+    except Exception:  # noqa: BLE001 — diagnostics must never 500
+        out["sources"] = []
+        out["counts"] = {"error": "unavailable"}
+    out["unmeasured"] = [{"where": w, "what": d} for w, d in _UNMEASURED]
+    out["note"] = (
+        "One row per upstream HOST, recorded at the shared client. A row is one "
+        "logical request: redirect hops, the transport's single retry and the "
+        "WARP tunnel-to-direct fallback collapse into one, so a WARP fallback "
+        "reads here as a clean success. Latency for streamed responses is "
+        "headers-only. State is measured, never inferred from configuration: "
+        "'unknown' means never attempted this process and is not a synonym for "
+        "healthy."
+    )
     return out
 
 

--- a/apps/api/app/upstream.py
+++ b/apps/api/app/upstream.py
@@ -16,6 +16,10 @@ from typing import Any, TypeVar
 import httpx
 
 _CLIENT: httpx.AsyncClient | None = None
+# host -> health row. Written only from the single uvicorn loop (get_client()
+# is never called from a thread; the sync ADS-B path at routes/adsb.py has its
+# own client and its own threading.Lock), so no lock is needed here.
+_SOURCES: OrderedDict[str, dict[str, Any]] = OrderedDict()
 
 
 def _transport(proxy: str | None = None) -> httpx.AsyncHTTPTransport:
@@ -133,6 +137,137 @@ class _WarpTransport(httpx.AsyncBaseTransport):
             await self._direct.aclose()
 
 
+# ── per-source health registry ───────────────────────────────────────────────
+#
+# Before this existed the API recorded `last_success` for exactly zero of its
+# ~100 upstreams and `last_error` for two, while /api/status asserted health for
+# nine feeds — two of them hardcoded `True` and four inferred from a key being
+# CONFIGURED rather than from a fetch that worked. A sweep of 207 GET routes
+# (docs/audits/2026-08-20-api-sweep.md) found 17 answering HTTP 200 with an
+# empty body, and nothing in the process could say which of those had a dead
+# upstream behind them and which were simply empty stores on a fresh boot.
+#
+# This records the difference, in the ONE place every upstream call already
+# passes through.
+#
+# Capture point is AsyncClient.send(), not an httpx event hook. A response hook
+# fires only after _send_single_request returns, so ConnectError / ReadTimeout /
+# ConnectTimeout never reach it — a registry built on hooks would read green
+# precisely when an upstream is unreachable, which is the overclaim this exists
+# to kill. (response.elapsed also raises inside a hook, and an exception thrown
+# in one aborts the request for all 113 call sites.)
+#
+# Grain, stated because it is not obvious: send() records one row per LOGICAL
+# request. Redirect hops, the transport's retries=1 and _WarpTransport's
+# tunnel→direct fallback all collapse into a single row, so a WARP fallback
+# reads here as a clean success. For stream=True the latency is headers-only,
+# because the caller reads the body after send() returns.
+
+_MAX_SOURCE_HOSTS = 512
+
+
+def _source_row(host: str) -> dict[str, Any]:
+    row = _SOURCES.get(host)
+    if row is None:
+        row = {
+            "host": host,
+            "ok": 0,
+            "fail": 0,
+            "last_success": None,
+            "last_error": None,
+            "last_error_at": None,
+            "last_status": None,
+            "latency_ms": None,
+        }
+        _SOURCES[host] = row
+        # Host keys are attacker-influenceable through any route that fetches a
+        # user-supplied URL, so the dict is bounded like the TTL cache below.
+        while len(_SOURCES) > _MAX_SOURCE_HOSTS:
+            _SOURCES.popitem(last=False)
+    _SOURCES.move_to_end(host)
+    return row
+
+
+def record_success(host: str, latency_ms: float, status: int) -> None:
+    row = _source_row(host)
+    row["ok"] += 1
+    row["last_success"] = time.time()
+    row["last_status"] = status
+    row["latency_ms"] = round(latency_ms, 1)
+
+
+def record_failure(host: str, reason: str, status: int | None = None) -> None:
+    """Record an upstream failure. Public because the wire is not the whole truth.
+
+    airplanes.live throttles with HTTP 200 + text/plain, which every
+    client-level capture point on earth records as a success. routes/_feedgeo.py
+    is the layer that knows a 200 was not an answer, so it calls this directly.
+    """
+    row = _source_row(host)
+    row["fail"] += 1
+    row["last_error"] = reason[:200]
+    row["last_error_at"] = time.time()
+    if status is not None:
+        row["last_status"] = status
+
+
+def source_health() -> list[dict[str, Any]]:
+    """Every upstream host seen this process, newest activity first."""
+    now = time.time()
+    out: list[dict[str, Any]] = []
+    for row in _SOURCES.values():
+        r = dict(row)
+        r["success_age_s"] = (
+            round(now - row["last_success"], 1) if row["last_success"] else None
+        )
+        r["error_age_s"] = (
+            round(now - row["last_error_at"], 1) if row["last_error_at"] else None
+        )
+        # Green needs a success MORE RECENT than the last failure. "Never
+        # attempted" is a third state and must never render as green — that
+        # conflation is the whole defect /api/status carried.
+        if row["last_success"] is None and row["last_error"] is None:
+            r["state"] = "unknown"
+        elif row["last_error_at"] and (
+            row["last_success"] is None or row["last_error_at"] > row["last_success"]
+        ):
+            r["state"] = "failing"
+        else:
+            r["state"] = "ok"
+        out.append(r)
+    return sorted(out, reverse=True, key=lambda r: max(
+        r["last_success"] or 0.0, r["last_error_at"] or 0.0))
+
+
+class _InstrumentedClient(httpx.AsyncClient):
+    """The shared client, plus one row per request in the health registry.
+
+    All bookkeeping is inside try/except: a bug in this file must never be able
+    to abort an upstream call, and this client carries the 1 Hz ADS-B path.
+    """
+
+    async def send(self, request: httpx.Request, **kwargs: Any) -> httpx.Response:
+        host = request.url.host
+        t0 = time.perf_counter()
+        try:
+            response = await super().send(request, **kwargs)
+        except Exception as exc:
+            try:
+                record_failure(host, f"{type(exc).__name__}: {exc}")
+            except Exception:  # noqa: BLE001 — diagnostics never break a fetch
+                pass
+            raise
+        try:
+            ms = (time.perf_counter() - t0) * 1000.0
+            if response.status_code >= 400:
+                record_failure(host, f"HTTP {response.status_code}", response.status_code)
+            else:
+                record_success(host, ms, response.status_code)
+        except Exception:  # noqa: BLE001 — diagnostics never break a fetch
+            pass
+        return response
+
+
 def get_client() -> httpx.AsyncClient:
     global _CLIENT
     if _CLIENT is None:
@@ -174,7 +309,12 @@ def get_client() -> httpx.AsyncClient:
             # explicitly for the case where only UPSTREAM_PROXIES / WARP is set.
             for pattern in upstream_proxy.LOOPBACK_PATTERNS:
                 mounts.setdefault(pattern, _transport())
-        _CLIENT = httpx.AsyncClient(
+        # _InstrumentedClient, not httpx.AsyncClient: the subclass records
+        # per-host health. transport/mounts are passed through UNCHANGED —
+        # proxy_stats() below reaches into _CLIENT._transport and isinstance-
+        # checks RotatingProxyTransport, so wrapping the transport instead of
+        # the client would silently blank /api/status's proxy panel.
+        _CLIENT = _InstrumentedClient(
             timeout=httpx.Timeout(15.0, connect=5.0),
             headers={"User-Agent": "osint-console/0.1"},
             transport=default,

--- a/apps/api/tests/test_feed_honesty.py
+++ b/apps/api/tests/test_feed_honesty.py
@@ -1,0 +1,221 @@
+"""A feed may be empty. It may not be empty and silent about why.
+
+The 2026-08-20 route sweep (docs/audits/2026-08-20-api-sweep.md) swept 207 GET
+routes and found 17 answering HTTP 200 with an empty body, with nothing in the
+process able to say which had a dead upstream behind them. These guards hold the
+three pieces that fixed that: the registry records failures, the layer that can
+see a semantic failure reports it, and the list of what is NOT measured stays
+true.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app import upstream
+from app.routes import _feedgeo as fg
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    upstream._SOURCES.clear()
+    yield
+    upstream._SOURCES.clear()
+
+
+def _client(handler) -> upstream._InstrumentedClient:
+    """The REAL instrumented client over a mock transport.
+
+    Deliberately not a mock client object: ~20 tests in this suite replace
+    upstream._CLIENT wholesale, and a client swapped for a mock carries no
+    instrumentation, so a guard built that way would pass against code that
+    records nothing. The transport is mocked; the class under test is not, and
+    no network is touched.
+    """
+    return upstream._InstrumentedClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_connect_error_is_recorded() -> None:
+    """The case that chose this design.
+
+    An httpx *response hook* fires only after the request succeeds, so
+    ConnectError / ReadTimeout never reach it and a hook-based registry would
+    read green exactly when an upstream is unreachable. Capturing in send()
+    is what makes this test possible at all.
+    """
+
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=request)
+
+    async with _client(boom) as c:
+        with pytest.raises(httpx.ConnectError):
+            await c.get("https://dead.example/feed.json")
+
+    rows = {r["host"]: r for r in upstream.source_health()}
+    assert rows["dead.example"]["state"] == "failing"
+    assert rows["dead.example"]["fail"] == 1
+    assert "ConnectError" in rows["dead.example"]["last_error"]
+
+
+@pytest.mark.asyncio
+async def test_success_and_http_error_are_distinguished() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        code = 403 if "blocked" in str(request.url) else 200
+        return httpx.Response(code, json={"ok": True})
+
+    async with _client(handler) as c:
+        await c.get("https://good.example/a.json")
+        await c.get("https://blocked.example/a.json")
+
+    rows = {r["host"]: r for r in upstream.source_health()}
+    assert rows["good.example"]["state"] == "ok"
+    assert rows["good.example"]["latency_ms"] is not None
+    assert rows["blocked.example"]["state"] == "failing"
+    assert rows["blocked.example"]["last_status"] == 403
+
+
+def test_never_attempted_is_not_healthy() -> None:
+    """'unknown' is a third state. Conflating it with green is the defect
+    /api/status carried for two hardcoded feeds and four key-presence checks."""
+    upstream._source_row("never.example")
+    row = next(r for r in upstream.source_health() if r["host"] == "never.example")
+    assert row["state"] == "unknown"
+    assert row["last_success"] is None
+
+
+def test_registry_is_bounded() -> None:
+    """Host keys are attacker-influenceable through any route that fetches a
+    user-supplied URL, so the dict cannot grow without limit."""
+    for i in range(upstream._MAX_SOURCE_HOSTS + 50):
+        upstream._source_row(f"h{i}.example")
+    assert len(upstream._SOURCES) <= upstream._MAX_SOURCE_HOSTS
+
+
+@pytest.mark.asyncio
+async def test_200_with_a_non_json_body_is_recorded_as_a_failure(monkeypatch) -> None:
+    """The failure no client-level capture point can see.
+
+    airplanes.live throttles with HTTP 200 + text/plain. On the wire that is a
+    success, so the registry would go green at the exact moment the feed dies
+    its most common death. _feedgeo is the layer that knows better.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="rate limited, try later")
+
+    c = _client(handler)
+    monkeypatch.setattr(fg, "get_client", lambda: c)
+    with pytest.raises(HTTPException) as exc:
+        await fg.fetch_json("https://throttled.example/data.json")
+    assert exc.value.status_code == 502
+    await c.aclose()
+
+    rows = {r["host"]: r for r in upstream.source_health()}
+    assert rows["throttled.example"]["state"] == "failing"
+    assert "non-JSON" in rows["throttled.example"]["last_error"]
+
+
+# ── anti-rot guards ──────────────────────────────────────────────────────────
+#
+# The two claims this work makes are "we measure our upstreams" and "an empty
+# feed says why". Both rot the moment someone adds a client or a swallow without
+# reading this file, and both rot INVISIBLY -- the product keeps working and
+# just stops being honest. These fail loudly instead.
+
+import ast  # noqa: E402
+import pathlib  # noqa: E402
+import re  # noqa: E402
+
+APP = pathlib.Path(__file__).resolve().parents[1] / "app"
+
+# Ad-hoc clients that talk to LOCALHOST sidecars. They are covered by the
+# sidecar rows in /api/status and are not external sources, so they do not
+# belong in the unmeasured list.
+_LOCALHOST_CLIENTS = {
+    "adsb_sidecar.py", "ais_sidecar.py", "browser_fetch.py", "llamacpp_sidecar.py",
+    "vllm_sidecar.py", "mavlink_sidecar.py", "routes/ai_models.py",
+}
+
+
+def test_unmeasured_list_matches_the_tree() -> None:
+    """Every external upstream that builds its own httpx client is declared.
+
+    /api/status/sources can only see calls through the shared client. A client
+    added elsewhere and left off the unmeasured list makes that endpoint quietly
+    incomplete, which is the same overclaim it was built to end.
+    """
+    from app.routes.status import _UNMEASURED
+
+    declared = {w.rsplit(":", 1)[0] for w, _ in _UNMEASURED}
+    found: set[str] = set()
+    for f in sorted(APP.rglob("*.py")):
+        rel = str(f.relative_to(APP))
+        if rel == "upstream.py" or rel in _LOCALHOST_CLIENTS:
+            continue
+        if re.search(r"httpx\.(Async)?Client\(", f.read_text()):
+            found.add(rel)
+    missing = found - declared
+    assert not missing, (
+        "these build their own httpx client and are invisible to "
+        f"/api/status/sources, but are not declared in _UNMEASURED: {sorted(missing)}"
+    )
+    stale = declared - found
+    assert not stale, f"_UNMEASURED names files with no httpx client any more: {sorted(stale)}"
+
+
+# Broad handlers around a _feedgeo fetch that deliberately do NOT state a reason,
+# and why. Adding a line here is a decision: it says an operator seeing this
+# route empty does not need to know whether it was asked.
+_SILENT_OK: dict[str, str] = {
+    "routes/spacewx.py": "three NOAA sub-feeds merged into one collection; any one "
+                         "failing must not 502 the other two, and the route has no "
+                         "per-sub-feed slot to report into",
+}
+
+
+def test_a_swallowed_feed_failure_states_a_reason() -> None:
+    """An empty layer and an unasked layer must not look identical.
+
+    The 2026-08-20 sweep found 17 routes answering 200 with an empty body. This
+    holds the ones fed by _feedgeo to the `degraded`/`note` shape the codebase
+    already uses (routes/events.py), so they land in the sweep's `200-degraded`
+    bucket rather than `200-empty`.
+    """
+    offenders: list[str] = []
+    for f in sorted(APP.rglob("*.py")):
+        rel = str(f.relative_to(APP))
+        if rel in _SILENT_OK:
+            continue
+        src = f.read_text()
+        try:
+            tree = ast.parse(src)
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            called = {
+                c.func.attr for c in ast.walk(node)
+                if isinstance(c, ast.Call) and isinstance(c.func, ast.Attribute)
+            }
+            if not ({"fetch_json", "fetch_text"} & called):
+                continue
+            for h in node.handlers:
+                if not (isinstance(h.type, ast.Name)
+                        and h.type.id in ("Exception", "BaseException")):
+                    continue
+                body = ast.unparse(ast.Module(body=h.body, type_ignores=[]))
+                honest = (
+                    "degraded" in body or "note" in body or "error" in body
+                    or "raise" in body
+                )
+                if not honest:
+                    offenders.append(f"{rel}:{h.lineno}")
+    assert not offenders, (
+        "these swallow an upstream failure and answer empty without saying so. "
+        "Use fg.degraded_fc(...) / fg.degraded(...), re-raise, or record an "
+        f"exception in _SILENT_OK with the reason: {offenders}"
+    )

--- a/apps/api/tests/test_feed_honesty.py
+++ b/apps/api/tests/test_feed_honesty.py
@@ -219,3 +219,37 @@ def test_a_swallowed_feed_failure_states_a_reason() -> None:
         "Use fg.degraded_fc(...) / fg.degraded(...), re-raise, or record an "
         f"exception in _SILENT_OK with the reason: {offenders}"
     )
+
+
+# ── the falsification test for /api/status ───────────────────────────────────
+#
+# The unknown -> green transition was proven live (USGS flipped after a real
+# fetch). The failing -> degraded branch was NOT: every host failing in the live
+# registry that day was one none of the three measured feeds map to, so a typo
+# in `_measured`'s failing branch would have survived the whole verification.
+# This is that half, and it needs neither root nor network.
+
+
+def test_a_failing_upstream_turns_its_status_feed_degraded(client, monkeypatch) -> None:
+    from app.routes import adsb as adsb_routes
+    from app.routes import status as status_mod
+
+    monkeypatch.setattr(adsb_routes, "snapshot_count", lambda: 9000)
+    monkeypatch.setattr(adsb_routes, "snapshot_age_s", lambda: 3.0)
+
+    def usgs(body: dict) -> dict:
+        return next(f for f in body["feeds"] if f["name"].startswith("USGS"))
+
+    # Never called: not green, and not red either.
+    assert usgs(client.get("/api/status").json())["status"] == "unknown"
+
+    upstream.record_success("earthquake.usgs.gov", 120.0, 200)
+    assert usgs(client.get("/api/status").json())["status"] == "green"
+
+    # A failure AFTER the success must win: this feed shipped hardcoded `True`
+    # with the detail "Keyless, always on."
+    upstream.record_failure("earthquake.usgs.gov", "HTTP 503", 503)
+    feed = usgs(client.get("/api/status").json())
+    assert feed["status"] == "degraded"
+    assert "503" in feed["detail"]
+    assert status_mod._measured("earthquake.usgs.gov")[0] is False

--- a/apps/api/tests/test_mega_ledger_parsers.py
+++ b/apps/api/tests/test_mega_ledger_parsers.py
@@ -99,7 +99,13 @@ def test_kiwisdr_reads_a_js_literal_and_always_answers_a_collection(
 
     monkeypatch.setattr(fg, "fetch_text", boom)
     dead = asyncio.run(sc.kiwisdr_stations())
-    assert dead == {"type": "FeatureCollection", "features": []}
+    # Still a well-formed collection, so the adapter never breaks -- but it now
+    # says WHY it is empty. "No receivers here" and "we could not ask" used to be
+    # the same response; see tests/test_feed_honesty.py.
+    assert dead["type"] == "FeatureCollection"
+    assert dead["features"] == []
+    assert dead["degraded"] is True
+    assert "KiwiSDR" in dead["note"]
 
 
 def test_ukraine_alt_lists_only_alerting_regions(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/web/src/osint/SourcesPanel.tsx
+++ b/apps/web/src/osint/SourcesPanel.tsx
@@ -27,6 +27,34 @@ interface CatalogSource {
   format?: string;
 }
 
+/** One row of the backend's measured upstream health (GET /api/status/sources).
+ *  `state` is measured, never inferred from configuration: 'unknown' means the
+ *  host has not been called this process and is NOT a synonym for healthy. */
+interface SourceHealth {
+  host: string;
+  state: 'ok' | 'failing' | 'unknown';
+  ok: number;
+  fail: number;
+  latency_ms: number | null;
+  last_error: string | null;
+  success_age_s: number | null;
+}
+
+interface SourcesHealthResponse {
+  sources: SourceHealth[];
+  counts: { total?: number; ok?: number; failing?: number; unknown?: number };
+  unmeasured: { where: string; what: string }[];
+}
+
+/** The host a catalog row talks to, or null when the row names no URL.
+ *  Matching on host is what lets a catalog written by hand line up with a
+ *  registry keyed by what was actually called. */
+export function hostOf(source: { url_pattern?: string; route?: string }): string | null {
+  const raw = source.url_pattern ?? '';
+  const m = /^https?:\/\/([^/?#]+)/i.exec(raw);
+  return m?.[1]?.toLowerCase() ?? null;
+}
+
 interface CatalogResponse {
   total: number;
   categories: string[];
@@ -932,9 +960,35 @@ function LookupRow({
   );
 }
 
+/** Measured state for one catalog row.
+ *
+ *  A source with no row has not been called this session. That is reported as
+ *  "not called", never as healthy: treating never-attempted as green is the
+ *  exact defect /api/status carried for two hardcoded feeds. */
+function SourceState({ row }: { row: SourceHealth | null }): JSX.Element {
+  if (row === null) {
+    return <span className="text-[10px] text-txt-3">not called</span>;
+  }
+  const tone =
+    row.state === 'ok' ? 'text-ok' : row.state === 'failing' ? 'text-alert' : 'text-txt-3';
+  const detail =
+    row.state === 'failing'
+      ? (row.last_error ?? 'failing')
+      : row.state === 'ok'
+        ? `${row.success_age_s === null ? '—' : `${Math.round(row.success_age_s)}s ago`}` +
+          `${row.latency_ms === null ? '' : ` · ${Math.round(row.latency_ms)}ms`}`
+        : 'not called';
+  return (
+    <span className={`text-[10px] ${tone}`} title={`${row.ok} ok · ${row.fail} failed`}>
+      {row.state} · {detail}
+    </span>
+  );
+}
+
 export function SourcesPanel(): JSX.Element {
   const [catalog, setCatalog] = useState<CatalogResponse | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [health, setHealth] = useState<SourcesHealthResponse | null>(null);
   const [category, setCategory] = useState<string>('');
   const [values, setValues] = useState<Record<string, string>>({});
 
@@ -957,6 +1011,31 @@ export function SourcesPanel(): JSX.Element {
       live = false;
     };
   }, []);
+
+  // Measured health, alongside the catalog. The catalog says what EXISTS; this
+  // says what answered. Best effort: the panel is still useful without it.
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      try {
+        const res = await apiFetch('/api/status/sources');
+        if (!res.ok) return;
+        const json = (await res.json()) as SourcesHealthResponse;
+        if (live) setHealth(json);
+      } catch {
+        /* the status column simply reads "—" */
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const byHost = useMemo(() => {
+    const m = new Map<string, SourceHealth>();
+    for (const r of health?.sources ?? []) m.set(r.host.toLowerCase(), r);
+    return m;
+  }, [health]);
 
   const shown = useMemo(
     () =>
@@ -1020,6 +1099,13 @@ export function SourcesPanel(): JSX.Element {
           {catalogError !== null && (
             <div className="mt-1 text-[11px] text-alert">{catalogError}</div>
           )}
+          <div className="mt-1 text-[11px] text-txt-3">
+            {health
+              ? `Measured this session · ${health.counts.ok ?? 0} answering · ` +
+                `${health.counts.failing ?? 0} failing · ${health.unmeasured.length} ` +
+                'upstreams build their own client and are not measured here'
+              : 'Measured health unavailable'}
+          </div>
         </div>
         {shown.map((s) => (
           <div key={s.id} className="border-b border-line-2 px-3 py-1.5">
@@ -1027,6 +1113,7 @@ export function SourcesPanel(): JSX.Element {
               <span className="text-[12px] text-txt-0">{s.name}</span>
               <span className="mono text-[10px] text-txt-3">{s.category}</span>
               <span className="text-[10px] text-txt-3">{s.auth ? `auth: ${s.auth}` : 'auth: —'}</span>
+              <SourceState row={byHost.get(hostOf(s) ?? '') ?? null} />
             </div>
             <div className="mono truncate text-[10px] text-txt-3">
               {s.route ?? s.url_pattern ?? '—'}

--- a/apps/web/src/osint/routeCoverage.test.ts
+++ b/apps/web/src/osint/routeCoverage.test.ts
@@ -25,7 +25,6 @@ const API_ROUTES = join(HERE, '../../../api/app/routes');
 const EXEMPT: Record<string, string> = {
   // Infrastructure the browser reaches without naming the path.
   '/api/health': 'liveness probe for the process supervisor, not the UI',
-  '/api/status/doctor': 'called by scripts/verify.sh --live',
   // Write/side-effect routes driven by an agent or a server-side caller.
   '/api/evidence/manifest': 'POST: written by the case exporter server-side',
   '/api/imagery/task': 'POST: commercial tasking, gated off in the keyless build',

--- a/docs/audits/2026-08-20-api-sweep-baseline.json
+++ b/docs/audits/2026-08-20-api-sweep-baseline.json
@@ -1,0 +1,2251 @@
+{
+  "posture": {
+    "open_mode": true,
+    "probe_status": 200,
+    "note": "ALLOW_UNAUTHENTICATED is in effect: auth-gated routes are reachable and a 401 below is a real finding"
+  },
+  "seeds": {
+    "icao24": "a204c9",
+    "hex": "a204c9",
+    "ident": "a204c9"
+  },
+  "counts": {
+    "200-real": 162,
+    "200-empty": 15,
+    "auth-gated": 6,
+    "5xx": 4,
+    "http-400": 1,
+    "200-degraded": 11,
+    "200-binary": 5,
+    "timeout": 1,
+    "404": 3
+  },
+  "results": {
+    "/api/acars": {
+      "bucket": "200-real",
+      "detail": "25,346 bytes",
+      "ms": 5456.815026998811,
+      "status": 200,
+      "bytes": 25346,
+      "url": "http://127.0.0.1:8000/api/acars"
+    },
+    "/api/acars/geojson": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 5461.776620999444,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/acars/geojson"
+    },
+    "/api/acars/stats": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 989.8581350007589,
+      "status": 200,
+      "bytes": 2,
+      "url": "http://127.0.0.1:8000/api/acars/stats"
+    },
+    "/api/actions": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 5.27014399995096,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/actions"
+    },
+    "/api/actions/proposals": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 5.13829400006216,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/actions/proposals"
+    },
+    "/api/adsb/fi/global": {
+      "bucket": "5xx",
+      "detail": "HTTP 502",
+      "ms": 812.1819579992007,
+      "status": 502,
+      "bytes": 34,
+      "url": "http://127.0.0.1:8000/api/adsb/fi/global"
+    },
+    "/api/adsb/fr24/search": {
+      "bucket": "200-real",
+      "detail": "323 bytes",
+      "ms": 739.4934340009058,
+      "status": 200,
+      "bytes": 323,
+      "url": "http://127.0.0.1:8000/api/adsb/fr24/search?q=berlin"
+    },
+    "/api/adsb/global": {
+      "bucket": "200-real",
+      "detail": "10,022,430 bytes",
+      "ms": 743.043504000525,
+      "status": 200,
+      "bytes": 10022430,
+      "url": "http://127.0.0.1:8000/api/adsb/global"
+    },
+    "/api/adsb/history/dates": {
+      "bucket": "200-real",
+      "detail": "489 bytes",
+      "ms": 67.44769100077974,
+      "status": 200,
+      "bytes": 489,
+      "url": "http://127.0.0.1:8000/api/adsb/history/dates"
+    },
+    "/api/adsb/ladd": {
+      "bucket": "200-real",
+      "detail": "287,633 bytes",
+      "ms": 6757.951706998938,
+      "status": 200,
+      "bytes": 287633,
+      "url": "http://127.0.0.1:8000/api/adsb/ladd"
+    },
+    "/api/adsb/live/emergencies": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 8208.04435699938,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/adsb/live/emergencies"
+    },
+    "/api/adsb/live/mil": {
+      "bucket": "200-real",
+      "detail": "168,188 bytes",
+      "ms": 1195.0656049993995,
+      "status": 200,
+      "bytes": 168188,
+      "url": "http://127.0.0.1:8000/api/adsb/live/mil"
+    },
+    "/api/adsb/live/squawk/{code}": {
+      "bucket": "http-400",
+      "detail": "",
+      "ms": 0.9830330000113463,
+      "status": 400,
+      "bytes": 36,
+      "url": "http://127.0.0.1:8000/api/adsb/live/squawk/DEU"
+    },
+    "/api/adsb/lol/global": {
+      "bucket": "200-real",
+      "detail": "10,022,430 bytes",
+      "ms": 147.62361599969154,
+      "status": 200,
+      "bytes": 10022430,
+      "url": "http://127.0.0.1:8000/api/adsb/lol/global"
+    },
+    "/api/adsb/lol/point": {
+      "bucket": "200-real",
+      "detail": "361,214 bytes",
+      "ms": 2479.2632600001525,
+      "status": 200,
+      "bytes": 361214,
+      "url": "http://127.0.0.1:8000/api/adsb/lol/point?lat=50&lon=10"
+    },
+    "/api/adsb/pia": {
+      "bucket": "200-real",
+      "detail": "3,214 bytes",
+      "ms": 3473.517898000864,
+      "status": 200,
+      "bytes": 3214,
+      "url": "http://127.0.0.1:8000/api/adsb/pia"
+    },
+    "/api/adsb/snapshot_age": {
+      "bucket": "200-real",
+      "detail": "92 bytes",
+      "ms": 101.85575300056371,
+      "status": 200,
+      "bytes": 92,
+      "url": "http://127.0.0.1:8000/api/adsb/snapshot_age"
+    },
+    "/api/advisories": {
+      "bucket": "200-real",
+      "detail": "96,587 bytes",
+      "ms": 1.6246450013568392,
+      "status": 200,
+      "bytes": 96587,
+      "url": "http://127.0.0.1:8000/api/advisories"
+    },
+    "/api/ai/batch": {
+      "bucket": "200-real",
+      "detail": "82 bytes",
+      "ms": 1.8936550004582386,
+      "status": 200,
+      "bytes": 82,
+      "url": "http://127.0.0.1:8000/api/ai/batch"
+    },
+    "/api/ai/hardware": {
+      "bucket": "200-real",
+      "detail": "837 bytes",
+      "ms": 38.635233000604785,
+      "status": 200,
+      "bytes": 837,
+      "url": "http://127.0.0.1:8000/api/ai/hardware"
+    },
+    "/api/ai/local": {
+      "bucket": "200-real",
+      "detail": "280 bytes",
+      "ms": 5.57564500013541,
+      "status": 200,
+      "bytes": 280,
+      "url": "http://127.0.0.1:8000/api/ai/local"
+    },
+    "/api/airspace/nas-status": {
+      "bucket": "200-real",
+      "detail": "1,291 bytes",
+      "ms": 0.856452001244179,
+      "status": 200,
+      "bytes": 1291,
+      "url": "http://127.0.0.1:8000/api/airspace/nas-status"
+    },
+    "/api/airspace/tfr": {
+      "bucket": "200-real",
+      "detail": "158,740 bytes",
+      "ms": 1.5933350005070679,
+      "status": 200,
+      "bytes": 158740,
+      "url": "http://127.0.0.1:8000/api/airspace/tfr"
+    },
+    "/api/alerts": {
+      "bucket": "200-real",
+      "detail": "15,203 bytes",
+      "ms": 0.7482720011466881,
+      "status": 200,
+      "bytes": 15203,
+      "url": "http://127.0.0.1:8000/api/alerts"
+    },
+    "/api/alerts/deliveries": {
+      "bucket": "200-real",
+      "detail": "7,909 bytes",
+      "ms": 2.111155999955372,
+      "status": 200,
+      "bytes": 7909,
+      "url": "http://127.0.0.1:8000/api/alerts/deliveries"
+    },
+    "/api/alerts/fema": {
+      "bucket": "200-real",
+      "detail": "26,832 bytes",
+      "ms": 1.2209429987706244,
+      "status": 200,
+      "bytes": 26832,
+      "url": "http://127.0.0.1:8000/api/alerts/fema"
+    },
+    "/api/alerts/meteoalarm": {
+      "bucket": "200-real",
+      "detail": "56,723 bytes",
+      "ms": 1.2940640008309856,
+      "status": 200,
+      "bytes": 56723,
+      "url": "http://127.0.0.1:8000/api/alerts/meteoalarm"
+    },
+    "/api/alerts/rules": {
+      "bucket": "200-real",
+      "detail": "257 bytes",
+      "ms": 1.3484539995261002,
+      "status": 200,
+      "bytes": 257,
+      "url": "http://127.0.0.1:8000/api/alerts/rules"
+    },
+    "/api/alerts/spc-storms": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 0.7179220010584686,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/alerts/spc-storms"
+    },
+    "/api/alerts/standing": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 1.3861539991921745,
+      "status": 200,
+      "bytes": 48,
+      "url": "http://127.0.0.1:8000/api/alerts/standing"
+    },
+    "/api/alerts/ukraine": {
+      "bucket": "200-real",
+      "detail": "5,811 bytes",
+      "ms": 1604.968674999327,
+      "status": 200,
+      "bytes": 5811,
+      "url": "http://127.0.0.1:8000/api/alerts/ukraine"
+    },
+    "/api/alerts/ukraine-alt": {
+      "bucket": "200-real",
+      "detail": "484 bytes",
+      "ms": 853.9123599985032,
+      "status": 200,
+      "bytes": 484,
+      "url": "http://127.0.0.1:8000/api/alerts/ukraine-alt"
+    },
+    "/api/answers": {
+      "bucket": "200-real",
+      "detail": "6,737 bytes",
+      "ms": 1585.2500119999604,
+      "status": 200,
+      "bytes": 6737,
+      "url": "http://127.0.0.1:8000/api/answers"
+    },
+    "/api/audit": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 83.67375399939192,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/audit"
+    },
+    "/api/aviation/airports/full": {
+      "bucket": "200-real",
+      "detail": "1,790,821 bytes",
+      "ms": 15.268000001015025,
+      "status": 200,
+      "bytes": 1790821,
+      "url": "http://127.0.0.1:8000/api/aviation/airports/full"
+    },
+    "/api/aviation/airports/openflights": {
+      "bucket": "200-real",
+      "detail": "2,045,408 bytes",
+      "ms": 32.86302800006524,
+      "status": 200,
+      "bytes": 2045408,
+      "url": "http://127.0.0.1:8000/api/aviation/airports/openflights"
+    },
+    "/api/aviation/routes": {
+      "bucket": "200-real",
+      "detail": "2,774,582 bytes",
+      "ms": 49.99943399889162,
+      "status": 200,
+      "bytes": 2774582,
+      "url": "http://127.0.0.1:8000/api/aviation/routes"
+    },
+    "/api/aviation/sigmet": {
+      "bucket": "200-real",
+      "detail": "3,410 bytes",
+      "ms": 1.0419919999549165,
+      "status": 200,
+      "bytes": 3410,
+      "url": "http://127.0.0.1:8000/api/aviation/sigmet"
+    },
+    "/api/aviation/states": {
+      "bucket": "200-real",
+      "detail": "4,930,514 bytes",
+      "ms": 3570.43088699902,
+      "status": 200,
+      "bytes": 4930514,
+      "url": "http://127.0.0.1:8000/api/aviation/states"
+    },
+    "/api/buildings/microsoft": {
+      "bucket": "200-real",
+      "detail": "54,972 bytes",
+      "ms": 1.573233999806689,
+      "status": 200,
+      "bytes": 54972,
+      "url": "http://127.0.0.1:8000/api/buildings/microsoft"
+    },
+    "/api/buildings/overture": {
+      "bucket": "200-real",
+      "detail": "382 bytes",
+      "ms": 0.8080719999270514,
+      "status": 200,
+      "bytes": 382,
+      "url": "http://127.0.0.1:8000/api/buildings/overture"
+    },
+    "/api/cables": {
+      "bucket": "200-real",
+      "detail": "738,945 bytes",
+      "ms": 3.220189000785467,
+      "status": 200,
+      "bytes": 738945,
+      "url": "http://127.0.0.1:8000/api/cables"
+    },
+    "/api/cables/landings": {
+      "bucket": "200-real",
+      "detail": "360,188 bytes",
+      "ms": 2.5513170003250707,
+      "status": 200,
+      "bytes": 360188,
+      "url": "http://127.0.0.1:8000/api/cables/landings"
+    },
+    "/api/cams": {
+      "bucket": "200-real",
+      "detail": "560,568 bytes",
+      "ms": 3.431760000239592,
+      "status": 200,
+      "bytes": 560568,
+      "url": "http://127.0.0.1:8000/api/cams"
+    },
+    "/api/cams/insecam": {
+      "bucket": "200-real",
+      "detail": "452 bytes",
+      "ms": 1.500483998825075,
+      "status": 200,
+      "bytes": 452,
+      "url": "http://127.0.0.1:8000/api/cams/insecam"
+    },
+    "/api/climate/anomalies": {
+      "bucket": "200-real",
+      "detail": "8,263 bytes",
+      "ms": 0.6453920013882453,
+      "status": 200,
+      "bytes": 8263,
+      "url": "http://127.0.0.1:8000/api/climate/anomalies"
+    },
+    "/api/config": {
+      "bucket": "200-real",
+      "detail": "400 bytes",
+      "ms": 0.535151000804035,
+      "status": 200,
+      "bytes": 400,
+      "url": "http://127.0.0.1:8000/api/config"
+    },
+    "/api/conflict/deepstate-firms": {
+      "bucket": "200-real",
+      "detail": "390,528 bytes",
+      "ms": 2.704737999010831,
+      "status": 200,
+      "bytes": 390528,
+      "url": "http://127.0.0.1:8000/api/conflict/deepstate-firms"
+    },
+    "/api/conflict/deepstate-news": {
+      "bucket": "200-real",
+      "detail": "56,561 bytes",
+      "ms": 1.0367630002292572,
+      "status": 200,
+      "bytes": 56561,
+      "url": "http://127.0.0.1:8000/api/conflict/deepstate-news"
+    },
+    "/api/conflict/deepstate-radiation": {
+      "bucket": "200-real",
+      "detail": "115,653 bytes",
+      "ms": 0.9482429995841812,
+      "status": 200,
+      "bytes": 115653,
+      "url": "http://127.0.0.1:8000/api/conflict/deepstate-radiation"
+    },
+    "/api/conflict/live": {
+      "bucket": "200-real",
+      "detail": "748,094 bytes",
+      "ms": 3.603970000767731,
+      "status": 200,
+      "bytes": 748094,
+      "url": "http://127.0.0.1:8000/api/conflict/live"
+    },
+    "/api/conflict/ucdp": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.9085719993890962,
+      "status": 200,
+      "bytes": 143,
+      "url": "http://127.0.0.1:8000/api/conflict/ucdp"
+    },
+    "/api/country/indicators": {
+      "bucket": "200-real",
+      "detail": "1,972 bytes",
+      "ms": 0.944022998737637,
+      "status": 200,
+      "bytes": 1972,
+      "url": "http://127.0.0.1:8000/api/country/indicators"
+    },
+    "/api/country/instability": {
+      "bucket": "200-real",
+      "detail": "5,757 bytes",
+      "ms": 7.9759609998291126,
+      "status": 200,
+      "bytes": 5757,
+      "url": "http://127.0.0.1:8000/api/country/instability"
+    },
+    "/api/country/instability/{iso3}": {
+      "bucket": "200-real",
+      "detail": "31,628 bytes",
+      "ms": 14.051196998480009,
+      "status": 200,
+      "bytes": 31628,
+      "url": "http://127.0.0.1:8000/api/country/instability/DEU"
+    },
+    "/api/country/list": {
+      "bucket": "200-real",
+      "detail": "28,081 bytes",
+      "ms": 1.6530350003449712,
+      "status": 200,
+      "bytes": 28081,
+      "url": "http://127.0.0.1:8000/api/country/list"
+    },
+    "/api/country/{iso3}/brief": {
+      "bucket": "200-real",
+      "detail": "2,617 bytes",
+      "ms": 148.10633700108156,
+      "status": 200,
+      "bytes": 2617,
+      "url": "http://127.0.0.1:8000/api/country/DEU/brief"
+    },
+    "/api/country/{iso3}/profile": {
+      "bucket": "200-real",
+      "detail": "1,119 bytes",
+      "ms": 1.32124299852876,
+      "status": 200,
+      "bytes": 1119,
+      "url": "http://127.0.0.1:8000/api/country/DEU/profile"
+    },
+    "/api/country/{iso3}/security": {
+      "bucket": "200-real",
+      "detail": "1,225 bytes",
+      "ms": 0.9201720004057279,
+      "status": 200,
+      "bytes": 1225,
+      "url": "http://127.0.0.1:8000/api/country/DEU/security"
+    },
+    "/api/country/{iso3}/un": {
+      "bucket": "200-real",
+      "detail": "6,684 bytes",
+      "ms": 0.8959229999163654,
+      "status": 200,
+      "bytes": 6684,
+      "url": "http://127.0.0.1:8000/api/country/DEU/un"
+    },
+    "/api/country/{iso3}/worldbank": {
+      "bucket": "200-real",
+      "detail": "12,641 bytes",
+      "ms": 0.9942430006049108,
+      "status": 200,
+      "bytes": 12641,
+      "url": "http://127.0.0.1:8000/api/country/DEU/worldbank"
+    },
+    "/api/cyber/cloudflare/outages": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.6185319998621708,
+      "status": 200,
+      "bytes": 53,
+      "url": "http://127.0.0.1:8000/api/cyber/cloudflare/outages"
+    },
+    "/api/cyber/ioda/outages": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.41018099909706507,
+      "status": 200,
+      "bytes": 55,
+      "url": "http://127.0.0.1:8000/api/cyber/ioda/outages"
+    },
+    "/api/cyber/kev": {
+      "bucket": "200-real",
+      "detail": "213,653 bytes",
+      "ms": 1.02594300005876,
+      "status": 200,
+      "bytes": 213653,
+      "url": "http://127.0.0.1:8000/api/cyber/kev"
+    },
+    "/api/cyber/routing": {
+      "bucket": "200-real",
+      "detail": "16,325 bytes",
+      "ms": 0.7489620002161246,
+      "status": 200,
+      "bytes": 16325,
+      "url": "http://127.0.0.1:8000/api/cyber/routing"
+    },
+    "/api/displacement": {
+      "bucket": "200-real",
+      "detail": "22,377 bytes",
+      "ms": 0.5791509993287036,
+      "status": 200,
+      "bytes": 22377,
+      "url": "http://127.0.0.1:8000/api/displacement"
+    },
+    "/api/displacement/unhcr": {
+      "bucket": "200-real",
+      "detail": "231 bytes",
+      "ms": 0.7841120004741242,
+      "status": 200,
+      "bytes": 231,
+      "url": "http://127.0.0.1:8000/api/displacement/unhcr"
+    },
+    "/api/env/air-quality": {
+      "bucket": "200-real",
+      "detail": "10,505 bytes",
+      "ms": 0.45658099952561315,
+      "status": 200,
+      "bytes": 10505,
+      "url": "http://127.0.0.1:8000/api/env/air-quality"
+    },
+    "/api/env/spaceweather": {
+      "bucket": "200-real",
+      "detail": "375 bytes",
+      "ms": 0.503561999721569,
+      "status": 200,
+      "bytes": 375,
+      "url": "http://127.0.0.1:8000/api/env/spaceweather"
+    },
+    "/api/eq": {
+      "bucket": "200-real",
+      "detail": "214,412 bytes",
+      "ms": 1.4917340013198555,
+      "status": 200,
+      "bytes": 214412,
+      "url": "http://127.0.0.1:8000/api/eq"
+    },
+    "/api/events/acled": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.545561000762973,
+      "status": 200,
+      "bytes": 90,
+      "url": "http://127.0.0.1:8000/api/events/acled"
+    },
+    "/api/events/all": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 0.941692000196781,
+      "status": 200,
+      "bytes": 321,
+      "url": "http://127.0.0.1:8000/api/events/all?lat=50&lon=10"
+    },
+    "/api/events/eonet": {
+      "bucket": "200-real",
+      "detail": "48,589 bytes",
+      "ms": 0.8169120010279585,
+      "status": 200,
+      "bytes": 48589,
+      "url": "http://127.0.0.1:8000/api/events/eonet"
+    },
+    "/api/events/gdelt": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.40316199920198414,
+      "status": 200,
+      "bytes": 85,
+      "url": "http://127.0.0.1:8000/api/events/gdelt"
+    },
+    "/api/events/gdelt-doc": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.9012819991767174,
+      "status": 200,
+      "bytes": 102,
+      "url": "http://127.0.0.1:8000/api/events/gdelt-doc"
+    },
+    "/api/events/gdelt-summary": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.7906119990366278,
+      "status": 200,
+      "bytes": 61,
+      "url": "http://127.0.0.1:8000/api/events/gdelt-summary"
+    },
+    "/api/evidence": {
+      "bucket": "200-real",
+      "detail": "990 bytes",
+      "ms": 3.1683590004831785,
+      "status": 200,
+      "bytes": 990,
+      "url": "http://127.0.0.1:8000/api/evidence"
+    },
+    "/api/export": {
+      "bucket": "200-real",
+      "detail": "11,096,085 bytes",
+      "ms": 156.5882100003364,
+      "status": 200,
+      "bytes": 11096085,
+      "url": "http://127.0.0.1:8000/api/export"
+    },
+    "/api/firms": {
+      "bucket": "200-real",
+      "detail": "15,010,387 bytes",
+      "ms": 92.36132800106134,
+      "status": 200,
+      "bytes": 15010387,
+      "url": "http://127.0.0.1:8000/api/firms"
+    },
+    "/api/foundry/bindings": {
+      "bucket": "200-real",
+      "detail": "315 bytes",
+      "ms": 192.7761470014957,
+      "status": 200,
+      "bytes": 315,
+      "url": "http://127.0.0.1:8000/api/foundry/bindings"
+    },
+    "/api/foundry/builds": {
+      "bucket": "200-real",
+      "detail": "6,035 bytes",
+      "ms": 96.95465000004333,
+      "status": 200,
+      "bytes": 6035,
+      "url": "http://127.0.0.1:8000/api/foundry/builds"
+    },
+    "/api/foundry/checks": {
+      "bucket": "200-real",
+      "detail": "202 bytes",
+      "ms": 1.996005999899353,
+      "status": 200,
+      "bytes": 202,
+      "url": "http://127.0.0.1:8000/api/foundry/checks"
+    },
+    "/api/foundry/connections": {
+      "bucket": "200-real",
+      "detail": "175 bytes",
+      "ms": 2.6158169985137647,
+      "status": 200,
+      "bytes": 175,
+      "url": "http://127.0.0.1:8000/api/foundry/connections"
+    },
+    "/api/foundry/datasets": {
+      "bucket": "200-real",
+      "detail": "7,402 bytes",
+      "ms": 2.0804760006285505,
+      "status": 200,
+      "bytes": 7402,
+      "url": "http://127.0.0.1:8000/api/foundry/datasets"
+    },
+    "/api/foundry/kinds": {
+      "bucket": "200-real",
+      "detail": "534 bytes",
+      "ms": 2.069875001325272,
+      "status": 200,
+      "bytes": 534,
+      "url": "http://127.0.0.1:8000/api/foundry/kinds"
+    },
+    "/api/foundry/lineage": {
+      "bucket": "200-real",
+      "detail": "3,007 bytes",
+      "ms": 17.776607999621774,
+      "status": 200,
+      "bytes": 3007,
+      "url": "http://127.0.0.1:8000/api/foundry/lineage"
+    },
+    "/api/foundry/monitors": {
+      "bucket": "200-real",
+      "detail": "391 bytes",
+      "ms": 1.2416240006132284,
+      "status": 200,
+      "bytes": 391,
+      "url": "http://127.0.0.1:8000/api/foundry/monitors"
+    },
+    "/api/foundry/schedules": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 1.2757429994962877,
+      "status": 200,
+      "bytes": 2,
+      "url": "http://127.0.0.1:8000/api/foundry/schedules"
+    },
+    "/api/foundry/summary": {
+      "bucket": "200-real",
+      "detail": "4,532 bytes",
+      "ms": 10.896589999902062,
+      "status": 200,
+      "bytes": 4532,
+      "url": "http://127.0.0.1:8000/api/foundry/summary"
+    },
+    "/api/foundry/transforms": {
+      "bucket": "200-real",
+      "detail": "1,454 bytes",
+      "ms": 1.7062539991457015,
+      "status": 200,
+      "bytes": 1454,
+      "url": "http://127.0.0.1:8000/api/foundry/transforms"
+    },
+    "/api/geocode": {
+      "bucket": "200-real",
+      "detail": "102 bytes",
+      "ms": 0.8957019999797922,
+      "status": 200,
+      "bytes": 102,
+      "url": "http://127.0.0.1:8000/api/geocode?q=berlin"
+    },
+    "/api/ground/nearby": {
+      "bucket": "200-real",
+      "detail": "9,613 bytes",
+      "ms": 0.9264820000680629,
+      "status": 200,
+      "bytes": 9613,
+      "url": "http://127.0.0.1:8000/api/ground/nearby?lat=50&lon=10"
+    },
+    "/api/hazards/cyclones": {
+      "bucket": "200-real",
+      "detail": "317 bytes",
+      "ms": 0.9442829996260116,
+      "status": 200,
+      "bytes": 317,
+      "url": "http://127.0.0.1:8000/api/hazards/cyclones"
+    },
+    "/api/hazards/fire-perimeters": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 1.380933999826084,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/hazards/fire-perimeters"
+    },
+    "/api/hazards/gdacs": {
+      "bucket": "5xx",
+      "detail": "HTTP 502",
+      "ms": 1043.1744979996438,
+      "status": 502,
+      "bytes": 25,
+      "url": "http://127.0.0.1:8000/api/hazards/gdacs"
+    },
+    "/api/hazards/radiation": {
+      "bucket": "200-real",
+      "detail": "235,682 bytes",
+      "ms": 1.500903999840375,
+      "status": 200,
+      "bytes": 235682,
+      "url": "http://127.0.0.1:8000/api/hazards/radiation"
+    },
+    "/api/hazards/reliefweb": {
+      "bucket": "5xx",
+      "detail": "HTTP 502",
+      "ms": 993.2685950006999,
+      "status": 502,
+      "bytes": 25,
+      "url": "http://127.0.0.1:8000/api/hazards/reliefweb"
+    },
+    "/api/hazards/volcanoes": {
+      "bucket": "200-real",
+      "detail": "290,807 bytes",
+      "ms": 2.812977998473798,
+      "status": 200,
+      "bytes": 290807,
+      "url": "http://127.0.0.1:8000/api/hazards/volcanoes"
+    },
+    "/api/health": {
+      "bucket": "200-real",
+      "detail": "15 bytes",
+      "ms": 0.6737820003763773,
+      "status": 200,
+      "bytes": 15,
+      "url": "http://127.0.0.1:8000/api/health"
+    },
+    "/api/health/memory": {
+      "bucket": "200-real",
+      "detail": "138 bytes",
+      "ms": 0.5323010009306017,
+      "status": 200,
+      "bytes": 138,
+      "url": "http://127.0.0.1:8000/api/health/memory"
+    },
+    "/api/history/coverage": {
+      "bucket": "200-real",
+      "detail": "259 bytes",
+      "ms": 0.7399419991998002,
+      "status": 200,
+      "bytes": 259,
+      "url": "http://127.0.0.1:8000/api/history/coverage"
+    },
+    "/api/history/stats": {
+      "bucket": "200-real",
+      "detail": "347 bytes",
+      "ms": 0.6358619993989123,
+      "status": 200,
+      "bytes": 347,
+      "url": "http://127.0.0.1:8000/api/history/stats"
+    },
+    "/api/history/timeseries": {
+      "bucket": "200-real",
+      "detail": "278 bytes",
+      "ms": 1968.2486000001518,
+      "status": 200,
+      "bytes": 278,
+      "url": "http://127.0.0.1:8000/api/history/timeseries"
+    },
+    "/api/history/tracks": {
+      "bucket": "200-real",
+      "detail": "1,770,503 bytes",
+      "ms": 7380.600856999081,
+      "status": 200,
+      "bytes": 1770503,
+      "url": "http://127.0.0.1:8000/api/history/tracks"
+    },
+    "/api/humanitarian/hdx": {
+      "bucket": "200-real",
+      "detail": "11,392 bytes",
+      "ms": 2.6737170010164846,
+      "status": 200,
+      "bytes": 11392,
+      "url": "http://127.0.0.1:8000/api/humanitarian/hdx"
+    },
+    "/api/imagery/catalog": {
+      "bucket": "200-real",
+      "detail": "4,714 bytes",
+      "ms": 1.374753001073259,
+      "status": 200,
+      "bytes": 4714,
+      "url": "http://127.0.0.1:8000/api/imagery/catalog"
+    },
+    "/api/imagery/chip": {
+      "bucket": "200-binary",
+      "detail": "image/jpeg - tile/chip route, correct",
+      "ms": 2.1564859998761676,
+      "status": 200,
+      "bytes": 662119,
+      "url": "http://127.0.0.1:8000/api/imagery/chip?lat=50&lon=10"
+    },
+    "/api/imagery/tasking/providers": {
+      "bucket": "200-real",
+      "detail": "627 bytes",
+      "ms": 1.1007020002580248,
+      "status": 200,
+      "bytes": 627,
+      "url": "http://127.0.0.1:8000/api/imagery/tasking/providers"
+    },
+    "/api/imagery/wayback": {
+      "bucket": "200-real",
+      "detail": "15,283 bytes",
+      "ms": 1.6855350004334468,
+      "status": 200,
+      "bytes": 15283,
+      "url": "http://127.0.0.1:8000/api/imagery/wayback"
+    },
+    "/api/infra/mines": {
+      "bucket": "200-real",
+      "detail": "13,184 bytes (needed params; empty when asked unbounded)",
+      "ms": 7.387879999441793,
+      "status": 200,
+      "bytes": 13184,
+      "url": "http://127.0.0.1:8000/api/infra/mines"
+    },
+    "/api/infra/powerplants": {
+      "bucket": "200-real",
+      "detail": "1,347,517 bytes",
+      "ms": 8.070041998507804,
+      "status": 200,
+      "bytes": 1347517,
+      "url": "http://127.0.0.1:8000/api/infra/powerplants"
+    },
+    "/api/intel/aircraft": {
+      "bucket": "200-real",
+      "detail": "46,777 bytes",
+      "ms": 810.7783939994988,
+      "status": 200,
+      "bytes": 46777,
+      "url": "http://127.0.0.1:8000/api/intel/aircraft"
+    },
+    "/api/intel/aircraft/{ident}": {
+      "bucket": "200-real",
+      "detail": "546 bytes",
+      "ms": 847.4997430002986,
+      "status": 200,
+      "bytes": 546,
+      "url": "http://127.0.0.1:8000/api/intel/aircraft/a204c9"
+    },
+    "/api/intel/anomalies": {
+      "bucket": "200-real",
+      "detail": "14,383 bytes",
+      "ms": 625.4154580001341,
+      "status": 200,
+      "bytes": 14383,
+      "url": "http://127.0.0.1:8000/api/intel/anomalies"
+    },
+    "/api/intel/aois": {
+      "bucket": "200-real",
+      "detail": "292 bytes",
+      "ms": 634.860641999694,
+      "status": 200,
+      "bytes": 292,
+      "url": "http://127.0.0.1:8000/api/intel/aois"
+    },
+    "/api/intel/area": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 255.84454599993478,
+      "status": 200,
+      "bytes": 41218,
+      "url": "http://127.0.0.1:8000/api/intel/area?lat=50&lon=10"
+    },
+    "/api/intel/corroborate": {
+      "bucket": "200-real",
+      "detail": "484 bytes",
+      "ms": 254.41376300113916,
+      "status": 200,
+      "bytes": 484,
+      "url": "http://127.0.0.1:8000/api/intel/corroborate?lon=10&lat=50"
+    },
+    "/api/intel/dark-vessels/sar": {
+      "bucket": "200-real",
+      "detail": "203,390 bytes",
+      "ms": 5453.224787999716,
+      "status": 200,
+      "bytes": 203390,
+      "url": "http://127.0.0.1:8000/api/intel/dark-vessels/sar"
+    },
+    "/api/intel/density": {
+      "bucket": "200-real",
+      "detail": "22,283 bytes",
+      "ms": 229.7642560006352,
+      "status": 200,
+      "bytes": 22283,
+      "url": "http://127.0.0.1:8000/api/intel/density"
+    },
+    "/api/intel/dossier/aircraft/{ident}": {
+      "bucket": "200-real",
+      "detail": "817 bytes",
+      "ms": 505.25101499988523,
+      "status": 200,
+      "bytes": 817,
+      "url": "http://127.0.0.1:8000/api/intel/dossier/aircraft/a204c9"
+    },
+    "/api/intel/incident-history": {
+      "bucket": "200-real",
+      "detail": "21,709 bytes",
+      "ms": 433.7043329996959,
+      "status": 200,
+      "bytes": 21709,
+      "url": "http://127.0.0.1:8000/api/intel/incident-history"
+    },
+    "/api/intel/jamming": {
+      "bucket": "200-real",
+      "detail": "22,644 bytes",
+      "ms": 757.1785309992265,
+      "status": 200,
+      "bytes": 22644,
+      "url": "http://127.0.0.1:8000/api/intel/jamming"
+    },
+    "/api/intel/lod1": {
+      "bucket": "timeout",
+      "detail": "timed out",
+      "ms": 25025.370506999025,
+      "status": 0,
+      "bytes": 0,
+      "url": "http://127.0.0.1:8000/api/intel/lod1"
+    },
+    "/api/intel/sar/sweep": {
+      "bucket": "200-real",
+      "detail": "3,520 bytes",
+      "ms": 401.90960800100584,
+      "status": 200,
+      "bytes": 3520,
+      "url": "http://127.0.0.1:8000/api/intel/sar/sweep"
+    },
+    "/api/intel/situation": {
+      "bucket": "200-real",
+      "detail": "1,313 bytes",
+      "ms": 332.30033199833997,
+      "status": 200,
+      "bytes": 1313,
+      "url": "http://127.0.0.1:8000/api/intel/situation"
+    },
+    "/api/intel/sources": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 70.14163799976814,
+      "status": 200,
+      "bytes": 2745,
+      "url": "http://127.0.0.1:8000/api/intel/sources"
+    },
+    "/api/intel/vessels": {
+      "bucket": "200-real",
+      "detail": "7,951 bytes",
+      "ms": 24.554696001359844,
+      "status": 200,
+      "bytes": 7951,
+      "url": "http://127.0.0.1:8000/api/intel/vessels"
+    },
+    "/api/jamming/alerts": {
+      "bucket": "200-real",
+      "detail": "15,298 bytes",
+      "ms": 24.4087449991639,
+      "status": 200,
+      "bytes": 15298,
+      "url": "http://127.0.0.1:8000/api/jamming/alerts"
+    },
+    "/api/jamming/gpsjam-manifest": {
+      "bucket": "200-real",
+      "detail": "563 bytes",
+      "ms": 3.629640001236112,
+      "status": 200,
+      "bytes": 563,
+      "url": "http://127.0.0.1:8000/api/jamming/gpsjam-manifest"
+    },
+    "/api/jamming/nacp": {
+      "bucket": "200-real",
+      "detail": "156,222 bytes",
+      "ms": 3.156638000291423,
+      "status": 200,
+      "bytes": 156222,
+      "url": "http://127.0.0.1:8000/api/jamming/nacp"
+    },
+    "/api/keys": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 8.543013000235078,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/keys"
+    },
+    "/api/legal/courtlistener": {
+      "bucket": "200-real",
+      "detail": "3,917 bytes",
+      "ms": 7.110709000698989,
+      "status": 200,
+      "bytes": 3917,
+      "url": "http://127.0.0.1:8000/api/legal/courtlistener?q=berlin"
+    },
+    "/api/legal/gleif": {
+      "bucket": "200-real",
+      "detail": "9,652 bytes",
+      "ms": 5.064913000751403,
+      "status": 200,
+      "bytes": 9652,
+      "url": "http://127.0.0.1:8000/api/legal/gleif?q=berlin"
+    },
+    "/api/maps": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 655.3588079987094,
+      "status": 200,
+      "bytes": 2,
+      "url": "http://127.0.0.1:8000/api/maps"
+    },
+    "/api/maritime/buoys": {
+      "bucket": "200-real",
+      "detail": "235,048 bytes",
+      "ms": 3.7042299991298933,
+      "status": 200,
+      "bytes": 235048,
+      "url": "http://127.0.0.1:8000/api/maritime/buoys"
+    },
+    "/api/maritime/chokepoints": {
+      "bucket": "200-real",
+      "detail": "2,213 bytes",
+      "ms": 3.2087380004668375,
+      "status": 200,
+      "bytes": 2213,
+      "url": "http://127.0.0.1:8000/api/maritime/chokepoints"
+    },
+    "/api/maritime/digitraffic": {
+      "bucket": "200-real",
+      "detail": "342,049 bytes",
+      "ms": 3.183588998581399,
+      "status": 200,
+      "bytes": 342049,
+      "url": "http://127.0.0.1:8000/api/maritime/digitraffic"
+    },
+    "/api/maritime/snapshot": {
+      "bucket": "200-real",
+      "detail": "10,043,140 bytes",
+      "ms": 576.4092970002821,
+      "status": 200,
+      "bytes": 10043140,
+      "url": "http://127.0.0.1:8000/api/maritime/snapshot"
+    },
+    "/api/maritime/warnings": {
+      "bucket": "200-real",
+      "detail": "520,675 bytes",
+      "ms": 645.7862120005302,
+      "status": 200,
+      "bytes": 520675,
+      "url": "http://127.0.0.1:8000/api/maritime/warnings"
+    },
+    "/api/markets/predictions": {
+      "bucket": "200-real",
+      "detail": "1,909 bytes",
+      "ms": 135.29038299930107,
+      "status": 200,
+      "bytes": 1909,
+      "url": "http://127.0.0.1:8000/api/markets/predictions"
+    },
+    "/api/markets/snapshot": {
+      "bucket": "200-real",
+      "detail": "1,126 bytes",
+      "ms": 134.79073099915695,
+      "status": 200,
+      "bytes": 1126,
+      "url": "http://127.0.0.1:8000/api/markets/snapshot"
+    },
+    "/api/markets/stress": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 133.12294699971972,
+      "status": 200,
+      "bytes": 742,
+      "url": "http://127.0.0.1:8000/api/markets/stress"
+    },
+    "/api/me": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 2.1653150015481515,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/me"
+    },
+    "/api/news/analysis": {
+      "bucket": "200-real",
+      "detail": "17 bytes",
+      "ms": 1.875125000879052,
+      "status": 200,
+      "bytes": 17,
+      "url": "http://127.0.0.1:8000/api/news/analysis"
+    },
+    "/api/news/brief": {
+      "bucket": "200-real",
+      "detail": "17 bytes",
+      "ms": 1.831014998970204,
+      "status": 200,
+      "bytes": 17,
+      "url": "http://127.0.0.1:8000/api/news/brief"
+    },
+    "/api/news/edition": {
+      "bucket": "200-real",
+      "detail": "206 bytes",
+      "ms": 1.7884150001918897,
+      "status": 200,
+      "bytes": 206,
+      "url": "http://127.0.0.1:8000/api/news/edition"
+    },
+    "/api/news/history": {
+      "bucket": "200-real",
+      "detail": "17 bytes",
+      "ms": 1.7168049998872448,
+      "status": 200,
+      "bytes": 17,
+      "url": "http://127.0.0.1:8000/api/news/history"
+    },
+    "/api/news/telegram": {
+      "bucket": "200-real",
+      "detail": "4,899 bytes",
+      "ms": 1.7468740006734151,
+      "status": 200,
+      "bytes": 4899,
+      "url": "http://127.0.0.1:8000/api/news/telegram"
+    },
+    "/api/oceans/surge": {
+      "bucket": "200-real",
+      "detail": "4,350 bytes",
+      "ms": 1.6062440008681733,
+      "status": 200,
+      "bytes": 4350,
+      "url": "http://127.0.0.1:8000/api/oceans/surge"
+    },
+    "/api/ontology/schema": {
+      "bucket": "200-real",
+      "detail": "4,569 bytes",
+      "ms": 1.776774999598274,
+      "status": 200,
+      "bytes": 4569,
+      "url": "http://127.0.0.1:8000/api/ontology/schema"
+    },
+    "/api/ontology/search": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 5.603355999483028,
+      "status": 200,
+      "bytes": 2,
+      "url": "http://127.0.0.1:8000/api/ontology/search?q=berlin"
+    },
+    "/api/org/resolve": {
+      "bucket": "200-real",
+      "detail": "6,405 bytes",
+      "ms": 1.268164000066463,
+      "status": 200,
+      "bytes": 6405,
+      "url": "http://127.0.0.1:8000/api/org/resolve?name=berlin"
+    },
+    "/api/osint/aleph": {
+      "bucket": "200-real",
+      "detail": "69 bytes",
+      "ms": 1.0867130004044157,
+      "status": 200,
+      "bytes": 69,
+      "url": "http://127.0.0.1:8000/api/osint/aleph?name=berlin"
+    },
+    "/api/osint/countries": {
+      "bucket": "200-real",
+      "detail": "19,511 bytes",
+      "ms": 1.38026399872615,
+      "status": 200,
+      "bytes": 19511,
+      "url": "http://127.0.0.1:8000/api/osint/countries"
+    },
+    "/api/osint/countries/categories": {
+      "bucket": "200-real",
+      "detail": "576 bytes",
+      "ms": 1.4304939995781751,
+      "status": 200,
+      "bytes": 576,
+      "url": "http://127.0.0.1:8000/api/osint/countries/categories"
+    },
+    "/api/osint/countries/{code}": {
+      "bucket": "404",
+      "detail": "",
+      "ms": 1.0766430004878202,
+      "status": 404,
+      "bytes": 38,
+      "url": "http://127.0.0.1:8000/api/osint/countries/DEU"
+    },
+    "/api/osint/countries/{code}/graph": {
+      "bucket": "404",
+      "detail": "",
+      "ms": 1.0836330002348404,
+      "status": 404,
+      "bytes": 38,
+      "url": "http://127.0.0.1:8000/api/osint/countries/DEU/graph"
+    },
+    "/api/osint/opencorporates": {
+      "bucket": "200-real",
+      "detail": "107 bytes",
+      "ms": 1.5532439992966829,
+      "status": 200,
+      "bytes": 107,
+      "url": "http://127.0.0.1:8000/api/osint/opencorporates?name=berlin"
+    },
+    "/api/osint/openownership": {
+      "bucket": "200-real",
+      "detail": "61 bytes",
+      "ms": 1.5329540001403075,
+      "status": 200,
+      "bytes": 61,
+      "url": "http://127.0.0.1:8000/api/osint/openownership?name=berlin"
+    },
+    "/api/osint/opensanctions": {
+      "bucket": "200-real",
+      "detail": "76 bytes",
+      "ms": 1.158463001047494,
+      "status": 200,
+      "bytes": 76,
+      "url": "http://127.0.0.1:8000/api/osint/opensanctions?name=berlin"
+    },
+    "/api/osint/sec-edgar": {
+      "bucket": "200-real",
+      "detail": "1,821 bytes",
+      "ms": 1.1356630002410384,
+      "status": 200,
+      "bytes": 1821,
+      "url": "http://127.0.0.1:8000/api/osint/sec-edgar?name=berlin"
+    },
+    "/api/osint/wikidata": {
+      "bucket": "200-real",
+      "detail": "72 bytes",
+      "ms": 1.3131639989296673,
+      "status": 200,
+      "bytes": 72,
+      "url": "http://127.0.0.1:8000/api/osint/wikidata?name=berlin"
+    },
+    "/api/osm/military": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 1.1586130003706785,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/osm/military"
+    },
+    "/api/osm/wikimapia": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 2.2614159988734173,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/osm/wikimapia"
+    },
+    "/api/places/airport/{ident}": {
+      "bucket": "404",
+      "detail": "",
+      "ms": 1.1467530002846615,
+      "status": 404,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/places/airport/a204c9"
+    },
+    "/api/places/airports": {
+      "bucket": "200-real",
+      "detail": "10,852 bytes (needed params; empty when asked unbounded)",
+      "ms": 3.299848000096972,
+      "status": 200,
+      "bytes": 10852,
+      "url": "http://127.0.0.1:8000/api/places/airports"
+    },
+    "/api/places/bases": {
+      "bucket": "200-real",
+      "detail": "9,676 bytes (needed params; empty when asked unbounded)",
+      "ms": 3.4342889994150028,
+      "status": 200,
+      "bytes": 9676,
+      "url": "http://127.0.0.1:8000/api/places/bases"
+    },
+    "/api/places/infrastructure": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 0.814622000689269,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/places/infrastructure"
+    },
+    "/api/places/military": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 0.7522319992858684,
+      "status": 200,
+      "bytes": 42,
+      "url": "http://127.0.0.1:8000/api/places/military"
+    },
+    "/api/places/ports": {
+      "bucket": "200-real",
+      "detail": "8,044 bytes (needed params; empty when asked unbounded)",
+      "ms": 1.4781739992031362,
+      "status": 200,
+      "bytes": 8044,
+      "url": "http://127.0.0.1:8000/api/places/ports"
+    },
+    "/api/population/worldpop": {
+      "bucket": "200-real",
+      "detail": "14,255 bytes",
+      "ms": 1.344132999292924,
+      "status": 200,
+      "bytes": 14255,
+      "url": "http://127.0.0.1:8000/api/population/worldpop"
+    },
+    "/api/sanctions/aircraft": {
+      "bucket": "200-real",
+      "detail": "1,698 bytes",
+      "ms": 22.953931998927146,
+      "status": 200,
+      "bytes": 1698,
+      "url": "http://127.0.0.1:8000/api/sanctions/aircraft"
+    },
+    "/api/sanctions/lookup": {
+      "bucket": "200-real",
+      "detail": "138 bytes",
+      "ms": 21.662597999238642,
+      "status": 200,
+      "bytes": 138,
+      "url": "http://127.0.0.1:8000/api/sanctions/lookup"
+    },
+    "/api/sanctions/summary": {
+      "bucket": "200-real",
+      "detail": "1,007 bytes",
+      "ms": 252.69803800074442,
+      "status": 200,
+      "bytes": 1007,
+      "url": "http://127.0.0.1:8000/api/sanctions/summary"
+    },
+    "/api/sanctions/vessels": {
+      "bucket": "200-real",
+      "detail": "11,113 bytes",
+      "ms": 252.8461290003179,
+      "status": 200,
+      "bytes": 11113,
+      "url": "http://127.0.0.1:8000/api/sanctions/vessels"
+    },
+    "/api/sdr/kiwisdr": {
+      "bucket": "200-real",
+      "detail": "285,609 bytes",
+      "ms": 46.828505999656045,
+      "status": 200,
+      "bytes": 285609,
+      "url": "http://127.0.0.1:8000/api/sdr/kiwisdr"
+    },
+    "/api/search": {
+      "bucket": "200-real",
+      "detail": "158 bytes",
+      "ms": 46.30524400090508,
+      "status": 200,
+      "bytes": 158,
+      "url": "http://127.0.0.1:8000/api/search?q=berlin"
+    },
+    "/api/search/objects": {
+      "bucket": "200-real",
+      "detail": "28,243 bytes",
+      "ms": 17.11634499952197,
+      "status": 200,
+      "bytes": 28243,
+      "url": "http://127.0.0.1:8000/api/search/objects"
+    },
+    "/api/seismic/emsc": {
+      "bucket": "200-real",
+      "detail": "183,127 bytes",
+      "ms": 15.736952000224846,
+      "status": 200,
+      "bytes": 183127,
+      "url": "http://127.0.0.1:8000/api/seismic/emsc"
+    },
+    "/api/situations": {
+      "bucket": "200-real",
+      "detail": "875 bytes",
+      "ms": 4.985653999028727,
+      "status": 200,
+      "bytes": 875,
+      "url": "http://127.0.0.1:8000/api/situations"
+    },
+    "/api/sources/catalog": {
+      "bucket": "200-real",
+      "detail": "13,028 bytes",
+      "ms": 1.0122029998456128,
+      "status": 200,
+      "bytes": 13028,
+      "url": "http://127.0.0.1:8000/api/sources/catalog"
+    },
+    "/api/space/gp": {
+      "bucket": "5xx",
+      "detail": "HTTP 502",
+      "ms": 952.9464560000633,
+      "status": 502,
+      "bytes": 35,
+      "url": "http://127.0.0.1:8000/api/space/gp"
+    },
+    "/api/space/launches": {
+      "bucket": "200-real",
+      "detail": "15,353 bytes",
+      "ms": 0.7660320006834809,
+      "status": 200,
+      "bytes": 15353,
+      "url": "http://127.0.0.1:8000/api/space/launches"
+    },
+    "/api/space/satnogs/observations": {
+      "bucket": "200-real",
+      "detail": "8,232 bytes",
+      "ms": 0.8599820012022974,
+      "status": 200,
+      "bytes": 8232,
+      "url": "http://127.0.0.1:8000/api/space/satnogs/observations"
+    },
+    "/api/space/satnogs/stations": {
+      "bucket": "200-real",
+      "detail": "74,975 bytes",
+      "ms": 1.129752999986522,
+      "status": 200,
+      "bytes": 74975,
+      "url": "http://127.0.0.1:8000/api/space/satnogs/stations"
+    },
+    "/api/space/satnogs/transmitters": {
+      "bucket": "200-real",
+      "detail": "108,862 bytes",
+      "ms": 1.116192999688792,
+      "status": 200,
+      "bytes": 108862,
+      "url": "http://127.0.0.1:8000/api/space/satnogs/transmitters"
+    },
+    "/api/space/sondes": {
+      "bucket": "200-real",
+      "detail": "192,785 bytes",
+      "ms": 2.2590560001845006,
+      "status": 200,
+      "bytes": 192785,
+      "url": "http://127.0.0.1:8000/api/space/sondes"
+    },
+    "/api/space/tinygs": {
+      "bucket": "200-degraded",
+      "detail": "declares its own degradation - honest",
+      "ms": 0.7853919996705372,
+      "status": 200,
+      "bytes": 107,
+      "url": "http://127.0.0.1:8000/api/space/tinygs"
+    },
+    "/api/splats/huggingface": {
+      "bucket": "200-real",
+      "detail": "3,787 bytes",
+      "ms": 1.1764930004574126,
+      "status": 200,
+      "bytes": 3787,
+      "url": "http://127.0.0.1:8000/api/splats/huggingface"
+    },
+    "/api/splats/search": {
+      "bucket": "200-real",
+      "detail": "12,785 bytes",
+      "ms": 0.8645229991088854,
+      "status": 200,
+      "bytes": 12785,
+      "url": "http://127.0.0.1:8000/api/splats/search"
+    },
+    "/api/status": {
+      "bucket": "200-real",
+      "detail": "1,632 bytes",
+      "ms": 6.153836000521551,
+      "status": 200,
+      "bytes": 1632,
+      "url": "http://127.0.0.1:8000/api/status"
+    },
+    "/api/status/doctor": {
+      "bucket": "200-real",
+      "detail": "602 bytes",
+      "ms": 0.5786909987364197,
+      "status": 200,
+      "bytes": 602,
+      "url": "http://127.0.0.1:8000/api/status/doctor"
+    },
+    "/api/status/perf": {
+      "bucket": "200-real",
+      "detail": "920 bytes",
+      "ms": 0.5302810004650382,
+      "status": 200,
+      "bytes": 920,
+      "url": "http://127.0.0.1:8000/api/status/perf"
+    },
+    "/api/status/provenance": {
+      "bucket": "200-real",
+      "detail": "361 bytes",
+      "ms": 412.562445999356,
+      "status": 200,
+      "bytes": 361,
+      "url": "http://127.0.0.1:8000/api/status/provenance"
+    },
+    "/api/status/sources": {
+      "bucket": "200-real",
+      "detail": "22,799 bytes",
+      "ms": 319.19710699912685,
+      "status": 200,
+      "bytes": 22799,
+      "url": "http://127.0.0.1:8000/api/status/sources"
+    },
+    "/api/targets/board": {
+      "bucket": "auth-gated",
+      "detail": "HTTP 401",
+      "ms": 1.350634000118589,
+      "status": 401,
+      "bytes": 29,
+      "url": "http://127.0.0.1:8000/api/targets/board"
+    },
+    "/api/timeline/density": {
+      "bucket": "200-real",
+      "detail": "1,556 bytes",
+      "ms": 29.742950000581914,
+      "status": 200,
+      "bytes": 1556,
+      "url": "http://127.0.0.1:8000/api/timeline/density"
+    },
+    "/api/timeline/events": {
+      "bucket": "200-real",
+      "detail": "25,443 bytes",
+      "ms": 1.3766739994025556,
+      "status": 200,
+      "bytes": 25443,
+      "url": "http://127.0.0.1:8000/api/timeline/events"
+    },
+    "/api/watch-officer/briefs": {
+      "bucket": "200-empty",
+      "detail": "well-formed and carries nothing",
+      "ms": 1.0160229994653491,
+      "status": 200,
+      "bytes": 13,
+      "url": "http://127.0.0.1:8000/api/watch-officer/briefs"
+    },
+    "/api/watch-officer/status": {
+      "bucket": "200-real",
+      "detail": "537 bytes",
+      "ms": 0.7602020014019217,
+      "status": 200,
+      "bytes": 537,
+      "url": "http://127.0.0.1:8000/api/watch-officer/status"
+    },
+    "/api/weather/alerts": {
+      "bucket": "200-real",
+      "detail": "37,684 bytes",
+      "ms": 0.9212129989464302,
+      "status": 200,
+      "bytes": 37684,
+      "url": "http://127.0.0.1:8000/api/weather/alerts"
+    },
+    "/api/weather/openmeteo": {
+      "bucket": "200-real",
+      "detail": "3,054 bytes",
+      "ms": 0.6065919988031965,
+      "status": 200,
+      "bytes": 3054,
+      "url": "http://127.0.0.1:8000/api/weather/openmeteo?lat=50&lon=10"
+    },
+    "/api/weather/swpc/kp": {
+      "bucket": "200-real",
+      "detail": "27,823 bytes",
+      "ms": 0.7320019994949689,
+      "status": 200,
+      "bytes": 27823,
+      "url": "http://127.0.0.1:8000/api/weather/swpc/kp"
+    },
+    "/api/weather/swpc/space": {
+      "bucket": "200-real",
+      "detail": "223,006 bytes",
+      "ms": 1.1720630009222077,
+      "status": 200,
+      "bytes": 223006,
+      "url": "http://127.0.0.1:8000/api/weather/swpc/space"
+    },
+    "/tiles/apple/{z}/{x}/{y}.jpg": {
+      "bucket": "200-binary",
+      "detail": "image/jpeg - tile/chip route, correct",
+      "ms": 0.9335220001958078,
+      "status": 200,
+      "bytes": 38907,
+      "url": "http://127.0.0.1:8000/tiles/apple/3/4/2.jpg"
+    },
+    "/tiles/basemap/{z}/{x}/{y}.png": {
+      "bucket": "200-binary",
+      "detail": "image/png - tile/chip route, correct",
+      "ms": 0.7803129992680624,
+      "status": 200,
+      "bytes": 25307,
+      "url": "http://127.0.0.1:8000/tiles/basemap/3/4/2.png"
+    },
+    "/tiles/sat/{z}/{x}/{y}.jpg": {
+      "bucket": "200-binary",
+      "detail": "image/jpeg - tile/chip route, correct",
+      "ms": 0.7741419994999887,
+      "status": 200,
+      "bytes": 98248,
+      "url": "http://127.0.0.1:8000/tiles/sat/3/4/2.jpg"
+    },
+    "/tiles/terrain/{z}/{x}/{y}.png": {
+      "bucket": "200-binary",
+      "detail": "image/png - tile/chip route, correct",
+      "ms": 0.705421998645761,
+      "status": 200,
+      "bytes": 104364,
+      "url": "http://127.0.0.1:8000/tiles/terrain/3/4/2.png"
+    }
+  },
+  "skipped": [
+    {
+      "path": "/api/adsb/callsign/{cs}",
+      "why": "no fixture for cs",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/adsb/hex/{icao}",
+      "why": "no fixture for icao",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/adsb/registration/{reg}",
+      "why": "no fixture for reg",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/adsb/trace/{icao}",
+      "why": "no fixture for icao",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/adsb/type/{type_code}",
+      "why": "no fixture for type_code",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ai/models",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/ai/models/download/{job_id}",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/answers/{answer_id}",
+      "why": "no fixture for answer_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/cams/{cam_id}/snapshot",
+      "why": "no fixture for cam_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/collab/{doc_id}",
+      "why": "no fixture for doc_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/correlations/{eid}",
+      "why": "no fixture for eid",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/cyber/shodan/{ip}",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/entity/{eid}",
+      "why": "no fixture for eid",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/entity/{eid}/imagery",
+      "why": "no fixture for eid",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/evidence/{sha}",
+      "why": "no fixture for sha",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/evidence/{sha}/blob",
+      "why": "no fixture for sha",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/evidence/{sha}/verify",
+      "why": "no fixture for sha",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/builds/{build_id}",
+      "why": "no fixture for build_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/checks/results",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/column-lineage",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/dead-letter",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/docs",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/geo",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/rows",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/stats",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/datasets/{dataset_id}/versions",
+      "why": "no fixture for dataset_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/monitors/{monitor_id}/events",
+      "why": "no fixture for monitor_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/foundry/transforms/{transform_id}",
+      "why": "no fixture for transform_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ground/photo/{source}/{photo_id}",
+      "why": "no fixture for source, photo_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/history/diff",
+      "why": "no fixture for at_a",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/history/track",
+      "why": "no fixture for id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/imagery/aoi",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/imagery/change",
+      "why": "no fixture for before, after",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/imagery/detect",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/imagery/{provider}/{layer}/{z}/{x}/{y}",
+      "why": "no fixture for provider, layer, date",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/intel/agent",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/intel/baseline",
+      "why": "baseline_store.sample() writes an AOI sample on read",
+      "class": "mutating-get"
+    },
+    {
+      "path": "/api/intel/brief",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/intel/deception",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/intel/dossier/vessel/{mmsi}",
+      "why": "no fixture for mmsi",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/intel/emitter",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/intel/investigate",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/intel/pol/{entity_id}",
+      "why": "no fixture for entity_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/intel/sar/sweep/{aoi}",
+      "why": "no fixture for aoi",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/intel/watch",
+      "why": "record() persists a watch entry",
+      "class": "mutating-get"
+    },
+    {
+      "path": "/api/maps/{map_id}",
+      "why": "no fixture for map_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/maritime/keyless",
+      "why": "store.add_many() into the LAST-WRITE-WINS vessel store",
+      "class": "mutating-get"
+    },
+    {
+      "path": "/api/news/factcheck",
+      "why": "no fixture for claim",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/news/feed",
+      "why": "_ensure_articles() triggers a refresh/write when stale",
+      "class": "mutating-get"
+    },
+    {
+      "path": "/api/ontology/analytics/{object_id}",
+      "why": "no fixture for object_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ontology/assertions/{object_id}",
+      "why": "no fixture for object_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ontology/object/{object_id}",
+      "why": "no fixture for object_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ontology/path",
+      "why": "no fixture for a, b",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/ontology/search-around/{object_id}",
+      "why": "no fixture for object_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/anubis",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/bgpview-asn",
+      "why": "no fixture for asn",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/bgpview-ip",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/blockchair",
+      "why": "no fixture for chain, address",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/blockscout",
+      "why": "no fixture for address",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/blockstream",
+      "why": "no fixture for address",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/certs",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/certspotter",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/columbus",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/dns",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/emailrep",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/feodo",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/github",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/gitlab",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/gravatar",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/greynoise",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/hackertarget",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/hibp",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/ip",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/libravatar",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/malwarebazaar",
+      "why": "no fixture for hash",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/mempool",
+      "why": "no fixture for address",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/onionoo",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/phishstats",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/pullpush",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/ripestat",
+      "why": "no fixture for ip",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/shodan",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/threat",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/urlhaus-host",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/urlhaus-url",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/urlscan",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/username",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/wayback",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/whois",
+      "why": "no fixture for target",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/osint/yaraify",
+      "why": "no fixture for hash",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/places/facility/{fid}",
+      "why": "no fixture for fid",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/places/port/{wpi}",
+      "why": "no fixture for wpi",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/recon/jobs",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/recon/jobs/{job_id}",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/recon/jobs/{job_id}/camera.json",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/recon/jobs/{job_id}/events",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/recon/jobs/{job_id}/result.ply",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/recon/jobs/{job_id}/result.spz",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/route/candidates",
+      "why": "no fixture for from_lat, from_lon, to_lat, to_lon",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/route/fastest",
+      "why": "no fixture for from_lat, from_lon, to_lat, to_lon",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/route/offroad",
+      "why": "no fixture for from_lat, from_lon, to_lat, to_lon",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/route/road",
+      "why": "no fixture for from_lat, from_lon, to_lat, to_lon",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/situations/{sit_id}",
+      "why": "no fixture for sit_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/targets/board/{target_id}/audit",
+      "why": "no fixture for target_id",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/weather/metar",
+      "why": "no fixture for ids",
+      "class": "needs-fixture"
+    },
+    {
+      "path": "/api/workflows",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/blocks",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/runs/{run_id}",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/schedules",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/{workflow_id}",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/{workflow_id}/memory",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    },
+    {
+      "path": "/api/workflows/{workflow_id}/runs",
+      "why": "ratelimit.is_compute_path: spends LLM credits, GPU or actuates",
+      "class": "compute"
+    }
+  ]
+}

--- a/docs/audits/2026-08-20-api-sweep.md
+++ b/docs/audits/2026-08-20-api-sweep.md
@@ -1,0 +1,245 @@
+
+baseline written to /tmp/claude-1000/-home-andrew-Projects-OSINT/8230bdac-3e88-4449-b58c-1b1234ee1f55/scratchpad/sweep-after.json
+# API sweep - 2026-08-20 22:42:32
+
+base=http://127.0.0.1:8000 workers=6 twice=True
+
+**Auth posture:** open_mode=True (probe /api/config -> 200). ALLOW_UNAUTHENTICATED is in effect: auth-gated routes are reachable and a 401 below is a real finding
+
+**Fixture seeds from live data:** {'icao24': 'a204c9', 'hex': 'a204c9', 'ident': 'a204c9'}
+
+GET routes in schema: 320 · swept: 208 · skipped: 112
+
+## Buckets
+
+| bucket | n | meaning |
+|---|---|---|
+| `5xx` | 4 | server error |
+| `timeout` | 1 | >25s |
+| `200-empty` | 15 | **200 carrying nothing, and not saying so** |
+| `404` | 3 | not found |
+| `200-degraded` | 11 | declares its own degradation - correct |
+| `auth-gated` | 6 | 401/403 - by design |
+| `200-binary` | 5 | image/tile body - correct |
+| `200-real` | 162 | answered with data |
+| `http-400` | 1 | |
+
+**Defect total: 20 of 208 swept.** `200-empty` alone: 15.
+
+### 5xx (4)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/adsb/fi/global` | 502 | 812 | HTTP 502 |
+| `/api/hazards/gdacs` | 502 | 1043 | HTTP 502 |
+| `/api/hazards/reliefweb` | 502 | 993 | HTTP 502 |
+| `/api/space/gp` | 502 | 953 | HTTP 502 |
+
+### timeout (1)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/intel/lod1` | 0 | 25025 | timed out |
+
+### 200-empty (15)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/acars/geojson` | 200 | 5462 | well-formed and carries nothing |
+| `/api/acars/stats` | 200 | 990 | well-formed and carries nothing |
+| `/api/adsb/live/emergencies` | 200 | 8208 | well-formed and carries nothing |
+| `/api/alerts/spc-storms` | 200 | 1 | well-formed and carries nothing |
+| `/api/alerts/standing` | 200 | 1 | well-formed and carries nothing |
+| `/api/events/all` | 200 | 1 | well-formed and carries nothing |
+| `/api/foundry/schedules` | 200 | 1 | well-formed and carries nothing |
+| `/api/hazards/fire-perimeters` | 200 | 1 | well-formed and carries nothing |
+| `/api/maps` | 200 | 655 | well-formed and carries nothing |
+| `/api/ontology/search` | 200 | 6 | well-formed and carries nothing |
+| `/api/osm/military` | 200 | 1 | well-formed and carries nothing |
+| `/api/osm/wikimapia` | 200 | 2 | well-formed and carries nothing |
+| `/api/places/infrastructure` | 200 | 1 | well-formed and carries nothing |
+| `/api/places/military` | 200 | 1 | well-formed and carries nothing |
+| `/api/watch-officer/briefs` | 200 | 1 | well-formed and carries nothing |
+
+### 404 (3)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/osint/countries/{code}` | 404 | 1 |  |
+| `/api/osint/countries/{code}/graph` | 404 | 1 |  |
+| `/api/places/airport/{ident}` | 404 | 1 |  |
+
+### 200-degraded (11)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/conflict/ucdp` | 200 | 1 | declares its own degradation - honest |
+| `/api/cyber/cloudflare/outages` | 200 | 1 | declares its own degradation - honest |
+| `/api/cyber/ioda/outages` | 200 | 0 | declares its own degradation - honest |
+| `/api/events/acled` | 200 | 1 | declares its own degradation - honest |
+| `/api/events/gdelt` | 200 | 0 | declares its own degradation - honest |
+| `/api/events/gdelt-doc` | 200 | 1 | declares its own degradation - honest |
+| `/api/events/gdelt-summary` | 200 | 1 | declares its own degradation - honest |
+| `/api/intel/area` | 200 | 256 | declares its own degradation - honest |
+| `/api/intel/sources` | 200 | 70 | declares its own degradation - honest |
+| `/api/markets/stress` | 200 | 133 | declares its own degradation - honest |
+| `/api/space/tinygs` | 200 | 1 | declares its own degradation - honest |
+
+### 200-binary (5)
+
+| endpoint | status | ms | detail |
+|---|---|---|---|
+| `/api/imagery/chip` | 200 | 2 | image/jpeg - tile/chip route, correct |
+| `/tiles/apple/{z}/{x}/{y}.jpg` | 200 | 1 | image/jpeg - tile/chip route, correct |
+| `/tiles/basemap/{z}/{x}/{y}.png` | 200 | 1 | image/png - tile/chip route, correct |
+| `/tiles/sat/{z}/{x}/{y}.jpg` | 200 | 1 | image/jpeg - tile/chip route, correct |
+| `/tiles/terrain/{z}/{x}/{y}.png` | 200 | 1 | image/png - tile/chip route, correct |
+
+## Skipped, and why (112)
+
+A ledger that hides its own gaps reads as coverage it does not have.
+
+| endpoint | class | reason |
+|---|---|---|
+| `/api/ai/models` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/ai/models/download/{job_id}` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/imagery/aoi` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/imagery/detect` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/agent` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/brief` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/deception` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/emitter` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/investigate` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs/{job_id}` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs/{job_id}/camera.json` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs/{job_id}/events` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs/{job_id}/result.ply` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/recon/jobs/{job_id}/result.spz` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/blocks` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/runs/{run_id}` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/schedules` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/{workflow_id}` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/{workflow_id}/memory` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/workflows/{workflow_id}/runs` | compute | ratelimit.is_compute_path: spends LLM credits, GPU or actuates |
+| `/api/intel/baseline` | mutating-get | baseline_store.sample() writes an AOI sample on read |
+| `/api/intel/watch` | mutating-get | record() persists a watch entry |
+| `/api/maritime/keyless` | mutating-get | store.add_many() into the LAST-WRITE-WINS vessel store |
+| `/api/news/feed` | mutating-get | _ensure_articles() triggers a refresh/write when stale |
+| `/api/adsb/callsign/{cs}` | needs-fixture | no fixture for cs |
+| `/api/adsb/hex/{icao}` | needs-fixture | no fixture for icao |
+| `/api/adsb/registration/{reg}` | needs-fixture | no fixture for reg |
+| `/api/adsb/trace/{icao}` | needs-fixture | no fixture for icao |
+| `/api/adsb/type/{type_code}` | needs-fixture | no fixture for type_code |
+| `/api/answers/{answer_id}` | needs-fixture | no fixture for answer_id |
+| `/api/cams/{cam_id}/snapshot` | needs-fixture | no fixture for cam_id |
+| `/api/collab/{doc_id}` | needs-fixture | no fixture for doc_id |
+| `/api/correlations/{eid}` | needs-fixture | no fixture for eid |
+| `/api/cyber/shodan/{ip}` | needs-fixture | no fixture for ip |
+| `/api/entity/{eid}` | needs-fixture | no fixture for eid |
+| `/api/entity/{eid}/imagery` | needs-fixture | no fixture for eid |
+| `/api/evidence/{sha}` | needs-fixture | no fixture for sha |
+| `/api/evidence/{sha}/blob` | needs-fixture | no fixture for sha |
+| `/api/evidence/{sha}/verify` | needs-fixture | no fixture for sha |
+| `/api/foundry/builds/{build_id}` | needs-fixture | no fixture for build_id |
+| `/api/foundry/datasets/{dataset_id}` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/checks/results` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/column-lineage` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/dead-letter` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/docs` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/geo` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/rows` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/stats` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/datasets/{dataset_id}/versions` | needs-fixture | no fixture for dataset_id |
+| `/api/foundry/monitors/{monitor_id}/events` | needs-fixture | no fixture for monitor_id |
+| `/api/foundry/transforms/{transform_id}` | needs-fixture | no fixture for transform_id |
+| `/api/ground/photo/{source}/{photo_id}` | needs-fixture | no fixture for source, photo_id |
+| `/api/history/diff` | needs-fixture | no fixture for at_a |
+| `/api/history/track` | needs-fixture | no fixture for id |
+| `/api/imagery/change` | needs-fixture | no fixture for before, after |
+| `/api/imagery/{provider}/{layer}/{z}/{x}/{y}` | needs-fixture | no fixture for provider, layer, date |
+| `/api/intel/dossier/vessel/{mmsi}` | needs-fixture | no fixture for mmsi |
+| `/api/intel/pol/{entity_id}` | needs-fixture | no fixture for entity_id |
+| `/api/intel/sar/sweep/{aoi}` | needs-fixture | no fixture for aoi |
+| `/api/maps/{map_id}` | needs-fixture | no fixture for map_id |
+| `/api/news/factcheck` | needs-fixture | no fixture for claim |
+| `/api/ontology/analytics/{object_id}` | needs-fixture | no fixture for object_id |
+| `/api/ontology/assertions/{object_id}` | needs-fixture | no fixture for object_id |
+| `/api/ontology/object/{object_id}` | needs-fixture | no fixture for object_id |
+| `/api/ontology/path` | needs-fixture | no fixture for a, b |
+| `/api/ontology/search-around/{object_id}` | needs-fixture | no fixture for object_id |
+| `/api/osint/anubis` | needs-fixture | no fixture for target |
+| `/api/osint/bgpview-asn` | needs-fixture | no fixture for asn |
+| `/api/osint/bgpview-ip` | needs-fixture | no fixture for ip |
+| `/api/osint/blockchair` | needs-fixture | no fixture for chain, address |
+| `/api/osint/blockscout` | needs-fixture | no fixture for address |
+| `/api/osint/blockstream` | needs-fixture | no fixture for address |
+| `/api/osint/certs` | needs-fixture | no fixture for target |
+| `/api/osint/certspotter` | needs-fixture | no fixture for target |
+| `/api/osint/columbus` | needs-fixture | no fixture for target |
+| `/api/osint/dns` | needs-fixture | no fixture for target |
+| `/api/osint/emailrep` | needs-fixture | no fixture for target |
+| `/api/osint/feodo` | needs-fixture | no fixture for ip |
+| `/api/osint/github` | needs-fixture | no fixture for target |
+| `/api/osint/gitlab` | needs-fixture | no fixture for target |
+| `/api/osint/gravatar` | needs-fixture | no fixture for target |
+| `/api/osint/greynoise` | needs-fixture | no fixture for ip |
+| `/api/osint/hackertarget` | needs-fixture | no fixture for target |
+| `/api/osint/hibp` | needs-fixture | no fixture for target |
+| `/api/osint/ip` | needs-fixture | no fixture for target |
+| `/api/osint/libravatar` | needs-fixture | no fixture for target |
+| `/api/osint/malwarebazaar` | needs-fixture | no fixture for hash |
+| `/api/osint/mempool` | needs-fixture | no fixture for address |
+| `/api/osint/onionoo` | needs-fixture | no fixture for ip |
+| `/api/osint/phishstats` | needs-fixture | no fixture for target |
+| `/api/osint/pullpush` | needs-fixture | no fixture for target |
+| `/api/osint/ripestat` | needs-fixture | no fixture for ip |
+| `/api/osint/shodan` | needs-fixture | no fixture for target |
+| `/api/osint/threat` | needs-fixture | no fixture for target |
+| `/api/osint/urlhaus-host` | needs-fixture | no fixture for target |
+| `/api/osint/urlhaus-url` | needs-fixture | no fixture for target |
+| `/api/osint/urlscan` | needs-fixture | no fixture for target |
+| `/api/osint/username` | needs-fixture | no fixture for target |
+| `/api/osint/wayback` | needs-fixture | no fixture for target |
+| `/api/osint/whois` | needs-fixture | no fixture for target |
+| `/api/osint/yaraify` | needs-fixture | no fixture for hash |
+| `/api/places/facility/{fid}` | needs-fixture | no fixture for fid |
+| `/api/places/port/{wpi}` | needs-fixture | no fixture for wpi |
+| `/api/route/candidates` | needs-fixture | no fixture for from_lat, from_lon, to_lat, to_lon |
+| `/api/route/fastest` | needs-fixture | no fixture for from_lat, from_lon, to_lat, to_lon |
+| `/api/route/offroad` | needs-fixture | no fixture for from_lat, from_lon, to_lat, to_lon |
+| `/api/route/road` | needs-fixture | no fixture for from_lat, from_lon, to_lat, to_lon |
+| `/api/situations/{sit_id}` | needs-fixture | no fixture for sit_id |
+| `/api/targets/board/{target_id}/audit` | needs-fixture | no fixture for target_id |
+| `/api/weather/metar` | needs-fixture | no fixture for ids |
+
+## Upstreams that failed during this sweep
+
+An empty route above with one of these behind it is a DEAD FEED. An empty route with nothing here is an empty store.
+
+| host | ok | failed | last error |
+|---|---|---|---|
+| `api.airplanes.live` | 0 | 115 | HTTP 403 |
+| `opendata.adsb.fi` | 3 | 84 | HTTP 400 |
+| `api.gdeltproject.org` | 0 | 13 | ConnectTimeout:  |
+| `www.gdacs.org` | 0 | 7 | HTTP 400 |
+| `overpass-api.de` | 0 | 6 | ReadTimeout:  |
+| `celestrak.org` | 0 | 6 | HTTP 403 |
+| `api.reliefweb.int` | 0 | 6 | HTTP 406 |
+| `api.airframes.io` | 11 | 6 | HTTP 404 |
+| `api.ioda.caida.org` | 0 | 3 | ConnectTimeout:  |
+| `api.tinygs.com` | 0 | 1 | ReadTimeout:  |
+| `aleph.occrp.org` | 0 | 1 | HTTP 401 |
+| `www.wikidata.org` | 0 | 1 | HTTP 403 |
+| `api.opensanctions.org` | 0 | 1 | HTTP 401 |
+| `api.opencorporates.com` | 0 | 1 | HTTP 401 |
+| `api.openownership.org` | 0 | 1 | ConnectError: [Errno -2] Name or service not known |
+| `stooq.com` | 5 | 1 | HTTP 404 |
+| `api.adsbdb.com` | 0 | 1 | HTTP 404 |
+| `kartaview.org` | 0 | 1 | HTTP 405 |
+| `query.wikidata.org` | 1 | 1 | ReadTimeout:  |
+
+Registry: 99 hosts called · 80 answering · 19 failing · 17 upstreams build their own client and are not measured.
+
+Latency p50 2 ms · p95 1605 ms · max 8208 ms

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1030,6 +1030,7 @@ with real bodies rendered.
 
 ## Backend test baseline history
 
+- 2400 + 2 skipped — 2026-08-20, feed-honesty-2026-08, measured source health
 - 2393 + 2 skipped — 2026-08-08, gotham-parity-2026-08, connection wire coverage
 - 2390 + 2 skipped — 2026-08-08, gotham-parity-2026-08, SQL connection coverage
 - 2386 + 2 skipped — 2026-08-08, gotham-parity-2026-08, MQTT socket coverage

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -895,6 +895,99 @@ removes the direct fallback, pool outranks WARP, SSRF check before the sidecar,
 jemalloc scrubbed from the Chrome env, supervise cancel-safe, an operator's own
 tunnel survives our shutdown). Baseline 2141 → 2162.
 
+## A feed may be empty. It may not be empty and silent about why (2026-08-20)
+
+The 2026-08-08 entry below asked whether every route had a UI address. This one
+asks the next question: when a route DOES answer, is the answer true?
+
+**What was measured.** A new sweep (`tools/perf/sweep_api.py`) enumerates every
+GET route from `/openapi.json` and classifies what comes back. 319 GET routes in
+the schema, 208 swept, 111 skipped and named. 21 defects, of which **16 answered
+HTTP 200 with an empty body**. Nothing in the process could say which of those
+had a dead upstream behind them and which were simply empty stores on a fresh
+boot, because the API recorded `last_success` for **zero** of its ~100 upstreams
+and `last_error` for two (`marinetraffic.py`, `warp.py`).
+
+Meanwhile `/api/status` asserted health for nine feeds. Two were hardcoded
+`True` ("USGS earthquakes — Keyless, always on."), four more read a key being
+CONFIGURED as proof it worked, and `/api/health` — which the Docker healthcheck
+depends on — is the constant `{"status": "ok"}`.
+
+**What the measurement found the moment it existed.** 99 upstream hosts called
+in one sweep, **19 failing**: `api.airplanes.live` 0 ok / 115 failed (HTTP 403),
+`opendata.adsb.fi` 3/84, `celestrak.org` 0/6 (403), `overpass-api.de` 0/6
+(ReadTimeout), `www.gdacs.org` 0/7, `api.reliefweb.int` 0/6 (406),
+`api.gdeltproject.org` 0/13 (ConnectTimeout). Two ADS-B tiers were 100% blocked
+and the console called the ADS-B feed green, because the snapshot count was
+healthy on the tiers that still worked. Caveat kept deliberately: a sweep is a
+burst, and CelesTrak and Wikidata are documented to punish bursts, so some of
+those counts are partly self-inflicted — which is why the sweep caps concurrency
+and treats the SECOND pass as canonical.
+
+**The decision.** Health is measured at the one shared choke point, or it is not
+claimed.
+
+- `upstream.py` gains a bounded per-host registry written by
+  `_InstrumentedClient`, an `httpx.AsyncClient` subclass overriding `send()`.
+  Every one of the 113 `get_client()` call sites is covered by that one override.
+- **Not an httpx event hook.** A response hook fires only after
+  `_send_single_request` returns, so `ConnectError` / `ReadTimeout` never reach
+  it: a hook-based registry reads green precisely when an upstream is
+  unreachable. `response.elapsed` also raises inside a hook, and an exception
+  thrown in one aborts the request for all 113 callers. This was the first
+  design and it was wrong; `tests/test_feed_honesty.py::test_connect_error_is_recorded`
+  is the guard that would have caught it.
+- **Not a transport wrapper.** `proxy_stats()` isinstance-checks
+  `_CLIENT._transport`, and a wrapper would have to cover every mount or miss
+  the proxied and per-host-WARP hosts — the ones most likely to fail.
+- `record_failure()` is public because the wire is not the whole truth:
+  airplanes.live throttles with HTTP 200 + `text/plain`, which every
+  client-level capture point records as a success. `_feedgeo` is the layer that
+  knows a 200 was not an answer, so it reports that case itself.
+- `GET /api/status/sources` publishes the registry, **including an `unmeasured`
+  list** naming the 17 upstreams that build their own httpx client — first among
+  them `routes/adsb.py:1140`, the sync client behind the platform's most
+  important feed. A health page that lists only what it can see, without saying
+  what it cannot, is the same overclaim in a new place.
+- `/api/status` stops asserting. `_feed()` takes `ok: bool | None`, and
+  **`None` renders as `unknown`, not green** — "never attempted" is a third
+  state, and conflating it with healthy is the original defect.
+- An empty answer is no longer pinned. The swallow sits INSIDE the loader passed
+  to `fg.cached`, so the empty was a normal successful value stored for the full
+  TTL: GDELT's summary pinned `{"summary": {}}` for 10 minutes after one failed
+  fetch. `cached()` now caps an empty result at 45 s using the existing
+  `cache.shorten`, once, instead of asking 127 loaders to remember.
+- Ten swallow sites now answer with `fg.degraded_fc(...)` / `fg.degraded(...)`
+  — the shape `routes/events.py` already used — instead of a bare `fc([])`.
+  `spacewx.py` is exempted in the guard WITH its reason: three NOAA sub-feeds
+  merge into one collection and it has no per-sub-feed slot to report into.
+- `scripts/verify.sh --live` sidecar probe now sets FAIL. It printed
+  ":8090 NOT answering" and exited ALL GREEN, which is how a silently empty feed
+  tier survives the probe written to catch it.
+
+**Rejected:** migrating the 17 ad-hoc clients (each carries its own
+timeout/proxy policy — a separate change), persisting health across restarts,
+and a metrics backend. The registry is process-lifetime memory, bounded at 512
+hosts because host keys are attacker-influenceable through any route that
+fetches a user-supplied URL.
+
+**Guards:** `apps/api/tests/test_feed_honesty.py` — the ConnectError case, the
+success/HTTP-error split, `unknown` is not healthy, the bound holds, 200+non-JSON
+is recorded, the `_UNMEASURED` list matches the tree (anti-rot, both directions),
+and no `_feedgeo` caller swallows into a bare empty without a stated exception.
+Also removed a stale exemption in `routeCoverage.test.ts`: it excused
+`/api/status/doctor` as "called by scripts/verify.sh --live", which verify.sh
+never did — the real caller is `DegradedBanner.tsx` and is inside the scanned
+blob, so the entry was both wrong and redundant.
+
+Ledger: `docs/audits/2026-08-20-api-sweep.md`, regenerated by
+`apps/api/.venv/bin/python tools/perf/sweep_api.py --twice`. Note the sweep's own
+safety rule: **GET-only is NOT the safety boundary on this app.**
+`GET /api/intel/baseline` writes a sample into the anomaly baseline store and
+`GET /api/maritime/keyless` writes into the last-write-wins vessel store, so the
+skip list is `ratelimit.is_compute_path` plus four named mutating GETs, and every
+skip is reported with its reason rather than dropped.
+
 ## Every backend route needs a UI address or a stated exception (2026-08-08)
 
 The operator's report was that the backend had grown a lot of capability the
@@ -937,6 +1030,7 @@ with real bodies rendered.
 
 ## Backend test baseline history
 
+- 2393 + 2 skipped — 2026-08-08, gotham-parity-2026-08, connection wire coverage
 - 2390 + 2 skipped — 2026-08-08, gotham-parity-2026-08, SQL connection coverage
 - 2386 + 2 skipped — 2026-08-08, gotham-parity-2026-08, MQTT socket coverage
 - 2377 + 2 skipped — 2026-08-08, gotham-parity-2026-08, analyst-surface wave

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -96,8 +96,17 @@ EOF
       out=$(curl -sf -m 5 "http://127.0.0.1:$port/health" 2>/dev/null) \
         || out=$(curl -sf -m 5 "http://127.0.0.1:$port/aircraft.json" 2>/dev/null | head -c 200) \
         || out=$(curl -sf -m 5 "http://127.0.0.1:$port/vessels.json" 2>/dev/null | head -c 200)
-      if [ -n "$out" ]; then echo ":$port alive"; else echo ":$port NOT answering (sidecar down?)"; fi
-    done'
+      if [ -n "$out" ]; then
+        echo ":$port alive"
+      else
+        # Was an echo. A dead sidecar printed this line and the run still exited
+        # ALL GREEN, which is how a silently empty feed tier survives a probe
+        # that was written to catch exactly that. Non-zero now.
+        echo ":$port NOT answering (sidecar down?)"
+        rc=1
+      fi
+    done
+    exit "${rc:-0}"'
 fi
 
 echo

--- a/tools/perf/sweep_api.py
+++ b/tools/perf/sweep_api.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Sweep every safe GET route and classify what it actually answers.
+
+`measure_api.py --routes` asks how EXPENSIVE the ~50 registered globe layers
+are. This asks a different question of all ~400 routes: does the endpoint tell
+the truth when its upstream is down? A route that answers 200 with an empty body
+after a failed fetch is indistinguishable, to a status-code probe, from a route
+that is genuinely working and genuinely has nothing to report.
+
+Enumeration comes from /openapi.json, which is exact (the app is a plain
+FastAPI with no include_in_schema=False anywhere, and the path is in
+auth.PUBLIC_PATHS so it serves regardless of auth posture). It is NOT a regex
+over @router decorators the way routeCoverage.test.ts must be -- that test runs
+in vitest with no server to ask.
+
+Three things this must not do, each learned the hard way:
+
+  1. "GET-only" is NOT the safety boundary on this app. GET /api/intel/baseline
+     WRITES (intel.py: baseline_store.sample), GET /api/maritime/keyless writes
+     into the last-write-wins vessel store, and a dozen GETs spend LLM credits
+     or GPU. The skip list is ratelimit.is_compute_path -- the existing single
+     source of truth -- plus the four mutating GETs named below.
+  2. It must not manufacture the defects it reports. ~380 cold GETs is a burst
+     against upstreams documented to punish bursts (CelesTrak 403s, Wikidata
+     SPARQL 429s). An UPSTREAM 429 arrives here as a 502 or an empty 200, not as
+     the `gated-429` bucket, so it would be filed as an upstream defect.
+     Concurrency is capped low and the SECOND pass is canonical.
+  3. It must not assume its own auth posture. ALLOW_UNAUTHENTICATED is dead code
+     whenever the resolved .env carries SUPABASE_URL+SUPABASE_ANON_KEY, and
+     config.py resolves env_file relative to CWD. Boot via
+     `bash scripts/run-api.sh` from the repo ROOT. This script asserts the
+     posture before classifying a single route.
+
+    apps/api/.venv/bin/python tools/perf/sweep_api.py --twice
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "apps/api"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The compute/actuation skip list already exists and is shared by the rate
+# limiter and the auth fail-closed gate. Import it; never re-list it here, or
+# the two drift and this sweep starts spending money the gate was written to
+# protect.
+from app.ratelimit import is_compute_path  # noqa: E402
+
+# measure_api.timed_get cannot be reused: it deliberately discards the body, and
+# the body is the entire question this script asks. Its percentile helper is
+# reusable as-is.
+from measure_api import pct  # noqa: E402
+
+# GET routes that mutate state. Verified by reading each handler, not inferred.
+MUTATING_GETS: dict[str, str] = {
+    "/api/intel/baseline": "baseline_store.sample() writes an AOI sample on read",
+    "/api/intel/watch": "record() persists a watch entry",
+    "/api/maritime/keyless": "store.add_many() into the LAST-WRITE-WINS vessel store",
+    "/api/news/feed": "_ensure_articles() triggers a refresh/write when stale",
+}
+
+# Params the sweep can answer honestly. Anything not here that is REQUIRED makes
+# the route `needs-fixture` -- a gap in this table, reported as such, never
+# reported as a broken endpoint.
+FIXTURES: dict[str, str] = {
+    "min_lon": "-10", "min_lat": "35", "max_lon": "30", "max_lat": "60",
+    "lomin": "-10", "lamin": "35", "lomax": "30", "lamax": "60",
+    "west": "-10", "south": "35", "east": "30", "north": "60",
+    "lon": "10", "lat": "50", "longitude": "10", "latitude": "50",
+    "radius_nm": "200", "radius_km": "200", "radius": "200",
+    "bbox": "-10,35,30,60",
+    "q": "berlin", "query": "berlin", "search": "berlin", "name": "berlin",
+    "country": "DEU", "iso3": "DEU", "cc": "DE", "code": "DEU",
+    "limit": "50", "days": "3", "hours": "6", "z": "3", "x": "4", "y": "2",
+    "category": "port", "kind": "aircraft", "scope": "global",
+}
+
+TIMEOUT_S = 25.0
+
+
+def http_get(url: str, timeout: float = TIMEOUT_S) -> dict:
+    """One GET, keeping the body. Returns status, content-type, body, ms."""
+    req = urllib.request.Request(url, headers={"accept": "application/json"})
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310 - localhost
+            body = r.read()
+            return {
+                "status": r.status,
+                "ctype": (r.headers.get("content-type") or "").split(";")[0],
+                "body": body,
+                "ms": (time.perf_counter() - t0) * 1000.0,
+            }
+    except urllib.error.HTTPError as e:
+        body = b""
+        try:
+            body = e.read()
+        except Exception:  # noqa: BLE001 - the error body is a nicety
+            pass
+        return {
+            "status": e.code,
+            "ctype": (e.headers.get("content-type") or "").split(";")[0] if e.headers else "",
+            "body": body,
+            "ms": (time.perf_counter() - t0) * 1000.0,
+        }
+    except (TimeoutError, urllib.error.URLError, OSError) as e:
+        reason = getattr(e, "reason", e)
+        timed_out = isinstance(reason, TimeoutError) or "timed out" in str(reason).lower()
+        return {
+            "status": 0,
+            "ctype": "",
+            "body": b"",
+            "ms": (time.perf_counter() - t0) * 1000.0,
+            "error": str(reason)[:80],
+            "timeout": timed_out,
+        }
+
+
+# -- classification -----------------------------------------------------------
+
+_EMPTY_LIST_KEYS = (
+    "features", "results", "items", "datasets", "sources", "events", "alerts",
+    "articles", "entries", "rows", "objects", "hits", "records", "data",
+)
+
+
+def _is_empty(payload: object) -> bool:
+    """True when the body is well-formed and carries no information.
+
+    Deliberately conservative: a payload with ANY non-empty collection or any
+    scalar field beyond bookkeeping counts as real. Over-reporting `200-empty`
+    would make the ledger the thing that lies.
+    """
+    if payload is None:
+        return True
+    if isinstance(payload, list):
+        return len(payload) == 0
+    if not isinstance(payload, dict):
+        return False
+    if not payload:
+        return True
+    # A FeatureCollection / result envelope whose collection is empty.
+    for k in _EMPTY_LIST_KEYS:
+        if k in payload:
+            v = payload[k]
+            if isinstance(v, (list, dict)) and len(v) == 0:
+                return True
+    # Every value is an empty container and there is nothing else to read.
+    meaningful = 0
+    for k, v in payload.items():
+        if k in ("type", "generated_at", "as_of", "count", "total", "note", "detail"):
+            continue
+        if isinstance(v, (list, dict, str)) and len(v) == 0:
+            continue
+        if v is None:
+            continue
+        meaningful += 1
+    return meaningful == 0
+
+
+def _is_degraded(payload: object) -> bool:
+    """The honest-degradation idiom already in the codebase.
+
+    `{"degraded": true, "note": ...}` (routes/events.py) and the explicit
+    `"note": "GDELT is throttling..."` shape (routes/mega_feeds.py) are CORRECT
+    answers to a failed upstream, not defects. They must be counted apart from
+    the silent empties or the fix looks like a regression.
+    """
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("degraded"):
+        return True
+    note = payload.get("note") or payload.get("detail")
+    return bool(note) and _is_empty(payload)
+
+
+def classify(res: dict) -> tuple[str, str]:
+    st = res["status"]
+    if st == 0:
+        return ("timeout" if res.get("timeout") else "unreachable", res.get("error", ""))
+    if st in (401, 403):
+        return ("auth-gated", f"HTTP {st}")
+    if st == 429:
+        return ("gated-429", "rate limiter answered - correct behaviour")
+    if st == 503:
+        return ("gated-503", "compute gate answered - correct behaviour")
+    if st == 404:
+        return ("404", "")
+    if st == 422:
+        return ("422-needs-fixture", "required param the fixture table cannot answer")
+    if st >= 500:
+        return ("5xx", f"HTTP {st}")
+    if st != 200:
+        return (f"http-{st}", "")
+    # 200 from here down. An /api/ path answering text/html is a routing defect.
+    if res["ctype"] and res["ctype"] not in ("application/json", "application/geo+json"):
+        if res["ctype"] == "text/html":
+            return ("200-html", "an /api/ path answered HTML")
+        if res["ctype"].startswith(("image/", "application/octet-stream")):
+            return ("200-binary", res["ctype"] + " - tile/chip route, correct")
+        return ("200-nonjson", res["ctype"])
+    try:
+        payload = json.loads(res["body"].decode("utf-8", "replace")) if res["body"] else None
+    except ValueError:
+        return ("200-nonjson", "body is not JSON")
+    if _is_degraded(payload):
+        return ("200-degraded", "declares its own degradation - honest")
+    if _is_empty(payload):
+        return ("200-empty", "well-formed and carries nothing")
+    return ("200-real", f"{len(res['body']):,} bytes")
+
+
+# -- enumeration --------------------------------------------------------------
+
+
+def enumerate_routes(base: str) -> list[dict]:
+    """Every GET route from the live schema, with its required params."""
+    res = http_get(f"{base}/openapi.json", timeout=30.0)
+    if res["status"] != 200:
+        raise SystemExit(f"/openapi.json answered {res['status']} - is the backend up?")
+    spec = json.loads(res["body"].decode("utf-8"))
+    out: list[dict] = []
+    for path, ops in (spec.get("paths") or {}).items():
+        op = (ops or {}).get("get")
+        if not op:
+            continue
+        params = op.get("parameters") or []
+        out.append({
+            "path": path,
+            "path_params": [p["name"] for p in params if p.get("in") == "path"],
+            "required_query": [
+                p["name"] for p in params if p.get("in") == "query" and p.get("required")
+            ],
+            "optional_query": [
+                p["name"] for p in params if p.get("in") == "query" and not p.get("required")
+            ],
+        })
+    return sorted(out, key=lambda r: r["path"])
+
+
+def build_url(base: str, route: dict, seeds: dict[str, str]) -> str | None:
+    """Fill the route's params from the fixture table. None = needs-fixture."""
+    table = {**FIXTURES, **seeds}
+    path = route["path"]
+    for name in route["path_params"]:
+        val = table.get(name)
+        if val is None:
+            return None
+        path = path.replace("{" + name + "}", urllib.parse.quote(str(val)))
+    if "{" in path:
+        return None
+    qs: dict[str, str] = {}
+    for name in route["required_query"]:
+        val = table.get(name)
+        if val is None:
+            return None
+        qs[name] = val
+    url = base + path
+    if qs:
+        url += "?" + urllib.parse.urlencode(qs)
+    return url
+
+
+def build_url_with_optionals(base: str, route: dict, seeds: dict[str, str]) -> str | None:
+    """The 422 retry: same URL plus every OPTIONAL param the table can answer.
+
+    Filling optionals on the FIRST attempt is a measured harness bug, not a
+    refinement: `category=port` emptied /api/sources/catalog (60 sources bare,
+    0 with that category) and the bbox/limit fixtures emptied /api/eq, which
+    serves the real USGS feed when left alone. Both were about to be reported as
+    dead endpoints. Optionals are a fallback for a 422, never a default.
+    """
+    base_url = build_url(base, route, seeds)
+    if base_url is None:
+        return None
+    table = {**FIXTURES, **seeds}
+    extra = {n: table[n] for n in route["optional_query"] if n in table}
+    if not extra:
+        return None
+    sep = "&" if "?" in base_url else "?"
+    return base_url + sep + urllib.parse.urlencode(extra)
+
+
+def seed_fixtures(base: str) -> dict[str, str]:
+    """Pull real identifiers out of the running snapshot.
+
+    An invented ICAO24 makes every dossier route answer an honest 404 that the
+    ledger would then have to call a defect. Read-only: /api/adsb/global is the
+    pre-rendered blob the refresher already built.
+    """
+    seeds: dict[str, str] = {}
+    res = http_get(f"{base}/api/adsb/global?limit=200", timeout=30.0)
+    if res["status"] == 200:
+        try:
+            feats = json.loads(res["body"].decode("utf-8")).get("features") or []
+            for f in feats:
+                ident = (f.get("properties") or {}).get("icao24") or f.get("id")
+                if ident and isinstance(ident, str):
+                    seeds["icao24"] = seeds["hex"] = seeds["ident"] = ident.strip()
+                    break
+        except (ValueError, AttributeError):
+            pass
+    return seeds
+
+
+# -- posture ------------------------------------------------------------------
+
+
+def assert_posture(base: str) -> dict:
+    """Know which auth mode we are in BEFORE classifying anything.
+
+    auth._auth_enabled() is true when the resolved .env carries API_KEY, a
+    Supabase JWT secret, or SUPABASE_URL+SUPABASE_ANON_KEY -- and the
+    allow_unauthenticated branch is only reachable when auth is OFF. The repo
+    has TWO .env files disagreeing about this and config.py resolves env_file
+    relative to CWD, so the boot path decides the answer. A sweep that assumed
+    open mode against a Supabase-configured backend would file 400 routes as
+    broken on a wall of 401s.
+    """
+    # /api/config is the app's OWN answer to this question (it is what the
+    # frontend boots from), so it cannot drift from the code the way a guessed
+    # probe route does. /api/audit was the first candidate here and it is WRONG:
+    # it 401s to bare curl by design in either mode, so it reported open mode as
+    # closed and would have filed 200 working routes as unreachable.
+    probe = http_get(f"{base}/api/config", timeout=10.0)
+    open_mode = False
+    if probe["status"] == 200:
+        try:
+            open_mode = bool(json.loads(probe["body"].decode("utf-8")).get("openMode"))
+        except ValueError:
+            pass
+    return {
+        "open_mode": open_mode,
+        "probe_status": probe["status"],
+        "note": (
+            "ALLOW_UNAUTHENTICATED is in effect: auth-gated routes are reachable "
+            "and a 401 below is a real finding"
+            if open_mode
+            else "auth is ON for this boot (the resolved .env carries API_KEY or "
+            "SUPABASE_URL+SUPABASE_ANON_KEY, which makes ALLOW_UNAUTHENTICATED "
+            "dead code). Every gated route answers 401 and is reported as "
+            "auth-gated, NOT as a defect. Boot via `bash scripts/run-api.sh` "
+            "from the repo ROOT for full coverage."
+        ),
+    }
+
+
+# -- driver -------------------------------------------------------------------
+
+
+def run_pass(base: str, plan: list[dict], workers: int) -> dict[str, dict]:
+    def one(item: dict) -> tuple[str, dict]:
+        res = http_get(item["url"])
+        bucket, detail = classify(res)
+        # Retry once with the optional fixtures when the bare call was empty or
+        # rejected. Both directions are real: /api/sources/catalog answers 60
+        # sources bare and 0 with a category, while /api/places/airports answers
+        # nothing bare and thousands inside a bbox. Take whichever call carried
+        # information -- but only ever as a SECOND attempt, so a bad fixture can
+        # never turn a working route into a reported defect.
+        if bucket in ("422-needs-fixture", "200-empty") and item.get("url_opt"):
+            res2 = http_get(item["url_opt"])
+            b2, d2 = classify(res2)
+            if b2 in ("200-real", "200-degraded"):
+                res, bucket = res2, b2
+                detail = d2 + " (needed params; empty when asked unbounded)"
+        return item["path"], {
+            "bucket": bucket, "detail": detail, "ms": res["ms"],
+            "status": res["status"], "bytes": len(res["body"]), "url": item["url"],
+        }
+
+    out: dict[str, dict] = {}
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for path, row in pool.map(one, plan):
+            out[path] = row
+    return out
+
+
+BUCKET_ORDER = [
+    "5xx", "unreachable", "timeout", "200-html", "200-nonjson", "200-empty",
+    "404", "422-needs-fixture", "200-degraded", "auth-gated", "gated-429",
+    "gated-503", "200-binary", "200-real",
+]
+DEFECT_BUCKETS = {"5xx", "unreachable", "timeout", "200-html", "200-nonjson", "200-empty"}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default="http://127.0.0.1:8000")
+    ap.add_argument("--twice", action="store_true",
+                    help="run two passes and classify from the SECOND (warm cache, "
+                         "and any throttling this sweep itself induced has settled)")
+    ap.add_argument("--workers", type=int, default=6,
+                    help="concurrency cap. Keep it low: several upstreams punish bursts.")
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    posture = assert_posture(args.base)
+    routes = enumerate_routes(args.base)
+    seeds = seed_fixtures(args.base)
+
+    plan: list[dict] = []
+    skipped: list[dict] = []
+    for r in routes:
+        path = r["path"]
+        if path in MUTATING_GETS:
+            skipped.append({"path": path, "why": MUTATING_GETS[path], "class": "mutating-get"})
+            continue
+        if is_compute_path(path):
+            skipped.append({"path": path, "why": "ratelimit.is_compute_path: spends LLM "
+                                                 "credits, GPU or actuates", "class": "compute"})
+            continue
+        url = build_url(args.base, r, seeds)
+        if url is None:
+            missing = [p for p in r["path_params"] + r["required_query"]
+                       if p not in {**FIXTURES, **seeds}]
+            skipped.append({"path": path, "why": "no fixture for " + ", ".join(missing),
+                            "class": "needs-fixture"})
+            continue
+        plan.append({
+            "path": path,
+            "url": url,
+            "url_opt": build_url_with_optionals(args.base, r, seeds),
+        })
+
+    print(f"# API sweep - {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"\nbase={args.base} workers={args.workers} twice={args.twice}")
+    print(f"\n**Auth posture:** open_mode={posture['open_mode']} "
+          f"(probe /api/config -> {posture['probe_status']}). {posture['note']}")
+    print(f"\n**Fixture seeds from live data:** {seeds or 'none - snapshot was empty'}")
+    print(f"\nGET routes in schema: {len(routes)} · swept: {len(plan)} · "
+          f"skipped: {len(skipped)}")
+
+    if args.twice:
+        run_pass(args.base, plan, args.workers)
+    results = run_pass(args.base, plan, args.workers)
+
+    counts: dict[str, int] = {}
+    for row in results.values():
+        counts[row["bucket"]] = counts.get(row["bucket"], 0) + 1
+
+    print("\n## Buckets\n")
+    print("| bucket | n | meaning |")
+    print("|---|---|---|")
+    meaning = {
+        "5xx": "server error", "unreachable": "no answer", "timeout": f">{TIMEOUT_S:.0f}s",
+        "200-html": "**routing defect** - /api/ answered HTML",
+        "200-nonjson": "200 with a body that is not JSON",
+        "200-empty": "**200 carrying nothing, and not saying so**",
+        "404": "not found", "422-needs-fixture": "fixture-table gap, not a defect",
+        "200-degraded": "declares its own degradation - correct",
+        "auth-gated": "401/403 - by design", "gated-429": "rate limiter - correct",
+        "gated-503": "compute gate - correct", "200-real": "answered with data",
+        "200-binary": "image/tile body - correct",
+    }
+    for b in BUCKET_ORDER:
+        if counts.get(b):
+            print(f"| `{b}` | {counts[b]} | {meaning.get(b,'')} |")
+    for b in sorted(set(counts) - set(BUCKET_ORDER)):
+        print(f"| `{b}` | {counts[b]} | |")
+
+    defects = sum(counts.get(b, 0) for b in DEFECT_BUCKETS)
+    print(f"\n**Defect total: {defects} of {len(plan)} swept.** "
+          f"`200-empty` alone: {counts.get('200-empty', 0)}.")
+
+    for b in BUCKET_ORDER:
+        rows = sorted([(p, r) for p, r in results.items() if r["bucket"] == b])
+        if not rows or b in ("200-real", "auth-gated"):
+            continue
+        print(f"\n### {b} ({len(rows)})\n")
+        print("| endpoint | status | ms | detail |")
+        print("|---|---|---|---|")
+        for p, r in rows:
+            print(f"| `{p}` | {r['status']} | {r['ms']:.0f} | {r['detail']} |")
+
+    print(f"\n## Skipped, and why ({len(skipped)})\n")
+    print("A ledger that hides its own gaps reads as coverage it does not have.\n")
+    print("| endpoint | class | reason |")
+    print("|---|---|---|")
+    for s in sorted(skipped, key=lambda x: (x["class"], x["path"])):
+        print(f"| `{s['path']}` | {s['class']} | {s['why']} |")
+
+    # The half of the answer a route sweep cannot give on its own.
+    #
+    # An empty body has two completely different causes -- a dead upstream, or a
+    # local store that is genuinely empty on a fresh boot -- and they are
+    # indistinguishable from outside. /api/status/sources is what tells them
+    # apart, so the ledger asks it rather than leaving the reader to guess.
+    health = http_get(f"{args.base}/api/status/sources", timeout=20.0)
+    if health["status"] == 200:
+        try:
+            hz = json.loads(health["body"].decode("utf-8"))
+        except ValueError:
+            hz = {}
+        failing = [r for r in hz.get("sources", []) if r.get("state") == "failing"]
+        print("\n## Upstreams that failed during this sweep\n")
+        if failing:
+            print("An empty route above with one of these behind it is a DEAD FEED. "
+                  "An empty route with nothing here is an empty store.\n")
+            print("| host | ok | failed | last error |")
+            print("|---|---|---|---|")
+            for r in sorted(failing, key=lambda r: -r["fail"]):
+                print(f"| `{r['host']}` | {r['ok']} | {r['fail']} | {r.get('last_error') or ''} |")
+        else:
+            print("None. Every upstream called through the shared client answered.\n")
+        counts_h = hz.get("counts", {})
+        print(f"\nRegistry: {counts_h.get('total', 0)} hosts called · "
+              f"{counts_h.get('ok', 0)} answering · {counts_h.get('failing', 0)} failing · "
+              f"{len(hz.get('unmeasured', []))} upstreams build their own client and are "
+              "not measured.")
+    else:
+        print(f"\n## Upstreams\n\n/api/status/sources answered {health['status']} - "
+              "the empty/dead distinction below is UNAVAILABLE for this run.")
+
+    lat = [r["ms"] for r in results.values() if r["status"]]
+    if lat:
+        print(f"\nLatency p50 {pct(lat,50):.0f} ms · p95 {pct(lat,95):.0f} ms · "
+              f"max {max(lat):.0f} ms")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(
+            {"posture": posture, "seeds": seeds, "counts": counts,
+             "results": results, "skipped": skipped}, indent=2), encoding="utf-8")
+        print(f"\nbaseline written to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

`/api/status` reported health for nine feeds. Two were hardcoded green
("USGS earthquakes — Keyless, always on."), four more inferred green from a key
being present in the config rather than from a fetch that worked, and
`/api/health` — which the Docker healthcheck depends on — is the constant
`{"status": "ok"}`.

Underneath that, the API recorded `last_success` for **zero** of its ~100
upstreams and `last_error` for two (`marinetraffic.py`, `warp.py`).

A new sweep over every GET route in `/openapi.json` found **15 endpoints
answering HTTP 200 with an empty body**, and nothing in the process could say
which of those had a dead upstream behind them and which were simply empty
stores on a fresh boot.

## What the measurement found the moment it existed

First boot with the registry in place: **99 upstream hosts called, 19 failing.**

| host | ok | failed | last error |
|---|---|---|---|
| `api.airplanes.live` | 0 | 115 | HTTP 403 |
| `opendata.adsb.fi` | 3 | 84 | HTTP 400 |
| `api.gdeltproject.org` | 0 | 13 | ConnectTimeout |
| `www.gdacs.org` | 0 | 7 | HTTP 400 |
| `overpass-api.de` | 0 | 6 | ReadTimeout |
| `celestrak.org` | 0 | 6 | HTTP 403 |
| `api.reliefweb.int` | 0 | 6 | HTTP 406 |

Two ADS-B tiers were fully blocked while the console called the feed green,
because the snapshot count was healthy on the tiers that still worked.

## What changed

Health is recorded at the one place every upstream call already passes through:
an `httpx.AsyncClient` subclass overriding `send()`, so all 113 `get_client()`
call sites are covered by one override.

- **Not an httpx event hook.** A response hook fires only after
  `_send_single_request` returns, so `ConnectError` / `ReadTimeout` never reach
  it — a hook-based registry reads green precisely when a host is unreachable.
  This was the first design; `test_connect_error_is_recorded` is the guard that
  catches it.
- **Not a transport wrapper.** `proxy_stats()` isinstance-checks
  `_CLIENT._transport`, and a wrapper would have to cover every mount or miss
  the proxied and per-host-WARP hosts — the ones most likely to fail.
- **The wire is not the whole truth.** airplanes.live throttles with HTTP 200 +
  `text/plain`, which any client-level capture records as a success, so
  `_feedgeo` reports that case itself via a public `record_failure()`.

Then:

- `GET /api/status/sources` publishes the registry, **including an `unmeasured`
  list** naming the 17 upstreams that build their own client and are therefore
  invisible to it — first among them the sync ADS-B client in `routes/adsb.py`.
- `_feed()` takes `ok: bool | None`; `None` renders **`unknown`, not green**.
  Never-attempted is a third state.
- `fg.cached()` caps an empty result at 45 s via the existing `cache.shorten`,
  so a failed fetch is no longer pinned for the full TTL (GDELT's summary held
  `{"summary": {}}` for ten minutes after one failure).
- Ten swallow sites answer with `fg.degraded_fc` / `fg.degraded` instead of a
  bare `fc([])`. `spacewx.py` is exempted in the guard **with its reason**.
- `verify.sh --live` sidecar probe sets FAIL. It printed ":8090 NOT answering"
  and exited ALL GREEN.
- Dropped a `routeCoverage.test.ts` exemption justified by a `verify.sh` call
  that never existed.

## Sweep safety

**GET-only is not the safety boundary on this app.** `GET /api/intel/baseline`
writes a sample into the anomaly baseline store; `GET /api/maritime/keyless`
writes into the last-write-wins vessel store. The skip list is
`ratelimit.is_compute_path` (the existing single source of truth for
money/GPU/actuation routes) plus four named mutating GETs, and **every skip is
reported with its reason** rather than dropped.

## Verification

- `bash scripts/verify.sh` → **ALL GREEN**
- Backend baseline **2393 → 2401** passed + 2 skipped
- `unknown → green` proven live: the USGS feed flipped after a real `/api/eq`
  fetch
- `failing → degraded` proven in `test_feed_honesty.py` (no live failing host
  mapped to a measured feed, so this branch would otherwise have shipped
  unverified)
- SourcesPanel walked at 1600×1000: *"Measured this session · 80 answering ·
  19 failing · 17 upstreams build their own client and are not measured here"*

## Caveats

- **The measurements above were taken from behind a VPN** (ProtonVPN exit,
  Singapore, AS208172), which is exactly the kind of address ADS-B aggregators
  block. Re-probed individually afterwards from the same exit:
  `celestrak.org` **200**, `overpass-api.de` **200**, `wikidata.org` **200**,
  `api.gdeltproject.org` **200 in 24.5 s** (over the 15 s client timeout, which
  is why it records as a timeout). Those four were sweep-burst artifacts, not
  blocks — the concurrency cap and second-pass-canonical rule exist for this,
  and the registry correctly recorded what it saw.
- Not VPN, and not fixed here — genuine defects the registry surfaced:
  `www.gdacs.org` returns `{"message":"Eventtype is required."}` (our URL omits
  a required param), `api.reliefweb.int` v1 is retired (406/410),
  `api.openownership.org` no longer resolves, and `api.adsbdb.com` /
  `api.airframes.io` / `kartaview.org` answer 404/405 on the paths we use.
- `api.airplanes.live` is 0 ok / 631 failed and returns an explicit API-policy
  message; it stays 403 with a browser UA and on `/re-api/`, which
  `apps/api/CLAUDE.md` records as answering bare httpx 200. That is
  address-level. Whether it clears without the VPN is **unverified** — a second
  independent egress was not available from this host.
- The 17 ad-hoc httpx clients are **named** as unmeasured rather than quietly
  omitted; migrating them is a separate change, since each carries its own
  timeout/proxy policy.

Ledger: `docs/audits/2026-08-20-api-sweep.md`, regenerated with
`apps/api/.venv/bin/python tools/perf/sweep_api.py --twice`.
