### PR TITLE
Probe upstream reachability per egress

### DIFF
--- a/docs/audits/2026-08-20-egress-vpn.json
+++ b/docs/audits/2026-08-20-egress-vpn.json
@@ -1,0 +1,2882 @@
+{
+ "egress": {
+  "ip": "159.26.115.142",
+  "city": "Singapore",
+  "country": "SG",
+  "org": "AS208172 Proton AG"
+ },
+ "at": 1787239950,
+ "rows": [
+  {
+   "host": "1.1.1.1",
+   "url": "https://1.1.1.1/cdn-cgi/trace",
+   "where": "warp.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "103ms"
+  },
+  {
+   "host": "a.basemaps.cartocdn.com",
+   "url": "https://a.basemaps.cartocdn.com",
+   "where": "routes/tiles.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "65ms"
+  },
+  {
+   "host": "ags.cuzk.cz",
+   "url": "https://ags.cuzk.cz/arcgis1/services/ORTOFOTO/MapServer/WMSServer",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "586ms"
+  },
+  {
+   "host": "air-quality-api.open-meteo.com",
+   "url": "https://air-quality-api.open-meteo.com/v1/air-quality",
+   "where": "routes/env.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "841ms"
+  },
+  {
+   "host": "airframes.io",
+   "url": "https://airframes.io/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "249ms"
+  },
+  {
+   "host": "aleph.occrp.org",
+   "url": "https://aleph.occrp.org/api/2/entities?q={quote(q)}",
+   "where": "osint/sources/corp.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "3130ms"
+  },
+  {
+   "host": "alerts.com.ua",
+   "url": "https://alerts.com.ua/api/states",
+   "where": "routes/civil_defense.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "405ms"
+  },
+  {
+   "host": "allafrica.com",
+   "url": "https://allafrica.com/tools/headlines/rdf/latest/headlines.rdf",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "795ms"
+  },
+  {
+   "host": "api.acleddata.com",
+   "url": "https://api.acleddata.com/acled/read",
+   "where": "routes/events.py",
+   "cls": "dns-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "[Errno -5] No address associated with hostname"
+  },
+  {
+   "host": "api.adsb.lol",
+   "url": "https://api.adsb.lol",
+   "where": "routes/adsb.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "4534ms"
+  },
+  {
+   "host": "api.adsbdb.com",
+   "url": "https://api.adsbdb.com/v0/callsign/{cs}",
+   "where": "routes/entity.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "827ms"
+  },
+  {
+   "host": "api.airframes.io",
+   "url": "https://api.airframes.io",
+   "where": "acars.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "391ms"
+  },
+  {
+   "host": "api.airplanes.live",
+   "url": "https://api.airplanes.live",
+   "where": "routes/adsb.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "667ms"
+  },
+  {
+   "host": "api.bgpview.io",
+   "url": "https://api.bgpview.io/ip/{v}",
+   "where": "osint/sources/netblock.py",
+   "cls": "dns-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "[Errno -2] Name or service not known"
+  },
+  {
+   "host": "api.blockchair.com",
+   "url": "https://api.blockchair.com/{c}/dashboards/address/{a}",
+   "where": "osint/sources/crypto.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "806ms"
+  },
+  {
+   "host": "api.certspotter.com",
+   "url": "https://api.certspotter.com/v1/issuances?domain={d}",
+   "where": "osint/sources/infra.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "740ms"
+  },
+  {
+   "host": "api.cloudflare.com",
+   "url": "https://api.cloudflare.com/client/v4/radar/annotations/outages",
+   "where": "routes/cyber.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "221ms"
+  },
+  {
+   "host": "api.coingecko.com",
+   "url": "https://api.coingecko.com/api/v3/simple/price",
+   "where": "markets.py",
+   "cls": "reached-4xx5xx",
+   "status": 422,
+   "browser_status": null,
+   "detail": "903ms"
+  },
+  {
+   "host": "api.daac.asf.alaska.edu",
+   "url": "https://api.daac.asf.alaska.edu/services/search/param?platform=NISAR&output=json",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "394ms"
+  },
+  {
+   "host": "api.datalastic.com",
+   "url": "https://api.datalastic.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2093ms"
+  },
+  {
+   "host": "api.deepseek.com",
+   "url": "https://api.deepseek.com",
+   "where": "llm.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "244ms"
+  },
+  {
+   "host": "api.gdeltproject.org",
+   "url": "https://api.gdeltproject.org/api/v2/geo/geo",
+   "where": "routes/events.py",
+   "cls": "timeout",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15039ms"
+  },
+  {
+   "host": "api.github.com",
+   "url": "https://api.github.com/repos/adsblol/globe_history_2024/releases",
+   "where": "routes/adsb.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "419ms"
+  },
+  {
+   "host": "api.gleif.org",
+   "url": "https://api.gleif.org/api/v1/lei-records",
+   "where": "intel/orgs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "999ms"
+  },
+  {
+   "host": "api.greynoise.io",
+   "url": "https://api.greynoise.io/v3/community/{v}",
+   "where": "osint/sources/netblock.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "977ms"
+  },
+  {
+   "host": "api.hackertarget.com",
+   "url": "https://api.hackertarget.com/hostsearch/?q={d}",
+   "where": "osint/sources/infra.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1154ms"
+  },
+  {
+   "host": "api.ioda.caida.org",
+   "url": "https://api.ioda.caida.org/v2/outages/events",
+   "where": "routes/cyber.py",
+   "cls": "timeout",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15038ms"
+  },
+  {
+   "host": "api.n2yo.com",
+   "url": "https://api.n2yo.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1732ms"
+  },
+  {
+   "host": "api.open-meteo.com",
+   "url": "https://api.open-meteo.com/v1/forecast",
+   "where": "routes/weather.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1002ms"
+  },
+  {
+   "host": "api.opencorporates.com",
+   "url": "https://api.opencorporates.com/v0.4/companies/search?q={quote(q)}",
+   "where": "osint/sources/corp.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "548ms"
+  },
+  {
+   "host": "api.openownership.org",
+   "url": "https://api.openownership.org/v0.4.0/search?q={quote(q)}",
+   "where": "osint/sources/corp.py",
+   "cls": "dns-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "[Errno -2] Name or service not known"
+  },
+  {
+   "host": "api.opensanctions.org",
+   "url": "https://api.opensanctions.org/search/default?q={quote(q)}",
+   "where": "osint/sources/corp.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "431ms"
+  },
+  {
+   "host": "api.panoramax.xyz",
+   "url": "https://api.panoramax.xyz/api/search",
+   "where": "intel/ground.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "842ms"
+  },
+  {
+   "host": "api.planespotters.net",
+   "url": "https://api.planespotters.net/pub/photos/hex/{icao24}",
+   "where": "routes/entity.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "1329ms"
+  },
+  {
+   "host": "api.pullpush.io",
+   "url": "https://api.pullpush.io/reddit/search/submission/?author={u}&size={_BOUND}",
+   "where": "osint/sources/social.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "932ms"
+  },
+  {
+   "host": "api.reliefweb.int",
+   "url": "https://api.reliefweb.int/v1/disasters",
+   "where": "routes/hazards.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "728ms"
+  },
+  {
+   "host": "api.safecast.org",
+   "url": "https://api.safecast.org/measurements.json",
+   "where": "routes/hazards.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "891ms"
+  },
+  {
+   "host": "api.sketchfab.com",
+   "url": "https://api.sketchfab.com/v3/search",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "71ms"
+  },
+  {
+   "host": "api.tidesandcurrents.noaa.gov",
+   "url": "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter",
+   "where": "routes/primary.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "978ms"
+  },
+  {
+   "host": "api.tinygs.com",
+   "url": "https://api.tinygs.com/v2/packets",
+   "where": "routes/mega_feeds.py",
+   "cls": "TimeoutError",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15389ms"
+  },
+  {
+   "host": "api.unhcr.org",
+   "url": "https://api.unhcr.org/population/v1/population/",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2137ms"
+  },
+  {
+   "host": "api.usaspending.gov",
+   "url": "https://api.usaspending.gov/api/v2/search/spending_by_award/",
+   "where": "intel/orgs.py",
+   "cls": "reached-4xx5xx",
+   "status": 405,
+   "browser_status": null,
+   "detail": "1022ms"
+  },
+  {
+   "host": "api.v2.sondehub.org",
+   "url": "https://api.v2.sondehub.org/sondes",
+   "where": "routes/satnogs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "3021ms"
+  },
+  {
+   "host": "api.weather.gov",
+   "url": "https://api.weather.gov/alerts/active",
+   "where": "routes/weather.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "492ms"
+  },
+  {
+   "host": "api.wikimapia.org",
+   "url": "https://api.wikimapia.org/",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1427ms"
+  },
+  {
+   "host": "api.worldbank.org",
+   "url": "https://api.worldbank.org/v2/country/{iso3u}/indicator/{ind}",
+   "where": "routes/country_stats.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "118ms"
+  },
+  {
+   "host": "apps.euspaceimaging.com",
+   "url": "https://apps.euspaceimaging.com/atom/api/tara/library/search/ogc",
+   "where": "eusi.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "744ms"
+  },
+  {
+   "host": "archive-api.open-meteo.com",
+   "url": "https://archive-api.open-meteo.com/v1/era5",
+   "where": "routes/climate.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "950ms"
+  },
+  {
+   "host": "archive.liveatc.net",
+   "url": "https://archive.liveatc.net/",
+   "where": "routes/source_catalog.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "894ms"
+  },
+  {
+   "host": "archive.org",
+   "url": "https://archive.org/advancedsearch.php?q=liveatc",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "3493ms"
+  },
+  {
+   "host": "auth.opensky-network.org",
+   "url": "https://auth.opensky-network.org/auth/realms/opensky-network/",
+   "where": "ingest/opensky.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "884ms"
+  },
+  {
+   "host": "aviationweather.gov",
+   "url": "https://aviationweather.gov/api/data/metar",
+   "where": "routes/weather.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "1048ms"
+  },
+  {
+   "host": "b.basemaps.cartocdn.com",
+   "url": "https://b.basemaps.cartocdn.com",
+   "where": "routes/tiles.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "68ms"
+  },
+  {
+   "host": "blockstream.info",
+   "url": "https://blockstream.info/api/address/{a}",
+   "where": "osint/sources/crypto.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "650ms"
+  },
+  {
+   "host": "buenosairesherald.com",
+   "url": "https://buenosairesherald.com/feed",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "973ms"
+  },
+  {
+   "host": "c.basemaps.cartocdn.com",
+   "url": "https://c.basemaps.cartocdn.com",
+   "where": "routes/tiles.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "62ms"
+  },
+  {
+   "host": "capella-open-data.s3.amazonaws.com",
+   "url": "https://capella-open-data.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1297ms"
+  },
+  {
+   "host": "cdn.kartaview.com",
+   "url": "https://cdn.kartaview.com/{seq}",
+   "where": "intel/ground.py",
+   "cls": "timeout",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15039ms"
+  },
+  {
+   "host": "celestrak.org",
+   "url": "https://celestrak.org/pub/satcat.csv",
+   "where": "satcat.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "843ms"
+  },
+  {
+   "host": "columbus.elmasy.com",
+   "url": "https://columbus.elmasy.com/api/lookup/{d}",
+   "where": "osint/sources/infra.py",
+   "cls": "dns-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "[Errno -3] Temporary failure in name resolution"
+  },
+  {
+   "host": "core-sat.maps.yandex.net",
+   "url": "https://core-sat.maps.yandex.net/tiles?l=sat&v=3.1266.0&x={x}&y={y}&z={z}&lang=en_US",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "810ms"
+  },
+  {
+   "host": "crt.sh",
+   "url": "https://crt.sh/?q=%25.{d}&output=json",
+   "where": "osint/connectors.py",
+   "cls": "reached-4xx5xx",
+   "status": 502,
+   "browser_status": null,
+   "detail": "717ms"
+  },
+  {
+   "host": "cwwp2.dot.ca.gov",
+   "url": "https://cwwp2.dot.ca.gov/data/d{n}/cctv/cctvStatusD{n:02d}.json",
+   "where": "routes/cams.py",
+   "cls": "reached-4xx5xx",
+   "status": 500,
+   "browser_status": null,
+   "detail": "1041ms"
+  },
+  {
+   "host": "cyberjapandata.gsi.go.jp",
+   "url": "https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/{z}/{x}/{y}.jpg",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "108ms"
+  },
+  {
+   "host": "cyberscoop.com",
+   "url": "https://cyberscoop.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "113ms"
+  },
+  {
+   "host": "d.basemaps.cartocdn.com",
+   "url": "https://d.basemaps.cartocdn.com",
+   "where": "routes/tiles.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "56ms"
+  },
+  {
+   "host": "data-cloud.flightradar24.com",
+   "url": "https://data-cloud.flightradar24.com/zones/fcgi/feed.js",
+   "where": "adsb_fr24.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "291ms"
+  },
+  {
+   "host": "data.3dbag.nl",
+   "url": "https://data.3dbag.nl/",
+   "where": "routes/source_catalog.py",
+   "cls": "conn-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "301ms"
+  },
+  {
+   "host": "data.gdeltproject.org",
+   "url": "http://data.gdeltproject.org/gdeltv2",
+   "where": "intel/conflict.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "394ms"
+  },
+  {
+   "host": "data.geopf.fr",
+   "url": "https://data.geopf.fr/annexes/ressources/wmts/ortho.xml",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "744ms"
+  },
+  {
+   "host": "data.humdata.org",
+   "url": "https://data.humdata.org/api/3/action/package_search",
+   "where": "routes/mega_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "952ms"
+  },
+  {
+   "host": "data.sec.gov",
+   "url": "https://data.sec.gov/submissions/CIK{cik10}.json",
+   "where": "osint/sources/corp.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "277ms"
+  },
+  {
+   "host": "data.shipxplorer.com",
+   "url": "https://data.shipxplorer.com/live",
+   "where": "config.py",
+   "cls": "reached-4xx5xx",
+   "status": 500,
+   "browser_status": null,
+   "detail": "429ms"
+  },
+  {
+   "host": "davidmegginson.github.io",
+   "url": "https://davidmegginson.github.io/ourairports-data/airports.csv",
+   "where": "routes/adsb.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "42ms"
+  },
+  {
+   "host": "db.satnogs.org",
+   "url": "https://db.satnogs.org/api/transmitters/",
+   "where": "routes/satnogs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "807ms"
+  },
+  {
+   "host": "deepstatemap.live",
+   "url": "https://deepstatemap.live/api/seb/",
+   "where": "routes/deepstate.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "941ms"
+  },
+  {
+   "host": "developers.planet.com",
+   "url": "https://developers.planet.com/docs/tasking/",
+   "where": "imagery/tasking.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "611ms"
+  },
+  {
+   "host": "dns.google",
+   "url": "https://dns.google/resolve?name={d}&type={num}",
+   "where": "osint/connectors.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "66ms"
+  },
+  {
+   "host": "docs.canopy.umbra.space",
+   "url": "https://docs.canopy.umbra.space/",
+   "where": "imagery/tasking.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "543ms"
+  },
+  {
+   "host": "earth-search.aws.element84.com",
+   "url": "https://earth-search.aws.element84.com/v1/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "625ms"
+  },
+  {
+   "host": "earthquake.usgs.gov",
+   "url": "https://earthquake.usgs.gov/fdsnws/event/1/query",
+   "where": "routes/entity.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2013ms"
+  },
+  {
+   "host": "efts.sec.gov",
+   "url": "https://efts.sec.gov/LATEST/search-index",
+   "where": "intel/orgs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "336ms"
+  },
+  {
+   "host": "egyptindependent.com",
+   "url": "https://egyptindependent.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2874ms"
+  },
+  {
+   "host": "emailrep.io",
+   "url": "https://emailrep.io/{e}",
+   "where": "osint/sources/threat_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "1042ms"
+  },
+  {
+   "host": "en.mercopress.com",
+   "url": "https://en.mercopress.com/rss/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "946ms"
+  },
+  {
+   "host": "en.wikipedia.org",
+   "url": "https://en.wikipedia.org/api/rest_v1/page/summary/{path}",
+   "where": "routes/entity.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "49ms"
+  },
+  {
+   "host": "en.yna.co.kr",
+   "url": "https://en.yna.co.kr/RSS/news.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "455ms"
+  },
+  {
+   "host": "eonet.gsfc.nasa.gov",
+   "url": "https://eonet.gsfc.nasa.gov/api/v3/events",
+   "where": "routes/events.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1530ms"
+  },
+  {
+   "host": "eth.blockscout.com",
+   "url": "https://eth.blockscout.com/api/v2/addresses/{a}",
+   "where": "osint/sources/crypto.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "503ms"
+  },
+  {
+   "host": "feeds.a.dj.com",
+   "url": "https://feeds.a.dj.com/rss/RSSWorldNews.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "636ms"
+  },
+  {
+   "host": "feeds.arstechnica.com",
+   "url": "https://feeds.arstechnica.com/arstechnica/index",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "443ms"
+  },
+  {
+   "host": "feeds.bbci.co.uk",
+   "url": "https://feeds.bbci.co.uk/news/world/rss.xml",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "95ms"
+  },
+  {
+   "host": "feeds.elpais.com",
+   "url": "https://feeds.elpais.com/mrss-s/pages/ep/site/english.elpais.com/portada",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1854ms"
+  },
+  {
+   "host": "feeds.feedburner.com",
+   "url": "https://feeds.feedburner.com/TheHackersNews",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "571ms"
+  },
+  {
+   "host": "feeds.marketwatch.com",
+   "url": "https://feeds.marketwatch.com/marketwatch/topstories/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "851ms"
+  },
+  {
+   "host": "feeds.meteoalarm.org",
+   "url": "https://feeds.meteoalarm.org/feeds/meteoalarm-legacy-atom-{country}",
+   "where": "routes/civil_defense.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "816ms"
+  },
+  {
+   "host": "feeds.npr.org",
+   "url": "https://feeds.npr.org/1004/rss.xml",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "76ms"
+  },
+  {
+   "host": "feeds.skynews.com",
+   "url": "https://feeds.skynews.com/feeds/rss/world.xml",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "83ms"
+  },
+  {
+   "host": "feeds.washingtonpost.com",
+   "url": "https://feeds.washingtonpost.com/rss/world",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "334ms"
+  },
+  {
+   "host": "feodotracker.abuse.ch",
+   "url": "https://feodotracker.abuse.ch/downloads/ipblocklist.json",
+   "where": "osint/sources/netblock.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "68ms"
+  },
+  {
+   "host": "finance.yahoo.com",
+   "url": "https://finance.yahoo.com/news/rssindex",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "58ms"
+  },
+  {
+   "host": "firms.modaps.eosdis.nasa.gov",
+   "url": "https://firms.modaps.eosdis.nasa.gov/api/area/csv/",
+   "where": "routes/firms.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "1012ms"
+  },
+  {
+   "host": "fred.stlouisfed.org",
+   "url": "https://fred.stlouisfed.org/graph/fredgraph.csv?id={series_id}",
+   "where": "markets.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "315ms"
+  },
+  {
+   "host": "gamma-api.polymarket.com",
+   "url": "https://gamma-api.polymarket.com/events",
+   "where": "markets.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "107ms"
+  },
+  {
+   "host": "gateway.api.globalfishingwatch.org",
+   "url": "https://gateway.api.globalfishingwatch.org/v3/vessels/search",
+   "where": "routes/entity.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "501ms"
+  },
+  {
+   "host": "gibs.earthdata.nasa.gov",
+   "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best",
+   "where": "imagery/gibs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2563ms"
+  },
+  {
+   "host": "github.com",
+   "url": "https://github.com/AndrewCTF",
+   "where": "intel/country_profile.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "545ms"
+  },
+  {
+   "host": "gitlab.com",
+   "url": "https://gitlab.com/api/v4/users?username={u}",
+   "where": "osint/connectors.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "402ms"
+  },
+  {
+   "host": "globalenergymonitor.org",
+   "url": "https://globalenergymonitor.org/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1618ms"
+  },
+  {
+   "host": "globalnews.ca",
+   "url": "https://globalnews.ca/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "813ms"
+  },
+  {
+   "host": "globe.adsb.lol",
+   "url": "https://globe.adsb.lol/data/traces/{h[-2:]}/trace_full_{h}.json",
+   "where": "routes/adsb.py",
+   "cls": "conn-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "194ms"
+  },
+  {
+   "host": "globe.airplanes.live",
+   "url": "https://globe.airplanes.live/,https://globe.adsbexchange.com/,https://adsb.lol/",
+   "where": "adsb_sidecar.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "1033ms"
+  },
+  {
+   "host": "globe.theairtraffic.com",
+   "url": "https://globe.theairtraffic.com/data/aircraft.json",
+   "where": "config.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "553ms"
+  },
+  {
+   "host": "gpsjam.org",
+   "url": "https://gpsjam.org/data/manifest.csv",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "977ms"
+  },
+  {
+   "host": "gravatar.com",
+   "url": "https://gravatar.com/{h}.json",
+   "where": "osint/connectors.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "1708ms"
+  },
+  {
+   "host": "gspe35-ssl.ls.apple.com",
+   "url": "https://gspe35-ssl.ls.apple.com/geo_manifest/dynamic/config",
+   "where": "apple_maps.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "624ms"
+  },
+  {
+   "host": "hacker-news.firebaseio.com",
+   "url": "https://hacker-news.firebaseio.com/v0/user/{u}.json",
+   "where": "osint/connectors.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "456ms"
+  },
+  {
+   "host": "hapi.humdata.org",
+   "url": "https://hapi.humdata.org/api/v2/affected-people",
+   "where": "routes/displacement.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "969ms"
+  },
+  {
+   "host": "haveibeenpwned.com",
+   "url": "https://haveibeenpwned.com/api/v3/breachedaccount/{e}?truncateResponse=false",
+   "where": "osint/connectors.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "101ms"
+  },
+  {
+   "host": "hexdb.io",
+   "url": "https://hexdb.io/api-docs",
+   "where": "routes/entity.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "915ms"
+  },
+  {
+   "host": "hub.worldpop.org",
+   "url": "https://hub.worldpop.org/rest/data/pop/wpgp",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "749ms"
+  },
+  {
+   "host": "huggingface.co",
+   "url": "https://huggingface.co/api/datasets",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "330ms"
+  },
+  {
+   "host": "identity.dataspace.copernicus.eu",
+   "url": "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/",
+   "where": "imagery/cdse.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "539ms"
+  },
+  {
+   "host": "index.commoncrawl.org",
+   "url": "https://index.commoncrawl.org/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "969ms"
+  },
+  {
+   "host": "insecam.org",
+   "url": "https://insecam.org/en/bycountry/{ISO2}/",
+   "where": "routes/mega_feeds.py",
+   "cls": "tls-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "428ms"
+  },
+  {
+   "host": "integrate.api.nvidia.com",
+   "url": "https://integrate.api.nvidia.com/v1",
+   "where": "config.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "234ms"
+  },
+  {
+   "host": "internetdb.shodan.io",
+   "url": "https://internetdb.shodan.io",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "125ms"
+  },
+  {
+   "host": "ip-api.com",
+   "url": "http://ip-api.com/json/{v}",
+   "where": "osint/connectors.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "38ms"
+  },
+  {
+   "host": "jldc.me",
+   "url": "https://jldc.me/anubis/subdomains/{d}",
+   "where": "osint/sources/infra.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "2990ms"
+  },
+  {
+   "host": "kartaview.org",
+   "url": "https://kartaview.org/1.0/map/list/nearby",
+   "where": "intel/ground.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "67ms"
+  },
+  {
+   "host": "keybase.io",
+   "url": "https://keybase.io/_/api/1.0/user/lookup.json?usernames={u}",
+   "where": "osint/connectors.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "731ms"
+  },
+  {
+   "host": "kiwisdr.com",
+   "url": "http://kiwisdr.com/public/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "394ms"
+  },
+  {
+   "host": "krebsonsecurity.com",
+   "url": "https://krebsonsecurity.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "82ms"
+  },
+  {
+   "host": "kystdatahuset.no",
+   "url": "https://kystdatahuset.no/ws/api/ais/realtime/geojson",
+   "where": "ais_keyless.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1099ms"
+  },
+  {
+   "host": "ll.thespacedevs.com",
+   "url": "https://ll.thespacedevs.com/2.2.0/launch/",
+   "where": "routes/primary.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "731ms"
+  },
+  {
+   "host": "lumalabs.ai",
+   "url": "https://lumalabs.ai/explore",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "634ms"
+  },
+  {
+   "host": "maps.geogratis.gc.ca",
+   "url": "https://maps.geogratis.gc.ca/wms/canvec_en",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1079ms"
+  },
+  {
+   "host": "maps1.six.nsw.gov.au",
+   "url": "https://maps1.six.nsw.gov.au/arcgis/rest/services/sixmaps/LPI_Imagery_Best/MapServer",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "563ms"
+  },
+  {
+   "host": "mapserver.gis.umn.edu",
+   "url": "http://mapserver.gis.umn.edu/mapserver}",
+   "where": "routes/mega_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "408ms"
+  },
+  {
+   "host": "maxar-opendata.s3.amazonaws.com",
+   "url": "https://maxar-opendata.s3.amazonaws.com/events/catalog.json",
+   "where": "imagery/ondemand.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "828ms"
+  },
+  {
+   "host": "mb-api.abuse.ch",
+   "url": "https://mb-api.abuse.ch/api/v1/",
+   "where": "osint/sources/threat_feeds.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "954ms"
+  },
+  {
+   "host": "mempool.space",
+   "url": "https://mempool.space/api/address/{a}",
+   "where": "osint/sources/crypto.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "48ms"
+  },
+  {
+   "host": "meri.digitraffic.fi",
+   "url": "https://meri.digitraffic.fi/api/ais/v1/vessels",
+   "where": "routes/maritime.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "84ms"
+  },
+  {
+   "host": "minedbuildings.z5.web.core.windows.net",
+   "url": "https://minedbuildings.z5.web.core.windows.net/global-buildings/dataset-links.csv",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "904ms"
+  },
+  {
+   "host": "moxie.foxnews.com",
+   "url": "https://moxie.foxnews.com/google-publisher/world.xml",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "68ms"
+  },
+  {
+   "host": "mrdata.usgs.gov",
+   "url": "https://mrdata.usgs.gov/services/wfs/mrds",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "951ms"
+  },
+  {
+   "host": "msi.nga.mil",
+   "url": "https://msi.nga.mil/home",
+   "where": "routes/maritime.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "418ms"
+  },
+  {
+   "host": "nasstatus.faa.gov",
+   "url": "https://nasstatus.faa.gov/api/airport-status-information",
+   "where": "routes/nas_status.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "127ms"
+  },
+  {
+   "host": "network.satnogs.org",
+   "url": "https://network.satnogs.org/api/stations/",
+   "where": "routes/satnogs.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1001ms"
+  },
+  {
+   "host": "news.google.com",
+   "url": "https://news.google.com/rss/search?q=when:1d%20source:%22Associated%20Press%22",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "141ms"
+  },
+  {
+   "host": "news.un.org",
+   "url": "https://news.un.org/feed/subscribe/en/news/all/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "54ms"
+  },
+  {
+   "host": "nltimes.nl",
+   "url": "https://nltimes.nl/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "737ms"
+  },
+  {
+   "host": "noaa-goes16.s3.amazonaws.com",
+   "url": "https://noaa-goes16.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1448ms"
+  },
+  {
+   "host": "noaa-goes18.s3.amazonaws.com",
+   "url": "https://noaa-goes18.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1413ms"
+  },
+  {
+   "host": "noaa-himawari9.s3.amazonaws.com",
+   "url": "https://noaa-himawari9.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1390ms"
+  },
+  {
+   "host": "noaa-nexrad-level2.s3.amazonaws.com",
+   "url": "https://noaa-nexrad-level2.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "1760ms"
+  },
+  {
+   "host": "nominatim.openstreetmap.org",
+   "url": "https://nominatim.openstreetmap.org",
+   "where": "routes/entity.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "100ms"
+  },
+  {
+   "host": "nypost.com",
+   "url": "https://nypost.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "873ms"
+  },
+  {
+   "host": "ofsistorage.blob.core.windows.net",
+   "url": "https://ofsistorage.blob.core.windows.net/publishlive/2022format/ConList.csv",
+   "where": "intel/sanctions.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "939ms"
+  },
+  {
+   "host": "onionoo.torproject.org",
+   "url": "https://onionoo.torproject.org/details?type=relay&running=true&search={v}",
+   "where": "osint/sources/netblock.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "952ms"
+  },
+  {
+   "host": "opendata.adsb.fi",
+   "url": "https://opendata.adsb.fi/api",
+   "where": "routes/adsb.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "1762ms"
+  },
+  {
+   "host": "opensky-network.org",
+   "url": "https://opensky-network.org/api/states/all",
+   "where": "adsb_opensky_gaps.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2186ms"
+  },
+  {
+   "host": "otx.alienvault.com",
+   "url": "https://otx.alienvault.com/api/v1/indicators/{section}/{indicator}/general",
+   "where": "osint/connectors.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "255ms"
+  },
+  {
+   "host": "overpass-api.de",
+   "url": "https://overpass-api.de/api/interpreter",
+   "where": "intel/lod1.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "813ms"
+  },
+  {
+   "host": "overpass-turbo.eu",
+   "url": "https://overpass-turbo.eu/",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "818ms"
+  },
+  {
+   "host": "overpass.kumi.systems",
+   "url": "https://overpass.kumi.systems/api/interpreter",
+   "where": "intel/lod1.py",
+   "cls": "TimeoutError",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15370ms"
+  },
+  {
+   "host": "overpass.private.coffee",
+   "url": "https://overpass.private.coffee/api/interpreter",
+   "where": "intel/lod1.py",
+   "cls": "TimeoutError",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15377ms"
+  },
+  {
+   "host": "overturemaps-us-west-2.s3.amazonaws.com",
+   "url": "https://overturemaps-us-west-2.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "735ms"
+  },
+  {
+   "host": "overturemaps.org",
+   "url": "https://overturemaps.org/download/",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "277ms"
+  },
+  {
+   "host": "phishstats.info:2096",
+   "url": "https://phishstats.info:2096/api/phishing?_where=(url,eq,{u})&_size=5",
+   "where": "osint/sources/threat_feeds.py",
+   "cls": "dns-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "[Errno -2] Name or service not known"
+  },
+  {
+   "host": "poly.cam",
+   "url": "https://poly.cam/explore",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "65ms"
+  },
+  {
+   "host": "polymarket.com",
+   "url": "https://polymarket.com/event/{slug}",
+   "where": "markets.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "339ms"
+  },
+  {
+   "host": "praguemorning.cz",
+   "url": "https://praguemorning.cz/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "4008ms"
+  },
+  {
+   "host": "pskreporter.info",
+   "url": "https://pskreporter.info/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "782ms"
+  },
+  {
+   "host": "purl.org",
+   "url": "http://purl.org/dc/elements/1.1/}",
+   "where": "routes/advisories.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "3407ms"
+  },
+  {
+   "host": "query.wikidata.org",
+   "url": "https://query.wikidata.org/sparql",
+   "where": "intel/country_profile.py",
+   "cls": "TimeoutError",
+   "status": 0,
+   "browser_status": null,
+   "detail": "15051ms"
+  },
+  {
+   "host": "raw.githubusercontent.com",
+   "url": "https://raw.githubusercontent.com/wri/global-power-plant-database/master/",
+   "where": "routes/infra.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "374ms"
+  },
+  {
+   "host": "rdap.org",
+   "url": "https://rdap.org/ip/{ip}",
+   "where": "osint/connectors.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "53ms"
+  },
+  {
+   "host": "receiverbook.de",
+   "url": "https://receiverbook.de/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1757ms"
+  },
+  {
+   "host": "reliefweb.int",
+   "url": "https://reliefweb.int/updates/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "953ms"
+  },
+  {
+   "host": "riotimesonline.com",
+   "url": "https://riotimesonline.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "7297ms"
+  },
+  {
+   "host": "router.project-osrm.org",
+   "url": "https://router.project-osrm.org",
+   "where": "routes/route.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "645ms"
+  },
+  {
+   "host": "rss.cnn.com",
+   "url": "http://rss.cnn.com/rss/edition_world.rss",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "683ms"
+  },
+  {
+   "host": "rss.dw.com",
+   "url": "https://rss.dw.com/rdf/rss-en-bus",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "237ms"
+  },
+  {
+   "host": "rss.nytimes.com",
+   "url": "https://rss.nytimes.com/services/xml/rss/nyt/World.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "54ms"
+  },
+  {
+   "host": "rx-tx.info",
+   "url": "https://rx-tx.info/map-sdr-points",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1120ms"
+  },
+  {
+   "host": "rx.linkfanel.net",
+   "url": "http://rx.linkfanel.net/kiwisdr_com.js",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "331ms"
+  },
+  {
+   "host": "s1-bos.liveatc.net",
+   "url": "https://s1-bos.liveatc.net/{icao_lower}_twr",
+   "where": "routes/entity.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "1026ms"
+  },
+  {
+   "host": "s1-fmt2.liveatc.net",
+   "url": "https://s1-fmt2.liveatc.net/{icao_lower}_twr",
+   "where": "routes/entity.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "4091ms"
+  },
+  {
+   "host": "s3-us-west-2.amazonaws.com",
+   "url": "https://s3-us-west-2.amazonaws.com/config.maptiles.arcgis.com/waybackconfig.json",
+   "where": "imagery/vhr.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "794ms"
+  },
+  {
+   "host": "s3.amazonaws.com",
+   "url": "https://s3.amazonaws.com/hobu-lidar/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1579ms"
+  },
+  {
+   "host": "sanctionslist.ofac.treas.gov",
+   "url": "https://sanctionslist.ofac.treas.gov/Home/SdnList",
+   "where": "intel/sanctions.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1344ms"
+  },
+  {
+   "host": "sanctionslistservice.ofac.treas.gov",
+   "url": "https://sanctionslistservice.ofac.treas.gov/api/download/sdn.csv",
+   "where": "intel/sanctions.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2584ms"
+  },
+  {
+   "host": "scaniverse.com",
+   "url": "https://scaniverse.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1076ms"
+  },
+  {
+   "host": "scsanctions.un.org",
+   "url": "https://scsanctions.un.org/resources/xml/en/consolidated.xml",
+   "where": "intel/sanctions.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2317ms"
+  },
+  {
+   "host": "seccdn.libravatar.org",
+   "url": "https://seccdn.libravatar.org/avatar/{h}?d=404&s=80",
+   "where": "osint/sources/social.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1929ms"
+  },
+  {
+   "host": "server.arcgisonline.com",
+   "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "75ms"
+  },
+  {
+   "host": "service.pdok.nl",
+   "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "706ms"
+  },
+  {
+   "host": "services.arcgisonline.com",
+   "url": "https://services.arcgisonline.com/arcgis/rest/services",
+   "where": "routes/tiles.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "234ms"
+  },
+  {
+   "host": "services.marinetraffic.com",
+   "url": "https://services.marinetraffic.com/api/exportvessels/v:8/{key}/protocol:jsono",
+   "where": "config.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "308ms"
+  },
+  {
+   "host": "services.swpc.noaa.gov",
+   "url": "https://services.swpc.noaa.gov/products/alerts.json",
+   "where": "routes/spacewx.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "615ms"
+  },
+  {
+   "host": "services3.arcgis.com",
+   "url": "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/",
+   "where": "routes/hazards.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2689ms"
+  },
+  {
+   "host": "sh.dataspace.copernicus.eu",
+   "url": "https://sh.dataspace.copernicus.eu/api/v1/process",
+   "where": "imagery/cdse.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "559ms"
+  },
+  {
+   "host": "siren.pp.ua",
+   "url": "https://siren.pp.ua/api/v3/alerts",
+   "where": "routes/civil_defense.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "748ms"
+  },
+  {
+   "host": "sites.research.google",
+   "url": "https://sites.research.google/gr/open-buildings/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "353ms"
+  },
+  {
+   "host": "skyheinz.com",
+   "url": "https://skyheinz.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "69ms"
+  },
+  {
+   "host": "skylink.hpradar.com",
+   "url": "https://skylink.hpradar.com/data/aircraft.json",
+   "where": "config.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "268ms"
+  },
+  {
+   "host": "stat.ripe.net",
+   "url": "https://stat.ripe.net/data/country-resource-stats/data.json",
+   "where": "routes/routing.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "874ms"
+  },
+  {
+   "host": "stooq.com",
+   "url": "https://stooq.com/q/l/?s=",
+   "where": "markets.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "801ms"
+  },
+  {
+   "host": "superspl.at",
+   "url": "https://superspl.at/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "484ms"
+  },
+  {
+   "host": "t.me",
+   "url": "https://t.me/s/{channel}",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2223ms"
+  },
+  {
+   "host": "tass.com",
+   "url": "https://tass.com/rss/v2.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1176ms"
+  },
+  {
+   "host": "techcrunch.com",
+   "url": "https://techcrunch.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "41ms"
+  },
+  {
+   "host": "tfr.faa.gov",
+   "url": "https://tfr.faa.gov/download/detail_",
+   "where": "routes/airspace.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "597ms"
+  },
+  {
+   "host": "theintercept.com",
+   "url": "https://theintercept.com/feed/?rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "54ms"
+  },
+  {
+   "host": "therecord.media",
+   "url": "https://therecord.media/feed",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "320ms"
+  },
+  {
+   "host": "tie.digitraffic.fi",
+   "url": "https://tie.digitraffic.fi/api/weathercam/v1/stations",
+   "where": "routes/cams.py",
+   "cls": "reached-4xx5xx",
+   "status": 406,
+   "browser_status": null,
+   "detail": "87ms"
+  },
+  {
+   "host": "tile.googleapis.com",
+   "url": "https://tile.googleapis.com/v1/3dtiles/root.json",
+   "where": "routes/source_catalog.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "110ms"
+  },
+  {
+   "host": "tiles.maps.eox.at",
+   "url": "https://tiles.maps.eox.at/wmts/1.0.0/{_EOX_LAYER}/default",
+   "where": "routes/tiles.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "714ms"
+  },
+  {
+   "host": "timesofindia.indiatimes.com",
+   "url": "https://timesofindia.indiatimes.com/rssfeeds/296589292.cms",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "79ms"
+  },
+  {
+   "host": "travel.state.gov",
+   "url": "https://travel.state.gov/_res/rss/TAsTWs.xml",
+   "where": "routes/advisories.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "534ms"
+  },
+  {
+   "host": "tvn24.pl",
+   "url": "https://tvn24.pl/najnowsze.xml",
+   "where": "news/feeds_register.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "145ms"
+  },
+  {
+   "host": "ucdpapi.pcr.uu.se",
+   "url": "https://ucdpapi.pcr.uu.se/api/candidateged/{version}",
+   "where": "intel/ucdp.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "860ms"
+  },
+  {
+   "host": "umbra-open-data-catalog.s3.amazonaws.com",
+   "url": "https://umbra-open-data-catalog.s3.amazonaws.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "728ms"
+  },
+  {
+   "host": "unstats.un.org",
+   "url": "https://unstats.un.org/SDGAPI/v1/sdg/Series/Data",
+   "where": "routes/country_stats.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "6983ms"
+  },
+  {
+   "host": "urlhaus-api.abuse.ch",
+   "url": "https://urlhaus-api.abuse.ch/v1/url/",
+   "where": "osint/sources/threat_feeds.py",
+   "cls": "needs-key",
+   "status": 401,
+   "browser_status": null,
+   "detail": "712ms"
+  },
+  {
+   "host": "urlscan.io",
+   "url": "https://urlscan.io/api/v1/search/?q=domain:{d}",
+   "where": "osint/sources/infra.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "826ms"
+  },
+  {
+   "host": "usgs.entwine.io",
+   "url": "https://usgs.entwine.io/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "114ms"
+  },
+  {
+   "host": "vietnamnews.vn",
+   "url": "https://vietnamnews.vn/rss/politics-laws.rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "76ms"
+  },
+  {
+   "host": "warontherocks.com",
+   "url": "https://warontherocks.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1032ms"
+  },
+  {
+   "host": "wayback.maptiles.arcgis.com",
+   "url": "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer",
+   "where": "routes/mega_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "774ms"
+  },
+  {
+   "host": "weathercam.digitraffic.fi",
+   "url": "https://weathercam.digitraffic.fi/{preset}.jpg",
+   "where": "routes/cams.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "693ms"
+  },
+  {
+   "host": "web.archive.org",
+   "url": "https://web.archive.org/cdx/search",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "1634ms"
+  },
+  {
+   "host": "websdr.org",
+   "url": "http://websdr.org/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "350ms"
+  },
+  {
+   "host": "webservices.volcano.si.edu",
+   "url": "https://webservices.volcano.si.edu/geoserver/GVP-VOTW/ows",
+   "where": "routes/hazards.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1010ms"
+  },
+  {
+   "host": "wmts.geo.admin.ch",
+   "url": "https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "636ms"
+  },
+  {
+   "host": "wsprnet.org",
+   "url": "https://wsprnet.org/",
+   "where": "routes/source_catalog.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "3772ms"
+  },
+  {
+   "host": "www.aa.com.tr",
+   "url": "https://www.aa.com.tr/en/rss/default?cat=guncel",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2718ms"
+  },
+  {
+   "host": "www.abc.net.au",
+   "url": "https://www.abc.net.au/news/feed/51120/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "109ms"
+  },
+  {
+   "host": "www.africanews.com",
+   "url": "https://www.africanews.com/feed/rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "66ms"
+  },
+  {
+   "host": "www.al-monitor.com",
+   "url": "https://www.al-monitor.com/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "983ms"
+  },
+  {
+   "host": "www.aljazeera.com",
+   "url": "https://www.aljazeera.com/xml/rss/all.xml",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "73ms"
+  },
+  {
+   "host": "www.bangkokpost.com",
+   "url": "https://www.bangkokpost.com/rss/data/topstories.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1073ms"
+  },
+  {
+   "host": "www.bellingcat.com",
+   "url": "https://www.bellingcat.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "393ms"
+  },
+  {
+   "host": "www.cbc.ca",
+   "url": "https://www.cbc.ca/webfeed/rss/rss-world",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "135ms"
+  },
+  {
+   "host": "www.cgtn.com",
+   "url": "https://www.cgtn.com/subscribe/rss/section/world.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "55ms"
+  },
+  {
+   "host": "www.channelnewsasia.com",
+   "url": "https://www.channelnewsasia.com/rssfeeds/8395986",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "161ms"
+  },
+  {
+   "host": "www.cisa.gov",
+   "url": "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "310ms"
+  },
+  {
+   "host": "www.cnbc.com",
+   "url": "https://www.cnbc.com/id/100727362/device/rss/rss.html",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "314ms"
+  },
+  {
+   "host": "www.coindesk.com",
+   "url": "https://www.coindesk.com/arc/outboundfeeds/rss/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "268ms"
+  },
+  {
+   "host": "www.courtlistener.com",
+   "url": "https://www.courtlistener.com/api/rest/v4/search/",
+   "where": "routes/mega_feeds.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "3493ms"
+  },
+  {
+   "host": "www.dailymaverick.co.za",
+   "url": "https://www.dailymaverick.co.za/rss/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "854ms"
+  },
+  {
+   "host": "www.darkreading.com",
+   "url": "https://www.darkreading.com/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "654ms"
+  },
+  {
+   "host": "www.dawn.com",
+   "url": "https://www.dawn.com/feeds/home",
+   "where": "news/feeds_register.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": "timeout",
+   "detail": "16776ms"
+  },
+  {
+   "host": "www.defense.gov",
+   "url": "https://www.defense.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=945",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2156ms"
+  },
+  {
+   "host": "www.defenseone.com",
+   "url": "https://www.defenseone.com/rss/all/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "961ms"
+  },
+  {
+   "host": "www.engadget.com",
+   "url": "https://www.engadget.com/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "98ms"
+  },
+  {
+   "host": "www.euronews.com",
+   "url": "https://www.euronews.com/rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "61ms"
+  },
+  {
+   "host": "www.fema.gov",
+   "url": "https://www.fema.gov/api/open/v2/DisasterDeclarationsSummaries",
+   "where": "routes/civil_defense.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "168ms"
+  },
+  {
+   "host": "www.flightradar24.com",
+   "url": "https://www.flightradar24.com/v1/search/web/find",
+   "where": "routes/mega_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "243ms"
+  },
+  {
+   "host": "www.france24.com",
+   "url": "https://www.france24.com/en/rss",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "97ms"
+  },
+  {
+   "host": "www.gdacs.org",
+   "url": "https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP",
+   "where": "routes/hazards.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "2589ms"
+  },
+  {
+   "host": "www.geoboundaries.org",
+   "url": "https://www.geoboundaries.org/api/current/gbOpen/{ISO3}/{ADM1",
+   "where": "geo/adminshapes.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "751ms"
+  },
+  {
+   "host": "www.geospatial.jp",
+   "url": "https://www.geospatial.jp/ckan/dataset",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "532ms"
+  },
+  {
+   "host": "www.gov.uk",
+   "url": "https://www.gov.uk/foreign-travel-advice.atom",
+   "where": "routes/advisories.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "39ms"
+  },
+  {
+   "host": "www.iaea.org",
+   "url": "https://www.iaea.org/feeds/topnews",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2277ms"
+  },
+  {
+   "host": "www.iceye.com",
+   "url": "https://www.iceye.com/",
+   "where": "imagery/tasking.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "237ms"
+  },
+  {
+   "host": "www.ign.es",
+   "url": "https://www.ign.es/wmts/pnoa-ma",
+   "where": "routes/source_catalog.py",
+   "cls": "reached-4xx5xx",
+   "status": 400,
+   "browser_status": null,
+   "detail": "593ms"
+  },
+  {
+   "host": "www.investing.com",
+   "url": "https://www.investing.com/rss/news.rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "153ms"
+  },
+  {
+   "host": "www.jpost.com",
+   "url": "https://www.jpost.com/rss/rssfeedsfrontpage.aspx",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "300ms"
+  },
+  {
+   "host": "www.lemonde.fr",
+   "url": "https://www.lemonde.fr/en/rss/une.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "66ms"
+  },
+  {
+   "host": "www.liveatc.net",
+   "url": "https://www.liveatc.net/",
+   "where": "routes/source_catalog.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "4316ms"
+  },
+  {
+   "host": "www.middleeasteye.net",
+   "url": "https://www.middleeasteye.net/rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "42ms"
+  },
+  {
+   "host": "www.middleeastmonitor.com",
+   "url": "https://www.middleeastmonitor.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "708ms"
+  },
+  {
+   "host": "www.motherjones.com",
+   "url": "https://www.motherjones.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "62ms"
+  },
+  {
+   "host": "www.nationalreview.com",
+   "url": "https://www.nationalreview.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "782ms"
+  },
+  {
+   "host": "www.naturalearthdata.com",
+   "url": "https://www.naturalearthdata.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "948ms"
+  },
+  {
+   "host": "www.navalnews.com",
+   "url": "https://www.navalnews.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "886ms"
+  },
+  {
+   "host": "www.ndbc.noaa.gov",
+   "url": "https://www.ndbc.noaa.gov/data/latest_obs/latest_obs.txt",
+   "where": "routes/oceans.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "68ms"
+  },
+  {
+   "host": "www.nhc.noaa.gov",
+   "url": "https://www.nhc.noaa.gov/index-at.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "59ms"
+  },
+  {
+   "host": "www.nzherald.co.nz",
+   "url": "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/world/?outputType=xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "107ms"
+  },
+  {
+   "host": "www.opengis.net",
+   "url": "http://www.opengis.net/gml}",
+   "where": "routes/mega_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "371ms"
+  },
+  {
+   "host": "www.politico.eu",
+   "url": "https://www.politico.eu/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "193ms"
+  },
+  {
+   "host": "www.presstv.ir",
+   "url": "https://www.presstv.ir/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "tls-fail",
+   "status": 0,
+   "browser_status": null,
+   "detail": "501ms"
+  },
+  {
+   "host": "www.reddit.com",
+   "url": "https://www.reddit.com/user/{u}/about.json",
+   "where": "osint/connectors.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "4130ms"
+  },
+  {
+   "host": "www.rnz.co.nz",
+   "url": "https://www.rnz.co.nz/rss/world.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "78ms"
+  },
+  {
+   "host": "www.rt.com",
+   "url": "https://www.rt.com/rss/news/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "759ms"
+  },
+  {
+   "host": "www.scmp.com",
+   "url": "https://www.scmp.com/rss/91/feed",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "298ms"
+  },
+  {
+   "host": "www.securityweek.com",
+   "url": "https://www.securityweek.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "783ms"
+  },
+  {
+   "host": "www.seismicportal.eu",
+   "url": "https://www.seismicportal.eu/fdsnws/event/1/query",
+   "where": "routes/seismic.py",
+   "cls": "reached-4xx5xx",
+   "status": 413,
+   "browser_status": null,
+   "detail": "782ms"
+  },
+  {
+   "host": "www.shipxplorer.com",
+   "url": "https://www.shipxplorer.com",
+   "where": "ais_keyless.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1696ms"
+  },
+  {
+   "host": "www.sigidwiki.com",
+   "url": "https://www.sigidwiki.com/",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "2708ms"
+  },
+  {
+   "host": "www.smartraveller.gov.au",
+   "url": "https://www.smartraveller.gov.au/countries/documents/index.rss",
+   "where": "routes/advisories.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "106ms"
+  },
+  {
+   "host": "www.spc.noaa.gov",
+   "url": "https://www.spc.noaa.gov/climo/reports/today.csv",
+   "where": "routes/civil_defense.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1072ms"
+  },
+  {
+   "host": "www.spiegel.de",
+   "url": "https://www.spiegel.de/international/index.rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "392ms"
+  },
+  {
+   "host": "www.straitstimes.com",
+   "url": "https://www.straitstimes.com/news/world/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "110ms"
+  },
+  {
+   "host": "www.submarinecablemap.com",
+   "url": "https://www.submarinecablemap.com/api/v3/cable/cable-geo.json",
+   "where": "routes/cables.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "999ms"
+  },
+  {
+   "host": "www.taipeitimes.com",
+   "url": "https://www.taipeitimes.com/xml/index.rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "77ms"
+  },
+  {
+   "host": "www.theguardian.com",
+   "url": "https://www.theguardian.com/world/rss",
+   "where": "news/sources.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "71ms"
+  },
+  {
+   "host": "www.thehindu.com",
+   "url": "https://www.thehindu.com/news/international/feeder/default.rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "113ms"
+  },
+  {
+   "host": "www.thelocal.de",
+   "url": "https://www.thelocal.de/feeds/rss.php",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1080ms"
+  },
+  {
+   "host": "www.thelocal.it",
+   "url": "https://www.thelocal.it/feeds/rss.php",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1222ms"
+  },
+  {
+   "host": "www.thelocal.se",
+   "url": "https://www.thelocal.se/feeds/rss.php",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1834ms"
+  },
+  {
+   "host": "www.themoscowtimes.com",
+   "url": "https://www.themoscowtimes.com/rss/news",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "203ms"
+  },
+  {
+   "host": "www.theverge.com",
+   "url": "https://www.theverge.com/rss/index.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "68ms"
+  },
+  {
+   "host": "www.turkishminute.com",
+   "url": "https://www.turkishminute.com/feed/",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "1610ms"
+  },
+  {
+   "host": "www.twz.com",
+   "url": "https://www.twz.com/feed",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "43ms"
+  },
+  {
+   "host": "www.un.org",
+   "url": "https://www.un.org/securitycouncil/content/un-sc-consolidated-list",
+   "where": "intel/sanctions.py",
+   "cls": "ua-blocked",
+   "status": 403,
+   "browser_status": 200,
+   "detail": "1323ms"
+  },
+  {
+   "host": "www.vox.com",
+   "url": "https://www.vox.com/rss/index.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "67ms"
+  },
+  {
+   "host": "www.w3.org",
+   "url": "http://www.w3.org/2005/Atom}",
+   "where": "routes/advisories.py",
+   "cls": "reached-4xx5xx",
+   "status": 404,
+   "browser_status": null,
+   "detail": "142ms"
+  },
+  {
+   "host": "www.washingtontimes.com",
+   "url": "https://www.washingtontimes.com/rss/headlines/news/world/",
+   "where": "news/feeds_register.py",
+   "cls": "BLOCKED",
+   "status": 403,
+   "browser_status": 403,
+   "detail": "883ms"
+  },
+  {
+   "host": "www.wikidata.org",
+   "url": "https://www.wikidata.org/w/api.php?action=wbsearchentities",
+   "where": "osint/sources/corp.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "444ms"
+  },
+  {
+   "host": "www.wired.com",
+   "url": "https://www.wired.com/feed/rss",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "63ms"
+  },
+  {
+   "host": "www.wms.nrw.de",
+   "url": "https://www.wms.nrw.de/geobasis/wms_nw_dop",
+   "where": "routes/source_catalog.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "892ms"
+  },
+  {
+   "host": "www.xinhuanet.com",
+   "url": "http://www.xinhuanet.com/english/rss/worldrss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "385ms"
+  },
+  {
+   "host": "www.zdnet.com",
+   "url": "https://www.zdnet.com/news/rss.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "779ms"
+  },
+  {
+   "host": "www3.nhk.or.jp",
+   "url": "https://www3.nhk.or.jp/rss/news/cat0.xml",
+   "where": "news/feeds_register.py",
+   "cls": "ok",
+   "status": 200,
+   "browser_status": null,
+   "detail": "74ms"
+  },
+  {
+   "host": "xdworld.vworld.kr",
+   "url": "https://xdworld.vworld.kr/2d/Satellite/service/{z}/{x}/{y}.jpeg",
+   "where": "routes/source_catalog.py",
+   "cls": "RemoteDisconnected",
+   "status": 0,
+   "browser_status": null,
+   "detail": "332ms"
+  },
+  {
+   "host": "yaraify-api.abuse.ch",
+   "url": "https://yaraify-api.abuse.ch/api/v1/",
+   "where": "osint/sources/threat_feeds.py",
+   "cls": "reached-4xx5xx",
+   "status": 405,
+   "browser_status": null,
+   "detail": "976ms"
+  }
+ ]
+}

--- a/docs/audits/2026-08-20-egress-vpn.md
+++ b/docs/audits/2026-08-20-egress-vpn.md
@@ -1,0 +1,75 @@
+# egress reachability — 2026-08-20 23:31:20
+
+Exit: {'ip': '159.26.115.142', 'city': 'Singapore', 'country': 'SG', 'org': 'AS208172 Proton AG'}
+Upstream hosts referenced in apps/api/app: 319
+
+**Reached 287 of 319.**
+
+| class | n |
+|---|---|
+| `BLOCKED` | 14 |
+| `timeout` | 3 |
+| `tls-fail` | 2 |
+| `conn-fail` | 2 |
+| `dns-fail` | 5 |
+| `ua-blocked` | 1 |
+| `needs-key` | 9 |
+| `reached-4xx5xx` | 68 |
+| `ok` | 210 |
+
+### BLOCKED (14)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `api.airplanes.live` | 403 | 403 | `routes/adsb.py` |
+| `api.planespotters.net` | 403 | 403 | `routes/entity.py` |
+| `archive.liveatc.net` | 403 | 403 | `routes/source_catalog.py` |
+| `jldc.me` | 403 | 403 | `osint/sources/infra.py` |
+| `noaa-nexrad-level2.s3.amazonaws.com` | 403 | 403 | `routes/source_catalog.py` |
+| `riotimesonline.com` | 403 | 403 | `news/feeds_register.py` |
+| `tile.googleapis.com` | 403 | 403 | `routes/source_catalog.py` |
+| `tvn24.pl` | 403 | 403 | `news/feeds_register.py` |
+| `wsprnet.org` | 403 | 403 | `routes/source_catalog.py` |
+| `www.dawn.com` | 403 | timeout | `news/feeds_register.py` |
+| `www.liveatc.net` | 403 | 403 | `routes/source_catalog.py` |
+| `www.politico.eu` | 403 | 403 | `news/feeds_register.py` |
+| `www.reddit.com` | 403 | 403 | `osint/connectors.py` |
+| `www.washingtontimes.com` | 403 | 403 | `news/feeds_register.py` |
+
+### timeout (3)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `api.gdeltproject.org` | timeout | — | `routes/events.py` |
+| `api.ioda.caida.org` | timeout | — | `routes/cyber.py` |
+| `cdn.kartaview.com` | timeout | — | `intel/ground.py` |
+
+### tls-fail (2)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `insecam.org` | tls-fail | — | `routes/mega_feeds.py` |
+| `www.presstv.ir` | tls-fail | — | `news/feeds_register.py` |
+
+### conn-fail (2)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `data.3dbag.nl` | conn-fail | — | `routes/source_catalog.py` |
+| `globe.adsb.lol` | conn-fail | — | `routes/adsb.py` |
+
+### dns-fail (5)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `api.acleddata.com` | dns-fail | — | `routes/events.py` |
+| `api.bgpview.io` | dns-fail | — | `osint/sources/netblock.py` |
+| `api.openownership.org` | dns-fail | — | `osint/sources/corp.py` |
+| `columbus.elmasy.com` | dns-fail | — | `osint/sources/infra.py` |
+| `phishstats.info:2096` | dns-fail | — | `osint/sources/threat_feeds.py` |
+
+### ua-blocked (1)
+
+| host | status | browser UA | declared in |
+|---|---|---|---|
+| `www.un.org` | 403 | 200 | `intel/sanctions.py` |

--- a/tools/probe_egress.py
+++ b/tools/probe_egress.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Is every upstream reachable from THIS egress? And what changes if it moves?
+
+The question this answers is "is it me or is it them". A feed that reads empty
+has two causes that look identical from inside the app: the upstream is down, or
+this address is not welcome. `/api/status/sources` records which upstreams
+failed; this records whether they would answer ANY caller from here, and diffs
+two egress addresses so the difference is measured rather than argued.
+
+`probe_warp.py` is the neighbouring tool and answers a narrower question: does
+routing a host through WARP unblock it. Use that one when deciding WARP_HOSTS
+membership. Use this one when the whole egress changed - a VPN went up, the box
+moved, a deploy landed on a different address.
+
+    apps/api/.venv/bin/python tools/probe_egress.py --out on-vpn.json
+    # turn the VPN off, then:
+    apps/api/.venv/bin/python tools/probe_egress.py --diff on-vpn.json
+
+Classification is deliberately about REACHABILITY, not correctness: a 404 counts
+as reached, because they answered us. 403/451 with a browser User-Agent is the
+shape an address-level refusal takes - a plain 403 on our own UA is usually just
+bot filtering, which is why both are sent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import socket
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+APP = REPO / "apps/api/app"
+
+OUR_UA = "osint-console/0.1"
+BROWSER_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/140.0.0.0 Safari/537.36"
+)
+
+# Documentation placeholders and example values that live in config docstrings.
+# They are not providers and a DNS failure on them is not a finding.
+_PLACEHOLDER = re.compile(
+    r"(your-host\.tld|localhost|example\.(com|org)|user:pass@|^evil$|^host$|,)"
+)
+
+_URL_RE = re.compile(r'https?://[A-Za-z0-9._~:/?#\[\]@!$&\'()*+,;=%{}-]+')
+
+
+def upstream_urls() -> list[dict[str, str]]:
+    """One concrete URL per external host referenced anywhere in the backend.
+
+    Prefers the URL with the fewest templated segments, so the probe asks for
+    something the host can actually route.
+    """
+    best: dict[str, tuple[str, tuple[int, int, int], str]] = {}
+    for f in sorted(APP.rglob("*.py")):
+        for m in _URL_RE.finditer(f.read_text(errors="replace")):
+            url = m.group(0).rstrip('.,;\'")')
+            host = re.sub(r"^https?://", "", url).split("/")[0].split("?")[0].lower()
+            if not host or host.startswith(("127.", "localhost", "0.0.0.0")):
+                continue
+            if any(c in host for c in "{}$") or _PLACEHOLDER.search(host):
+                continue
+            score = (url.count("{"), url.count("$"), len(url))
+            cur = best.get(host)
+            if cur is None or score < cur[1]:
+                best[host] = (url, score, str(f.relative_to(APP)))
+    return [
+        {"host": h, "url": v[0], "where": v[2]} for h, v in sorted(best.items())
+    ]
+
+
+def _get(url: str, ua: str, timeout: float = 15.0) -> int | str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": ua, "Accept": "*/*", "Accept-Language": "en-US,en;q=0.9"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:  # noqa: S310
+            return int(r.status)
+    except urllib.error.HTTPError as e:
+        return int(e.code)
+    except urllib.error.URLError as e:
+        reason = getattr(e, "reason", e)
+        if isinstance(reason, (socket.timeout, TimeoutError)) or "timed out" in str(reason).lower():
+            return "timeout"
+        if isinstance(reason, ssl.SSLError):
+            return "tls-fail"
+        return "conn-fail"
+    except Exception as e:  # noqa: BLE001
+        return type(e).__name__
+
+
+def classify(code: int | str, browser: int | str | None) -> str:
+    if isinstance(code, str):
+        return code
+    if code in (403, 451):
+        # A 403 that a browser UA clears is bot filtering, not this address.
+        if isinstance(browser, int) and 200 <= browser < 400:
+            return "ua-blocked"
+        return "BLOCKED"
+    if code == 429:
+        return "throttled"
+    if code in (401, 402):
+        return "needs-key"
+    if 200 <= code < 400:
+        return "ok"
+    return "reached-4xx5xx"
+
+
+def probe(item: dict[str, str]) -> dict[str, object]:
+    host = item["host"]
+    try:
+        socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        return {**item, "cls": "dns-fail", "status": 0,
+                "browser_status": None, "detail": str(e)[:60]}
+    t0 = time.perf_counter()
+    code = _get(item["url"], OUR_UA)
+    browser = _get(item["url"], BROWSER_UA) if code in (403, 451) else None
+    return {
+        **item,
+        "cls": classify(code, browser),
+        "status": code if isinstance(code, int) else 0,
+        "browser_status": browser,
+        "detail": f"{(time.perf_counter() - t0) * 1000:.0f}ms",
+    }
+
+
+def egress_identity() -> dict[str, object]:
+    """Who the internet thinks we are. The diff is meaningless without it."""
+    try:
+        with urllib.request.urlopen(  # noqa: S310
+            urllib.request.Request("https://ipinfo.io/json", headers={"User-Agent": OUR_UA}),
+            timeout=12,
+        ) as r:
+            d = json.loads(r.read().decode("utf-8", "replace"))
+        return {k: d.get(k) for k in ("ip", "city", "country", "org")}
+    except Exception as e:  # noqa: BLE001
+        return {"error": f"{type(e).__name__}: {e}"[:80]}
+
+
+ORDER = ["BLOCKED", "timeout", "tls-fail", "conn-fail", "dns-fail", "ua-blocked",
+         "throttled", "needs-key", "reached-4xx5xx", "ok"]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="")
+    ap.add_argument("--diff", default="", help="a previous --out file to compare against")
+    ap.add_argument("--workers", type=int, default=6,
+                    help="keep it low: several upstreams punish bursts and a "
+                         "throttle would be indistinguishable from a block")
+    args = ap.parse_args()
+
+    who = egress_identity()
+    items = upstream_urls()
+    print(f"# egress reachability — {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    print(f"\nExit: {who}")
+    print(f"Upstream hosts referenced in apps/api/app: {len(items)}\n")
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        rows = list(pool.map(probe, items))
+
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[str(r["cls"])] = counts.get(str(r["cls"]), 0) + 1
+    reached = sum(counts.get(c, 0) for c in ("ok", "reached-4xx5xx", "needs-key", "throttled"))
+    print(f"**Reached {reached} of {len(rows)}.**\n")
+    print("| class | n |")
+    print("|---|---|")
+    for c in ORDER:
+        if counts.get(c):
+            print(f"| `{c}` | {counts[c]} |")
+
+    for c in ("BLOCKED", "timeout", "tls-fail", "conn-fail", "dns-fail", "ua-blocked"):
+        sel = sorted([r for r in rows if r["cls"] == c], key=lambda r: str(r["host"]))
+        if not sel:
+            continue
+        print(f"\n### {c} ({len(sel)})\n")
+        print("| host | status | browser UA | declared in |")
+        print("|---|---|---|---|")
+        for r in sel:
+            print(f"| `{r['host']}` | {r['status'] or r['cls']} | "
+                  f"{r.get('browser_status') if r.get('browser_status') is not None else '—'} | "
+                  f"`{r['where']}` |")
+
+    if args.diff:
+        prev = json.loads(Path(args.diff).read_text())
+        old = {r["host"]: r for r in prev["rows"]}
+        print(f"\n## Diff against {args.diff}\n")
+        print(f"That run's exit: {prev.get('egress')}\n")
+        changed = [(r, old[r["host"]]) for r in rows
+                   if r["host"] in old and old[r["host"]]["cls"] != r["cls"]]
+        if not changed:
+            print("No class changed. The egress is not what decides these.")
+        else:
+            print("| host | was | now | verdict |")
+            print("|---|---|---|---|")
+            for new, was in sorted(changed, key=lambda t: str(t[0]["host"])):
+                better = new["cls"] in ("ok", "reached-4xx5xx", "needs-key")
+                worse = was["cls"] in ("ok", "reached-4xx5xx", "needs-key")
+                v = ("**this egress was the problem**" if better and not worse
+                     else "**this egress broke it**" if worse and not better else "changed")
+                print(f"| `{new['host']}` | {was['cls']} | {new['cls']} | {v} |")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(
+            {"egress": who, "at": int(time.time()), "rows": rows}, indent=1), encoding="utf-8")
+        print(f"\nbaseline written to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #84. That PR made the app record **which upstream failed**. This
one answers the question that immediately follows: **would it have answered
anyone from this address?**

Those two look identical from inside the app, and the distinction is not
academic here — this box currently egresses through a VPN (ProtonVPN,
Singapore, `AS208172`), and a VPN datacenter address is exactly what feed
aggregators refuse.

## What it does

`tools/probe_egress.py` walks every external host referenced anywhere in
`apps/api/app` (**319** of them), asks each for something routable, and
classifies by **reachability, not correctness** — a 404 counts as *reached*,
because they answered us.

A 403/451 is retried with a browser User-Agent, because a 403 a browser clears
is bot filtering rather than the address. `www.un.org` is exactly that case:
403 to our UA, **200** to a browser's. Without that second request it would sit
in the blocked list forever.

`--diff` compares two runs and labels each class change, so moving the egress
(VPN up or down, a deploy landing on a different address) produces a
measurement instead of an argument.

`probe_warp.py` remains the tool for the narrower "should this host be in
`WARP_HOSTS`" question; this one is for when the whole egress moved.

## Baseline from the current exit

**287 of 319 reached.** 210 `ok`, 68 `reached-4xx5xx`, 9 `needs-key`.

**14 refused at address level** (403 to our UA *and* to a browser's):
`api.airplanes.live`, `api.planespotters.net`, `www.liveatc.net`,
`archive.liveatc.net`, `wsprnet.org`, `www.reddit.com`, `tile.googleapis.com`,
`noaa-nexrad-level2.s3.amazonaws.com`, `jldc.me`, and five news domains.

Also caught, and *not* egress problems: 5 hosts whose DNS no longer resolves
(`api.acleddata.com`, `api.bgpview.io`, `api.openownership.org`,
`columbus.elmasy.com`, `phishstats.info`) — those are dead providers still
referenced in the code.

## What is NOT proven

Whether those 14 clear without the VPN. **No second independent egress exists
on this host**: the WARP proxy on `:40000` tunnels over the same `tun0` default
route and reports the same Proton exit, which independently reproduces the
2026-08-01 finding in `docs/decisions.md` that WARP unblocked nothing from this
egress.

Settling it is one command with the VPN off:

```
apps/api/.venv/bin/python tools/probe_egress.py --diff docs/audits/2026-08-20-egress-vpn.json
```

Any host that flips is labelled **"this egress was the problem"**. If
`api.airplanes.live` does not flip, the ban is on the project rather than the
address, and the fix is the email their 403 body asks for.

## Verification

`bash scripts/verify.sh` → **ALL GREEN**, 2401 passed + 2 skipped. No
application code is touched; this adds one standalone tool under `tools/` plus
its baseline and report under `docs/audits/`.
